### PR TITLE
Role password signup fixes

### DIFF
--- a/aleph/tests/test_roles_api.py
+++ b/aleph/tests/test_roles_api.py
@@ -1,5 +1,6 @@
 import json
 
+from aleph.core import db
 from aleph.model import Role
 from aleph.tests.util import TestCase
 from aleph.tests.factories.models import RoleFactory
@@ -133,6 +134,7 @@ class RolesApiTestCase(TestCase):
             code=Role.SIGNATURE_SERIALIZER.dumps(email, salt=email)
         )
         res = self.client.post('/api/1/roles', data=payload)
+        db.session.close()
 
         self.assertEqual(res.status_code, 201)
         self.assertEqual(res.json['status'], 'ok')

--- a/aleph/views/roles_api.py
+++ b/aleph/views/roles_api.py
@@ -95,7 +95,7 @@ def create():
     role.set_password(password)
 
     db.session.add(role)
-    db.session.flush()
+    db.session.commit()
 
     return jsonify(dict(status='ok')), 201
 


### PR DESCRIPTION
Was investigating using Aleph and wanted to use email and password signup rather than Oauth, I couldn't get the signup process to work. The user role would never end up in the database for the next session.

I think the current test  `RolesApiTestCase.test_create_success` passes because the database session is still around from which to retrieve the role from, but if this session is closed, as would happen for a new request, the role won't have been committed to the database yet.

I've included a change to the test to illustrate this and a fix in the API view.

I'm new to Aleph so maybe I've missed/overlooked something here, feedback welcome, maybe I'm just not doing something right.

Cheers!