### PR TITLE
	jwt auth compatibility for standalone ui running on a different port

### DIFF
--- a/aleph/core.py
+++ b/aleph/core.py
@@ -196,8 +196,8 @@ language_whitelist = LocalProxy(get_language_whitelist)
 def url_for(*a, **kw):
     """Generate external URLs with HTTPS (if configured)."""
     try:
-        kw['_external'] = True
-        if get_config('PREFERRED_URL_SCHEME'):
+        kw['_external'] = not kw.pop('_relative', False)
+        if kw['_external'] and get_config('PREFERRED_URL_SCHEME'):
             kw['_scheme'] = get_config('PREFERRED_URL_SCHEME')
         return flask_url_for(*a, **kw)
     except RuntimeError:

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -53,8 +53,8 @@ def metadata():
 
     if auth['password_login']:
         auth['registration'] = get_config('PASSWORD_REGISTRATION')
-        auth['password_login_uri'] = url_for('sessions_api.password_login')
-        auth['registration_uri'] = url_for('roles_api.invite_email')
+        auth['password_login_uri'] = url_for('sessions_api.password_login', _relative=True)
+        auth['registration_uri'] = url_for('roles_api.invite_email', _relative=True)
 
     return jsonify({
         'status': 'ok',

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -74,7 +74,7 @@ def is_safe_url(target):
     ref_url = urlparse(request.host_url)
     test_url = urlparse(urljoin(request.host_url, target))
     return test_url.scheme in ('http', 'https') and \
-        ref_url.netloc == test_url.netloc
+        ref_url.hostname == test_url.hostname
 
 
 def extract_next_url(req):


### PR DESCRIPTION
oauth: require same host, but not same port
password login: use relative urls