### PR TITLE
Fix oauth next URL

### DIFF
--- a/aleph/tests/test_view_util.py
+++ b/aleph/tests/test_view_util.py
@@ -18,6 +18,6 @@ class ViewUtilTest(TestCase):
         self.assertEqual('http://localhost:5000/', extract_next_url(req))
 
     def test_extract_next_url_safe(self):
-        req = Request.from_values('/?next=/help')
-
+        headers = {'Referer': '/blah'}
+        req = Request.from_values('/?next=/help', headers=headers)
         self.assertEqual('/help', extract_next_url(req))

--- a/aleph/tests/test_view_util.py
+++ b/aleph/tests/test_view_util.py
@@ -1,6 +1,6 @@
 from flask import Request
 
-from aleph.views.util import extract_next_url
+from aleph.views.util import extract_next_url, get_best_next_url
 from aleph.tests.util import TestCase
 
 
@@ -21,3 +21,16 @@ class ViewUtilTest(TestCase):
         headers = {'Referer': '/blah'}
         req = Request.from_values('/?next=/help', headers=headers)
         self.assertEqual('/help', extract_next_url(req))
+
+    def test_get_best_next_url_blank(self):
+        self.assertEqual('http://localhost:5000/', get_best_next_url(''))
+
+    def test_get_best_next_url_unsafe(self):
+        self.assertEqual('http://localhost:5000/', get_best_next_url(self.fake.url()))
+
+    def test_get_best_next_url_unsafe_safe(self):
+        self.assertEqual('/next', get_best_next_url(self.fake.url(), '/next'))
+
+    def test_get_best_next_url_all_unsafe(self):
+        self.assertEqual('http://localhost:5000/',
+            get_best_next_url(self.fake.url(), self.fake.url()))

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -84,6 +84,13 @@ def is_safe_url(target):
         urlparse(app_url).hostname == test_url.hostname
 
 
+def get_best_next_url(*urls):
+    """Returns the safest URL to redirect to from a given list or defaults to app_url. """
+    for url in urls + (app_url,):
+        if url and is_safe_url(url):
+            return url
+
+
 def extract_next_url(req):
     """Extracts the URL/path to follow when redirects/unauthorization occurs.
 


### PR DESCRIPTION
OAuth2 [only supports](https://auth0.com/docs/protocols/oauth2/oauth-state) the `state` parameter for passing custom state, so this PR moves the next URL to the state.

It also fixes the next URL extraction. Currently `extract_next_url` will always default to returning the request referrer as it tests this after the `next` query parameter. I've made one of the tests set a referrer to show this happening.

The PR adds a new method, `get_best_next_url` that you pass any number of URLs to and the first safe URL is returned, or the app URL. Given that we can no longer assume the next URL will be in the `next` query parameter this seems like a nicer, more general method. I've left `extract_next_url` in the codebase for comparison purposes, but I think it should be removed before this PR is merged.

As an aside, the OAuth link above recommends using `state` to send a nonce to protect against CSRF attacks, should we do this?