### PR TITLE
Add post_filter to API and make OR default

### DIFF
--- a/aleph/search/parser.py
+++ b/aleph/search/parser.py
@@ -100,14 +100,6 @@ class SearchQueryParser(QueryParser):
         self.highlight = []
 
     @property
-    def has_query(self):
-        if self.text is not None:
-            return True
-        for (field, value) in self.filter_items:
-            return True
-        return False
-
-    @property
     def highlight_terms(self):
         if self.text is not None:
             yield self.text

--- a/aleph/search/parser.py
+++ b/aleph/search/parser.py
@@ -26,25 +26,19 @@ class QueryParser(object):
             return 1
         return (self.offset / self.limit) + 1
 
-    @property
-    def filter_items(self):
-        for key in self.args.keys():
-            if not key.startswith('filter:'):
-                continue
-            _, field = key.split(':', 1)
+    def prefixed_items(self, prefix):
+        return {
+            key[len(prefix):]: set(self.getlist(key))
+                for key in self.args.keys() if key.startswith(prefix)
+        }
 
-            for value in self.getlist(key):
-                yield (field, value)
+    @property
+    def drilldowns(self):
+        return self.prefixed_items('drilldown:')
 
     @property
     def filters(self):
-        filters = {}
-        for field, value in self.filter_items:
-            if field not in filters:
-                filters[field] = set([value])
-            else:
-                filters[field].add(value)
-        return filters
+        return self.prefixed_items('filter:')
 
     @property
     def items(self):

--- a/aleph/search/parser.py
+++ b/aleph/search/parser.py
@@ -33,8 +33,8 @@ class QueryParser(object):
         }
 
     @property
-    def drilldowns(self):
-        return self.prefixed_items('drilldown:')
+    def post_filters(self):
+        return self.prefixed_items('post_filter:')
 
     @property
     def filters(self):

--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -11,7 +11,6 @@ class Query(object):
     DOC_TYPES = []
     RETURN_FIELDS = True
     TEXT_FIELDS = ['_all']
-    MULTI_FIELDS = ['collection_id', 'schema', 'countries']
     SORT = {
         'default': ['_score']
     }
@@ -40,11 +39,8 @@ class Query(object):
             # Combine id or _id into one filter
             if field in ['id', '_id']:
                 id_values.extend(values)
-            elif field in self.MULTI_FIELDS:
-                filters.append({'terms': {field: list(values)}})
             else:
-                for value in values:
-                    filters.append({'term': {field: value}})
+                filters.append({'terms': {field: list(values)}})
 
         if id_values:
             filters.append({'ids': {'values': id_values}})
@@ -73,25 +69,7 @@ class Query(object):
                     }
                 }
             }
-            # Fields to be excluded from their own aggregation. This is true
-            # when a filter on a faceted fied is not supposed to affect the
-            # selection of aggregations.
-            if name in self.MULTI_FIELDS:
-                if 'scoped' not in aggs:
-                    aggs['scoped'] = {
-                        'global': {},
-                        'aggregations': {}
-                    }
-                aggs['scoped']['aggregations'][name] = {
-                    'filter': {
-                        'bool': {
-                            'filter': self.get_filters(exclude=name)
-                        }
-                    },
-                    'aggregations': facet
-                }
-            else:
-                aggs.update(facet)
+            aggs.update(facet)
         return aggs
 
     def get_sort(self):

--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -33,16 +33,22 @@ class Query(object):
     def get_filters(self, exclude=None):
         """Apply query filters from the user interface."""
         filters = []
+        id_values = []
         for field, values in self.parser.filters.items():
             if field == exclude:
                 continue
+            # Combine id or _id into one filter
             if field in ['id', '_id']:
-                filters.append({'ids': {'values': list(values)}})
+                id_values.extend(values)
             elif field in self.MULTI_FIELDS:
                 filters.append({'terms': {field: list(values)}})
             else:
                 for value in values:
                     filters.append({'term': {field: value}})
+
+        if id_values:
+            filters.append({'ids': {'values': id_values}})
+
         return filters
 
     def get_query(self):

--- a/aleph/tests/test_search_api.py
+++ b/aleph/tests/test_search_api.py
@@ -43,8 +43,14 @@ class SearchApiTestCase(TestCase):
         res = self.client.get('/api/2/search?facet=schema&filter:schema=Company')  # noqa
         assert res.status_code == 200, res
         facet = res.json['facets']['schema']
-        assert len(facet['values']) == 2, facet['values']
+        assert len(facet['values']) == 1, facet['values']
         assert facet['values'][0]['label'] == 'Companies', facet
+
+        res = self.client.get('/api/2/search?facet=schema&post_filter:schema=Company')
+        assert res.status_code == 200, res
+        facet = res.json['facets']['schema']
+        assert len(facet['values']) == 2, facet['values']
+        assert facet['values'][0]['label'] == 'Documents', facet
 
     def test_basic_filters(self):
         res = self.client.get('/api/2/search?filter:source_id=23')

--- a/aleph/tests/test_search_parser.py
+++ b/aleph/tests/test_search_parser.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+from aleph.search.parser import QueryParser
+
+args = QueryParser([
+    ('offset', '5'),
+    ('filter:key1', 'foo1'),
+    ('filter:key1', 'foo2'),
+    ('filter:key2', 'foo3'),
+    ('filter:key3', 'foo4'),
+    ('filter:key3', 'foo4'),
+    ('filter:key2', 'foo5'),
+    ('myint', 100),
+    ('myint', 105),
+    ('mybadint', 'six'),
+    ('mybool', 't'),
+    ('mybadbool', 'oui')
+], None)
+
+class QueryParserTestCase(TestCase):
+    def test_offset(self):
+        self.assertEqual(args.offset, 5)
+
+    def test_filters(self):
+        self.assertItemsEqual(args.filters.keys(), ['key1', 'key2', 'key3'])
+        self.assertEqual(args.filters['key1'], set(['foo1', 'foo2']))
+        self.assertEqual(args.filters['key2'], set(['foo3', 'foo5']))
+        self.assertEqual(args.filters['key3'], set(['foo4']))
+
+    def test_getintlist(self):
+        self.assertEqual(args.getintlist('myint'), [100, 105])
+        self.assertEqual(args.getintlist('notakey'), [])
+        self.assertEqual(args.getintlist('notakey', [8]), [8])
+
+    def test_getint(self):
+        self.assertEqual(args.getint('myint'), 100)
+        self.assertEqual(args.getint('mybadint'), None)
+        self.assertEqual(args.getint('notakey'), None)
+        self.assertEqual(args.getint('notakey', 8), 8)
+
+    def test_getbool(self):
+        self.assertEqual(args.getbool('mybool'), True)
+        self.assertEqual(args.getbool('mybadbool'), False)
+        self.assertEqual(args.getbool('notakey'), False)
+        self.assertEqual(args.getbool('notakey', True), True)

--- a/aleph/tests/test_search_query.py
+++ b/aleph/tests/test_search_query.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+from aleph.search.parser import SearchQueryParser
+from aleph.search.query import Query
+
+def query(args):
+    return Query(SearchQueryParser(args, None))
+
+class QueryTestCase(TestCase):
+    def setUp(self):
+        # Allow list elements to be in any order
+        self.addTypeEqualityFunc(list, self.assertItemsEqual)
+
+    def test_no_text(self):
+        q = query([])
+        self.assertEqual(q.get_text_query(), {'match_all': {}})
+
+    def test_has_text(self):
+        q = query([('q', 'search text')])
+        text_q = q.get_text_query()
+        self.assertEqual(text_q['simple_query_string']['query'], 'search text')
+
+    def test_id_filter(self):
+        q = query([
+            ('filter:id', '5'),
+            ('filter:id', '8'),
+            ('filter:id', '2'),
+            ('filter:_id', '3')
+        ])
+
+        filters = q.get_filters()
+        self.assertEqual(len(filters), 1)
+        self.assertEqual(filters[0].keys(), ['ids'])
+        self.assertEqual(filters[0]['ids']['values'], ['8', '5', '2', '3'])
+
+    def test_filters(self):
+        q = query([
+            ('filter:key1', 'foo'),
+            ('filter:key1', 'bar'),
+            ('filter:key2', 'blah'),
+            ('filter:key2', 'blahblah')
+        ])
+
+        filters = q.get_filters()
+        self.assertEqual(len(filters), 2)
+        self.assertEqual(filters[0].keys(), ['terms'])
+        self.assertEqual(filters[1].keys(), ['terms'])
+
+        # Extract filters without assuming order
+        filter_key1 = filter(lambda f: ['key1'] == f['terms'].keys(), filters)[0]['terms']['key1']
+        filter_key2 = filter(lambda f: ['key2'] == f['terms'].keys(), filters)[0]['terms']['key2']
+
+        self.assertEquals(filter_key1, ['foo', 'bar'])
+        self.assertEquals(filter_key2, ['blah', 'blahblah'])
+
+    def test_offset(self):
+        q = query([('offset', 10), ('limit', 100)])
+        body = q.get_body()
+        self.assertEqual(body['from'], 10)
+        self.assertEqual(body['size'], 100)


### PR DESCRIPTION
This PR adds the `post_filter` param and makes all filters OR by default.

Fields flagged as `MULTI_FIELDS` already used OR logic, given that a non-multi field can never match more than one value, it seems more sensible that it follows the same convention. This means we can remove the `MULTI_FIELDS` distinction in favour of more predictable API behaviour.

---

The `post_filter` parameter filters the results **after** aggregations.

For example, given the following API calls:
```
/search?facet:collection_id&filter:collection_id=5
/search?facet:collection_id&post_filter:collection_id=5
```
Both will return the same set of results, but in the former there will only be one entry in the `collection_id` facet (for `collection_id = 5`), while in the latter there will be a full `collection_id` facet.

This actually turns out to be quite easy as Elasticsearch provides a `post_filter` argument!

The primary use case is for the UI where we want users to be able to filter for a specific schemata (e.g. Person), but still show how many other schematas there are.