### PR TITLE
Support ElasticSearch 6.0.0

### DIFF
--- a/aleph/index/__init__.py
+++ b/aleph/index/__init__.py
@@ -3,7 +3,3 @@ from aleph.index.entities import index_entity, delete_entity, index_bulk  # noqa
 from aleph.index.documents import index_document, index_document_id  # noqa
 from aleph.index.documents import delete_document  # noqa
 from aleph.index.records import index_records  # noqa
-from aleph.index.mapping import TYPE_DOCUMENT, DOCUMENT_MAPPING  # noqa
-from aleph.index.mapping import TYPE_RECORD, RECORD_MAPPING  # noqa
-from aleph.index.mapping import TYPE_ENTITY, ENTITY_MAPPING  # noqa
-from aleph.index.mapping import TYPE_COLLECTION, COLLECTION_MAPPING  # noqa

--- a/aleph/index/admin.py
+++ b/aleph/index/admin.py
@@ -1,30 +1,39 @@
 import logging
 
-from aleph.core import es, es_index
-from aleph.index.mapping import TYPE_DOCUMENT, DOCUMENT_MAPPING
-from aleph.index.mapping import TYPE_RECORD, RECORD_MAPPING
-from aleph.index.mapping import TYPE_ENTITY, ENTITY_MAPPING
-from aleph.index.mapping import TYPE_COLLECTION, COLLECTION_MAPPING
+from aleph.core import es
+from aleph.index.core import record_index, record_type
+from aleph.index.core import entity_index, entity_type
+from aleph.index.core import collection_index, collection_type
+from aleph.index.mapping import RECORD_MAPPING
+from aleph.index.mapping import ENTITY_MAPPING
+from aleph.index.mapping import COLLECTION_MAPPING
 
 log = logging.getLogger(__name__)
 
 
 def upgrade_search():
     """Add any missing properties to the index mappings."""
-    log.info("Creating ElasticSearch index and uploading mapping...")
-    es.indices.create(es_index, ignore=[404, 400])
-    es.indices.put_mapping(index=es_index, body=COLLECTION_MAPPING, doc_type=TYPE_COLLECTION)  # noqa
-    es.indices.put_mapping(index=es_index, body=DOCUMENT_MAPPING, doc_type=TYPE_DOCUMENT)  # noqa
-    es.indices.put_mapping(index=es_index, body=RECORD_MAPPING, doc_type=TYPE_RECORD)  # noqa
-    es.indices.put_mapping(index=es_index, body=ENTITY_MAPPING, doc_type=TYPE_ENTITY)  # noqa
-    es.indices.open(index=es_index, ignore=[400, 404])
-    flush_index()
+    INDEXES = [
+        (collection_index(), collection_type(), COLLECTION_MAPPING),
+        (entity_index(), entity_type(), ENTITY_MAPPING),
+        (record_index(), record_type(), RECORD_MAPPING),
+    ]
+    for (index, doc_type, mapping) in INDEXES:
+        log.info("Creating index: %s (%s)", index, doc_type)
+        es.indices.create(index, ignore=[404, 400])
+        es.indices.put_mapping(index=index, doc_type=doc_type, body=mapping)
+        es.indices.open(index=index, ignore=[400, 404])
+        es.indices.refresh(index=index)
 
 
 def delete_index():
-    es.indices.delete(es_index, ignore=[404, 400])
+    es.indices.delete(collection_index(), ignore=[404, 400])
+    es.indices.delete(entity_index(), ignore=[404, 400])
+    es.indices.delete(record_index(), ignore=[404, 400])
 
 
 def flush_index():
     """Run a refresh to apply all indexing changes."""
-    es.indices.refresh(index=es_index)
+    es.indices.refresh(index=collection_index())
+    es.indices.refresh(index=entity_index())
+    es.indices.refresh(index=record_index())

--- a/aleph/index/collections.py
+++ b/aleph/index/collections.py
@@ -4,7 +4,8 @@ from aleph.core import es
 from aleph.index.stats import get_collection_stats
 from aleph.index.core import collection_type
 from aleph.index.core import collection_index, collections_index
-from aleph.index.core import entity_type, entity_index
+from aleph.index.core import entities_index, entity_type, entity_index
+from aleph.index.core import records_index
 from aleph.index.util import query_delete
 
 
@@ -55,7 +56,9 @@ def update_roles(collection):
 
 def delete_collection(collection_id, wait=True):
     """Delete all documents from a particular collection."""
-    query_delete({'term': {'collection_id': collection_id}}, wait=wait)
+    query = {'term': {'collection_id': collection_id}}
+    query_delete(records_index(), query, wait=wait)
+    query_delete(entities_index(), query, wait=wait)
     es.delete(index=collections_index(),
               doc_type=collection_type(),
               id=collection_id,

--- a/aleph/index/core.py
+++ b/aleph/index/core.py
@@ -38,7 +38,7 @@ def collection_index():
 
 def collections_index():
     """Combined index to run all queries against."""
-    return record_index()
+    return collection_index()
 
 
 def collection_type():

--- a/aleph/index/core.py
+++ b/aleph/index/core.py
@@ -1,0 +1,46 @@
+from aleph.core import es_index
+
+
+def entity_index():
+    """Index that us currently written by new queries."""
+    return '%s-entity-v1' % es_index
+
+
+def entities_index():
+    """Combined index to run all queries against."""
+    return entity_index()
+
+
+def entity_type():
+    """doc_type for all entities."""
+    return 'base'
+
+
+def record_index():
+    """Index that us currently written by new queries."""
+    return '%s-record-v1' % es_index
+
+
+def records_index():
+    """Combined index to run all queries against."""
+    return record_index()
+
+
+def record_type():
+    """doc_type for all records."""
+    return 'base'
+
+
+def collection_index():
+    """Index that us currently written by new queries."""
+    return '%s-collection-v1' % es_index
+
+
+def collections_index():
+    """Combined index to run all queries against."""
+    return record_index()
+
+
+def collection_type():
+    """doc_type for all collections."""
+    return 'base'

--- a/aleph/index/mapping.py
+++ b/aleph/index/mapping.py
@@ -1,10 +1,4 @@
 
-TYPE_COLLECTION = 'collection'
-TYPE_DOCUMENT = 'document'
-TYPE_RECORD = 'record'
-TYPE_ENTITY = 'entity'
-
-
 COLLECTION_MAPPING = {
     "dynamic_templates": [
         {
@@ -18,8 +12,14 @@ COLLECTION_MAPPING = {
     ],
     "date_detection": False,
     "properties": {
-        "label": {"type": "text"},
-        "name_sort": {"type": "keyword"},
+        "label": {
+            "type": "text",
+            "fields": {
+                "kw": {
+                    "type": "keyword"
+                }
+            }
+        },
         "roles": {"type": "long"},
         "foreign_id": {"type": "keyword"},
         "languages": {"type": "keyword"},
@@ -29,10 +29,8 @@ COLLECTION_MAPPING = {
         "managed": {"type": "boolean"},
         "created_at": {"type": "date"},
         "updated_at": {"type": "date"},
-        "$total": {"type": "long"},
-        "$entities": {"type": "long"},
-        "$documents": {"type": "long"},
-        "$schemata": {"type": "object"},
+        "total": {"type": "long"},
+        "schemata": {"type": "object"},
         "creator": {
             "type": "object",
             "properties": {
@@ -41,52 +39,6 @@ COLLECTION_MAPPING = {
                 "name": {"type": "keyword"}
             }
         },
-    }
-}
-
-DOCUMENT_MAPPING = {
-    "date_detection": False,
-    "properties": {
-        "title": {"type": "text"},
-        "name_sort": {"type": "keyword"},
-        "schema": {"type": "keyword"},
-        "schemata": {"type": "keyword"},
-        "type": {"type": "keyword"},
-        "status": {"type": "keyword"},
-        "error_message": {"type": "text"},
-        "content_hash": {"type": "keyword"},
-        "foreign_id": {"type": "keyword"},
-        "file_name": {"type": "keyword"},
-        "collection_id": {"type": "long"},
-        "roles": {"type": "long"},
-        "uploader_id": {"type": "long"},
-        "$children": {"type": "long"},
-        "source_url": {"type": "keyword"},
-        "extension": {"type": "keyword"},
-        "mime_type": {"type": "keyword"},
-        "encoding": {"type": "keyword"},
-        "languages": {"type": "keyword"},
-        "countries": {"type": "keyword"},
-        "keywords": {"type": "keyword"},
-        "fingerprints": {"type": "keyword"},
-        "names": {"type": "text"},
-        "emails": {"type": "keyword"},
-        "phones": {"type": "keyword"},
-        "columns": {"type": "keyword"},
-        "dates": {"type": "date", "format": "yyyy-MM-dd||yyyy-MM||yyyy-MM-d||yyyy-M||yyyy"},  # noqa
-        "author": {"type": "text"},
-        "summary": {"type": "text"},
-        "text": {"type": "text"},
-        "parent": {
-            "type": "object",
-            "properties": {
-                "id": {"type": "long"},
-                "type": {"type": "keyword"},
-                "title": {"type": "keyword"}
-            }
-        },
-        "created_at": {"type": "date"},
-        "updated_at": {"type": "date"},
     }
 }
 
@@ -102,6 +54,66 @@ RECORD_MAPPING = {
 }
 
 ENTITY_MAPPING = {
+    "date_detection": False,
+    "properties": {
+        "title": {"type": "text"},
+        "name": {
+            "type": "text",
+            "fields": {
+                "kw": {
+                    "type": "keyword"
+                }
+            }
+        },
+        "schema": {"type": "keyword"},
+        "schemata": {"type": "keyword"},
+        "type": {"type": "keyword"},
+        "bulk": {"type": "boolean"},
+        "status": {"type": "keyword"},
+        "error_message": {"type": "text"},
+        "content_hash": {"type": "keyword"},
+        "foreign_id": {"type": "keyword"},
+        "foreign_ids": {"type": "keyword"},
+        "file_name": {"type": "keyword"},
+        "collection_id": {"type": "long"},
+        "roles": {"type": "long"},
+        "uploader_id": {"type": "long"},
+        "children": {"type": "long"},
+        "source_url": {"type": "keyword"},
+        "extension": {"type": "keyword"},
+        "mime_type": {"type": "keyword"},
+        "encoding": {"type": "keyword"},
+        "languages": {"type": "keyword"},
+        "countries": {"type": "keyword"},
+        "keywords": {"type": "keyword"},
+        "fingerprints": {"type": "keyword"},
+        "names": {"type": "text"},
+        "emails": {"type": "keyword"},
+        "phones": {"type": "keyword"},
+        "identifiers": {"type": "keyword"},
+        "addresses": {"type": "text"},
+        "columns": {"type": "keyword"},
+        "dates": {"type": "date", "format": "yyyy-MM-dd||yyyy-MM||yyyy-MM-d||yyyy-M||yyyy"},  # noqa
+        "created_at": {"type": "date"},
+        "updated_at": {"type": "date"},
+        "author": {"type": "text"},
+        "summary": {"type": "text"},
+        "text": {"type": "text"},
+        "properties": {
+            "type": "object"
+        },
+        "data": {
+            "type": "object"
+        },
+        "parent": {
+            "type": "object",
+            "properties": {
+                "id": {"type": "long"},
+                "type": {"type": "keyword"},
+                "title": {"type": "keyword"}
+            }
+        },
+    },
     "dynamic_templates": [
         {
             "fields": {
@@ -119,29 +131,5 @@ ENTITY_MAPPING = {
                 }
             }
         }
-    ],
-    "date_detection": False,
-    "properties": {
-        "name": {"type": "text"},
-        "name_sort": {"type": "keyword"},
-        "schema": {"type": "keyword"},
-        "schemata": {"type": "keyword"},
-        "text": {"type": "text"},
-        "collection_id": {"type": "long"},
-        "roles": {"type": "long"},
-        "foreign_ids": {"type": "keyword"},
-        "fingerprints": {"type": "keyword"},
-        "names": {"type": "text"},
-        "identifiers": {"type": "keyword"},
-        "countries": {"type": "keyword"},
-        "dates": {"type": "date", "format": "yyyy-MM-dd||yyyy-MM||yyyy-MM-d||yyyy-M||yyyy"},  # noqa
-        "emails": {"type": "keyword"},
-        "phones": {"type": "keyword"},
-        "addresses": {"type": "text"},
-        "properties": {"type": "object"},
-        "data": {"type": "object"},
-        "created_at": {"type": "date"},
-        "updated_at": {"type": "date"},
-        "$bulk": {"type": "boolean"}
-    }
+    ]
 }

--- a/aleph/index/mapping.py
+++ b/aleph/index/mapping.py
@@ -3,7 +3,7 @@ COLLECTION_MAPPING = {
     "dynamic_templates": [
         {
             "fields": {
-                "match": "$schemata.*",
+                "match": "schemata.*",
                 "mapping": {
                     "type": "keyword"
                 }
@@ -29,8 +29,10 @@ COLLECTION_MAPPING = {
         "managed": {"type": "boolean"},
         "created_at": {"type": "date"},
         "updated_at": {"type": "date"},
-        "total": {"type": "long"},
-        "schemata": {"type": "object"},
+        "count": {"type": "long"},
+        "schemata": {
+            "type": "object"
+        },
         "creator": {
             "type": "object",
             "properties": {
@@ -93,7 +95,10 @@ ENTITY_MAPPING = {
         "identifiers": {"type": "keyword"},
         "addresses": {"type": "text"},
         "columns": {"type": "keyword"},
-        "dates": {"type": "date", "format": "yyyy-MM-dd||yyyy-MM||yyyy-MM-d||yyyy-M||yyyy"},  # noqa
+        "dates": {
+            "type": "date",
+            "format": "yyyy-MM-dd||yyyy-MM||yyyy-MM-d||yyyy-M||yyyy"  # noqa
+        },
         "created_at": {"type": "date"},
         "updated_at": {"type": "date"},
         "author": {"type": "text"},

--- a/aleph/index/records.py
+++ b/aleph/index/records.py
@@ -1,11 +1,10 @@
-import six
 import time
 import logging
 from elasticsearch.helpers import BulkIndexError
 
-from aleph.core import es_index, db
+from aleph.core import db
 from aleph.model import DocumentRecord
-from aleph.index.mapping import TYPE_RECORD
+from aleph.index.core import record_type, record_index, records_index
 from aleph.index.util import bulk_op, query_delete, index_form
 
 log = logging.getLogger(__name__)
@@ -14,18 +13,18 @@ log = logging.getLogger(__name__)
 def clear_records(document_id):
     """Delete all records associated with the given document."""
     q = {'term': {'document_id': document_id}}
-    query_delete(q, doc_type=TYPE_RECORD)
+    query_delete(records_index(), q)
 
 
 def generate_records(document):
     """Generate index records, based on document rows or pages."""
     q = db.session.query(DocumentRecord)
     q = q.filter(DocumentRecord.document_id == document.id)
-    for record in q.yield_per(1000):
+    for record in q:
         yield {
             '_id': record.id,
-            '_type': TYPE_RECORD,
-            '_index': six.text_type(es_index),
+            '_index': record_index(),
+            '_type': record_type(),
             '_source': {
                 'document_id': document.id,
                 'collection_id': document.collection_id,

--- a/aleph/index/stats.py
+++ b/aleph/index/stats.py
@@ -19,7 +19,7 @@ def get_instance_stats(authz):
                        body=query)
     aggregations = result.get('aggregations')
     data = {
-        'total': result.get('hits').get('total'),
+        'count': result.get('hits').get('total'),
         'schemata': {}
     }
     for schema in aggregations.get('schema').get('buckets'):
@@ -50,23 +50,21 @@ def get_collection_stats(collection_id):
     aggregations = result.get('aggregations')
     data = {
         'schemata': {},
-        'total': result.get('hits').get('total')
+        'count': result['hits']['total']
     }
 
     # expose entities by schema count.
-    for schema in aggregations.get('schema').get('buckets'):
-        key = schema.get('key')
-        count = schema.get('doc_count')
-        data['schemata'][key] = count
+    for schema in aggregations['schema']['buckets']:
+        data['schemata'][schema['key']] = schema['doc_count']
 
     # if no countries or langs are given, take the most common from the data.
-    if not data.get('countries') or not len(data.get('countries')):
-        countries = aggregations.get('countries').get('buckets')
-        data['countries'] = [c.get('key') for c in countries]
+    if not len(data.get('countries', [])):
+        countries = aggregations['countries']['buckets']
+        data['countries'] = [c['key'] for c in countries]
 
-    if not data.get('languages') or not len(data.get('languages')):
-        countries = aggregations.get('languages').get('buckets')
-        data['languages'] = [c.get('key') for c in countries]
+    if not len(data.get('languages', [])):
+        countries = aggregations['languages']['buckets']
+        data['languages'] = [c['key'] for c in countries]
 
     # pprint(data)
     return data

--- a/aleph/logic/collections.py
+++ b/aleph/logic/collections.py
@@ -51,7 +51,7 @@ def process_collection(collection_id):
 
 
 @celery.task()
-def delete_collection(collection_id):
+def delete_collection(collection_id, wait=False):
     # Deleting a collection affects many associated objects and requires
     # checks, so this is done manually and in detail here.
     q = db.session.query(Collection)
@@ -63,7 +63,7 @@ def delete_collection(collection_id):
 
     log.info("Deleting collection [%r]: %r", collection.id, collection.label)
     deleted_at = datetime.utcnow()
-    index_delete(collection_id, wait=False)
+    index_delete(collection_id, wait=wait)
 
     log.info("Delete cross-referencing matches...")
     Match.delete_by_collection(collection_id)

--- a/aleph/search/__init__.py
+++ b/aleph/search/__init__.py
@@ -2,7 +2,7 @@ import logging
 from followthemoney import model
 
 from aleph.core import es
-from aleph.model import DocumentRecord
+from aleph.model import Document, DocumentRecord
 from aleph.index.xref import entity_query
 from aleph.index.util import unpack_result
 from aleph.index.core import entities_index, entity_type
@@ -26,6 +26,13 @@ class DocumentsQuery(AuthzQuery):
         'default': ['_score', {'name.kw': 'asc'}],
         'name': [{'name.kw': 'asc'}, '_score'],
     }
+
+    def get_filters(self):
+        filters = super(DocumentsQuery, self).get_filters()
+        filters.append({
+            'term': {'schema': Document.SCHEMA}
+        })
+        return filters
 
     def get_index(self):
         return entities_index()
@@ -182,7 +189,7 @@ class CollectionsQuery(AuthzQuery):
     RETURN_FIELDS = True
     TEXT_FIELDS = ['label^3', 'summary']
     SORT = {
-        'default': [{'total': 'desc'}, {'label.kw': 'asc'}],
+        'default': [{'count': 'desc'}, {'label.kw': 'asc'}],
         'score': ['_score', {'label.kw': 'asc'}],
         'label': [{'label.kw': 'asc'}],
     }

--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -1,9 +1,10 @@
 from pprint import pprint  # noqa
 from elasticsearch.helpers import scan
 
-from aleph.core import es, es_index
+from aleph.core import es
 from aleph.search.result import SearchQueryResult
 from aleph.search.parser import SearchQueryParser
+
 
 def convert_filters(filters):
     ret = []
@@ -21,9 +22,9 @@ def convert_filters(filters):
 
     return ret
 
+
 class Query(object):
     RESULT_CLASS = SearchQueryResult
-    DOC_TYPES = []
     RETURN_FIELDS = True
     TEXT_FIELDS = ['_all']
     SORT = {
@@ -106,8 +107,8 @@ class Query(object):
     def search(self):
         """Execute the query as assmbled."""
         # pprint(self.get_body())
-        return es.search(index=es_index,
-                         doc_type=self.DOC_TYPES,
+        return es.search(index=self.get_index(),
+                         doc_type=self.get_doc_type(),
                          body=self.get_body())
 
     def scan(self):
@@ -118,8 +119,8 @@ class Query(object):
             '_source': self.RETURN_FIELDS
         }
         return scan(es,
-                    index=es_index,
-                    doc_type=self.DOC_TYPES,
+                    index=self.get_index(),
+                    doc_type=self.get_doc_type(),
                     query=body)
 
     @classmethod

--- a/aleph/tests/test_base_api.py
+++ b/aleph/tests/test_base_api.py
@@ -29,12 +29,10 @@ class BaseApiTestCase(TestCase):
     def test_statistics(self):
         res = self.client.get('/api/2/statistics')
         assert res.status_code == 200, res
-        assert '$total' in res.json, res.json
-        assert res.json['$total'] == 0, res.json
+        assert 'count' in res.json, res.json
+        assert res.json['count'] == 0, res.json
         self.load_fixtures('docs.yaml')
         res = self.client.get('/api/2/statistics')
         assert res.status_code == 200, res
-        assert res.json['$total'] == 5, res.json
-        assert res.json['$documents'] == 3, res.json
-        assert res.json['$entities'] == 1, res.json
-        assert res.json['$collections'] == 1, res.json
+        assert res.json['count'] == 4, res.json
+        assert res.json['schemata']['Document'] == 3, res.json

--- a/aleph/tests/test_index.py
+++ b/aleph/tests/test_index.py
@@ -10,11 +10,11 @@ class IndexTestCase(TestCase):
         super(IndexTestCase, self).setUp()
         self.load_fixtures('docs.yaml')
 
-    def test_delete_source(self):
+    def test_delete_collection(self):
         collection = Collection.by_id(1000)
         res = self.client.get('/api/2/search?q="mention fruit"')
         assert res.json['total'] == 1, res.json
-        delete_collection(collection.id)
+        delete_collection(collection.id, wait=True)
         flush_index()
         res = self.client.get('/api/2/search?q="mention fruit"')
         assert res.json['total'] == 0, res.json

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -70,11 +70,11 @@ class RoleSchema(Schema, DatedSchema):
 
     @post_dump
     def transient(self, data):
-        data['$uri'] = url_for('roles_api.view', id=data.get('id'))
+        data['uri'] = url_for('roles_api.view', id=data.get('id'))
         writeable = False
         if str(request.authz.id) == str(data.get('id')):
             writeable = True
-        data['$writeable'] = writeable
+        data['writeable'] = writeable
         if not request.authz.is_admin and not writeable:
             data.pop('email')
         if not writeable:
@@ -122,8 +122,8 @@ class AlertSchema(Schema, DatedSchema):
 
     @post_dump
     def transient(self, data):
-        data['$uri'] = url_for('alerts_api.view', id=data.get('id'))
-        data['$writeable'] = True
+        data['uri'] = url_for('alerts_api.view', id=data.get('id'))
+        data['writeable'] = True
         return data
 
 
@@ -141,21 +141,15 @@ class CollectionSchema(Schema, DatedSchema):
     @post_dump
     def transient(self, data):
         id_ = str(data.get('id'))
-        data['$uri'] = url_for('collections_api.view', id=id_)
-        data['$ui'] = collection_url(id_)
-        data['$writeable'] = request.authz.can_write(id_)
+        data['uri'] = url_for('collections_api.view', id=id_)
+        data['ui'] = collection_url(id_)
+        data['writeable'] = request.authz.can_write(id_)
         return data
 
 
 class CollectionIndexSchema(CollectionSchema):
-    total = Integer(dump_to='$total', attribute='$total',
-                    dump_only=True, default=0)
-    entities = Integer(dump_to='$entities', attribute='$entities',
-                       dump_only=True, default=0)
-    documents = Integer(dump_to='$documents', attribute='$documents',
-                        dump_only=True, default=0)
-    schemata = Dict(dump_to='$schemata', attribute='$schemata',
-                    dump_only=True, default={})
+    count = Integer(dump_only=True)
+    schemata = Dict(dump_only=True, default={})
 
 
 class EntitySchema(Schema, DatedSchema):
@@ -169,17 +163,17 @@ class EntitySchema(Schema, DatedSchema):
     schemata = List(SchemaName(), dump_only=True)
     data = Dict()
     properties = Dict(dump_only=True)
-    bulk = Boolean(dump_to='$bulk', attribute='$bulk', dump_only=True)
+    bulk = Boolean(dump_only=True)
 
     @post_dump
     def transient(self, data):
-        data['$uri'] = url_for('entities_api.view', id=data.get('id'))
-        data['$ui'] = entity_url(data.get('id'))
-        if data.get('$bulk'):
-            data['$writeable'] = False
+        data['uri'] = url_for('entities_api.view', id=data.get('id'))
+        data['ui'] = entity_url(data.get('id'))
+        if data.get('bulk'):
+            data['writeable'] = False
         else:
             collection_id = data.get('collection_id')
-            data['$writeable'] = request.authz.can_write(collection_id)
+            data['writeable'] = request.authz.can_write(collection_id)
         return data
 
 
@@ -230,16 +224,15 @@ class DocumentSchema(Schema, DatedSchema):
     text = String(dump_only=True)
     html = String(dump_only=True)
     columns = List(String(), dump_only=True)
-    children = Boolean(dump_to='$children', attribute='$children',
-                       dump_only=True)
+    children = Boolean(dump_only=True)
 
     @post_dump
     def transient(self, data):
-        data['$uri'] = url_for('documents_api.view',
-                               document_id=data.get('id'))
-        data['$ui'] = document_url(data.get('id'))
+        data['uri'] = url_for('documents_api.view',
+                              document_id=data.get('id'))
+        data['ui'] = document_url(data.get('id'))
         collection_id = data.get('collection_id')
-        data['$writeable'] = request.authz.can_write(collection_id)
+        data['writeable'] = request.authz.can_write(collection_id)
         return data
 
 
@@ -252,9 +245,9 @@ class RecordSchema(Schema):
 
     @post_dump
     def transient(self, data):
-        data['$uri'] = url_for('documents_api.record',
-                               document_id=data.get('document_id'),
-                               index=data.get('index'))
+        data['uri'] = url_for('documents_api.record',
+                              document_id=data.get('document_id'),
+                              index=data.get('index'))
         return data
 
 
@@ -271,9 +264,9 @@ class MatchCollectionsSchema(Schema, DatedSchema):
 
     @post_dump
     def transient(self, data):
-        data['$uri'] = url_for('xref_api.matches',
-                               id=data.pop('parent'),
-                               other_id=data.get('collection').get('id'))
+        data['uri'] = url_for('xref_api.matches',
+                              id=data.pop('parent'),
+                              other_id=data.get('collection').get('id'))
 
 
 class SearchResultSchema(object):

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -8,11 +8,10 @@ from marshmallow.exceptions import ValidationError
 from marshmallow.validate import Email, Length
 
 from aleph.core import url_for, get_config
-from aleph.index import TYPE_ENTITY, TYPE_DOCUMENT
 from aleph.logic.collections import collection_url
 from aleph.logic.entities import entity_url
 from aleph.logic.documents import document_url
-from aleph.model import Role
+from aleph.model import Role, Document
 from aleph.util import ensure_list
 
 
@@ -279,16 +278,13 @@ class MatchCollectionsSchema(Schema, DatedSchema):
 
 class SearchResultSchema(object):
 
-    SCHEMATA = {
-        TYPE_ENTITY: EntitySchema,
-        TYPE_DOCUMENT: DocumentSchema
-    }
-
     def dump(self, data, many=False):
         results = []
         for res in ensure_list(data):
-            schema = self.SCHEMATA[res['$doc_type']]
-            res = schema().dump(res)
+            if res.get('schema') == Document.SCHEMA:
+                res = DocumentSchema().dump(res)
+            else:
+                res = EntitySchema().dump(res)
             if not many:
                 return res
             results.append(res.data)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_DATABASE: aleph
 
   elasticsearch:
-    image: elasticsearch:6.0.0
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0
     volumes:
       - "./build/data/elasticsearch:/usr/share/elasticsearch/data"
       - "./build/logs/elasticsearch:/var/log"

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_DATABASE: aleph
 
   elasticsearch:
-    image: elasticsearch:5.4
+    image: elasticsearch:6.0.0
     volumes:
       - "./build/data/elasticsearch:/usr/share/elasticsearch/data"
       - "./build/logs/elasticsearch:/var/log"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_DATABASE: aleph
 
   elasticsearch:
-    image: elasticsearch:6.0.0
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.0.0
     volumes:
       - "./build/data/elasticsearch:/usr/share/elasticsearch/data"
       - "./build/logs/elasticsearch:/var/log"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_DATABASE: aleph
 
   elasticsearch:
-    image: elasticsearch:5.4
+    image: elasticsearch:6.0.0
     volumes:
       - "./build/data/elasticsearch:/usr/share/elasticsearch/data"
       - "./build/logs/elasticsearch:/var/log"

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ SQLAlchemy==1.0.13
 alembic==0.8.6
 
 celery == 4.1.0
-elasticsearch == 5.3.0
+elasticsearch >= 6.0.0, <= 7.0.0
 marshmallow == 2.13.5
 psycopg2 >= 2.7.1
 apikit == 0.3.2
@@ -44,4 +44,4 @@ ingestors >= 0.5.0
 normality >= 0.5.3
 
 # Python 3 backports
-functools32>=3.2
+functools32 >= 3.2


### PR DESCRIPTION
Last night, ES 6 came out. There's now a plan to abandon support for doc_types, i.e. there can be only one mapping per index. I've decided that the easiest way to work around that is to have multiple indexes: one for documents and entities, one for collections and one for records.

In this refactor, I've also introduced the option to write to one index and potentially query another, as discussed in #244. This should make future mapping migrations more flexible. 