### PR TITLE
Make all entity properties into lists

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,8 @@
-build*
-node_modules*
+build
+node_modules
 aleph.env
+aleph.egg-info
 docker-compose.*
 celerybeat-schedul*
 .git
+.vscode

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,6 @@ RUN pip install -r /tmp/requirements.txt
 COPY . /aleph
 WORKDIR /aleph
 RUN pip install -e .
-RUN pip install --upgrade ingestors
 
 # Expose the green unicorn
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ COPY requirements-docs.txt requirements-testing.txt /tmp/
 RUN pip install -r /tmp/requirements-docs.txt
 COPY requirements.txt /tmp/
 RUN pip install -r /tmp/requirements.txt
+RUN pip install --upgrade ingestors
 
 # Install aleph
 COPY . /aleph

--- a/Makefile
+++ b/Makefile
@@ -4,17 +4,19 @@ DEVDOCKER=$(COMPOSE) run --rm app /aleph/contrib/devwrapper.sh
 shell:
 	$(DEVDOCKER) /bin/bash
 
-test:
+test: build
 	$(DEVDOCKER) contrib/test.sh
 
 upgrade: build
 	$(COMPOSE) up -d postgres elasticsearch
 	sleep 4
 	$(DEVDOCKER) aleph upgrade
+
+installdata:
 	$(DEVDOCKER) aleph installdata
 
 web:
-	$(COMPOSE) run --rm -p 5000:5000 app /aleph/contrib/devwrapper.sh \
+	$(COMPOSE) run --rm --service-ports app /aleph/contrib/devwrapper.sh \
 		python aleph/manage.py runserver -h 0.0.0.0
 
 worker:
@@ -30,7 +32,7 @@ rebuild:
 	$(COMPOSE) build --pull --no-cache
 
 build:
-	$(COMPOSE) build --pull
+	$(COMPOSE) build
 
 docs:
 	$(DEVDOCKER) sphinx-build -b html -d docs/_build/doctrees ./docs docs/_build/html

--- a/aleph/default_settings.py
+++ b/aleph/default_settings.py
@@ -7,7 +7,6 @@
 # alter.
 from celery.schedules import crontab
 from apikit.args import BOOL_TRUISH
-from tempfile import gettempdir
 from os import environ as env, path
 
 
@@ -198,9 +197,5 @@ CELERYBEAT_SCHEDULE = {
     'alert-every-night': {
         'task': 'aleph.logic.alerts.check_alerts',
         'schedule': crontab(hour=1, minute=30)
-    },
-    'periodic-cleanup': {
-        'task': 'aleph.logic.cleanup_system',
-        'schedule': crontab(hour='*/6')
-    },
+    }
 }

--- a/aleph/index/documents.py
+++ b/aleph/index/documents.py
@@ -53,6 +53,7 @@ def index_document(document):
         'name': document.title,
         'summary': document.summary,
         'author': document.author,
+        'generator': document.generator,
         'file_size': document.file_size,
         'file_name': document.file_name,
         'source_url': document.source_url,

--- a/aleph/index/entities.py
+++ b/aleph/index/entities.py
@@ -31,6 +31,7 @@ def index_entity(entity):
         return delete_entity(entity.id)
 
     data = {
+        'name': entity.name,
         'foreign_ids': entity.foreign_ids,
         'created_at': entity.created_at,
         'updated_at': entity.updated_at,
@@ -135,12 +136,12 @@ def finalize_index(data, schema):
     properties = data.get('properties', {})
 
     texts = []
-    for prop in schema.properties:
-        if prop.name not in properties:
+    for name, prop in schema.properties.items():
+        if name not in properties:
             continue
         if prop.type_name in ['date', 'url', 'uri', 'country']:
             continue
-        texts.extend(ensure_list(properties[prop.name]))
+        texts.extend(ensure_list(properties[name]))
 
     data['text'] = index_form(texts)
     data = schema.invert(data)

--- a/aleph/index/entities.py
+++ b/aleph/index/entities.py
@@ -32,7 +32,6 @@ def index_entity(entity):
 
     data = {
         'foreign_ids': entity.foreign_ids,
-        'data': entity.data,
         'created_at': entity.created_at,
         'updated_at': entity.updated_at,
         'bulk': False,
@@ -43,8 +42,10 @@ def index_entity(entity):
         }
     }
 
-    for k, v in entity.data.items():
-        data['properties'][k] = ensure_list(v)
+    for prop, values in entity.data.items():
+        values = ensure_list(values)
+        if len(values):
+            data['properties'][prop] = values
 
     # data['$documents'] = get_count(entity)
     data = finalize_index(data, entity.schema)

--- a/aleph/index/mapping.py
+++ b/aleph/index/mapping.py
@@ -105,8 +105,8 @@ ENTITY_MAPPING = {
         "published_at": {"type": "date", "format": PARTIAL_DATE},
         "retrieved_at": {"type": "date", "format": PARTIAL_DATE},
         "dates": {"type": "date", "format": PARTIAL_DATE},
-        "author": {"type": "text"},
-        "generator": {"type": "text"},
+        "author": {"type": "keyword"},
+        "generator": {"type": "keyword"},
         "summary": {"type": "text"},
         "text": {"type": "text"},
         "properties": {

--- a/aleph/index/mapping.py
+++ b/aleph/index/mapping.py
@@ -112,9 +112,6 @@ ENTITY_MAPPING = {
         "properties": {
             "type": "object"
         },
-        "data": {
-            "type": "object"
-        },
         "parent": {
             "type": "object",
             "properties": {
@@ -128,14 +125,6 @@ ENTITY_MAPPING = {
         {
             "fields": {
                 "match": "properties.*",
-                "mapping": {
-                    "type": "text"
-                }
-            }
-        },
-        {
-            "fields": {
-                "match": "data.*",
                 "mapping": {
                     "type": "keyword"
                 }

--- a/aleph/ingest/result.py
+++ b/aleph/ingest/result.py
@@ -85,6 +85,7 @@ class DocumentResult(Result):
         doc.title = stringify(self.title) or doc.meta.get('title')
         doc.summary = stringify(self.summary) or doc.meta.get('summary')
         doc.author = stringify(self.author) or doc.meta.get('author')
+        doc.generator = stringify(self.generator) or doc.meta.get('generator')
         doc.mime_type = stringify(self.mime_type) or doc.meta.get('mime_type')
         doc.encoding = stringify(self.encoding) or doc.meta.get('encoding')
 

--- a/aleph/logic/__init__.py
+++ b/aleph/logic/__init__.py
@@ -6,17 +6,10 @@ the model but that also depends on components (like ES search)
 which in turn themselves depend on the model.
 """
 
-from aleph.core import celery
 from aleph.logic.entities import update_entity, update_entity_full  # noqa
 from aleph.logic.entities import reindex_entities, delete_entity  # noqa
 from aleph.logic.entities import fetch_entity  # noqa
 from aleph.logic.collections import update_collection, delete_collection  # noqa
-from aleph.logic.collections import process_collection, cleanup_collections  # noqa
+from aleph.logic.collections import process_collection  # noqa
 from aleph.logic.documents import update_document, delete_document  # noqa
 from aleph.logic.alerts import check_alerts  # noqa
-
-
-@celery.task()
-def cleanup_system():
-    """Periodic cleanup tasks run by the system to maintain consistency."""
-    cleanup_collections()

--- a/aleph/logic/collections.py
+++ b/aleph/logic/collections.py
@@ -22,6 +22,10 @@ def update_collection(collection):
         index_delete(collection.id)
         return
 
+    collection.updated_at = datetime.utcnow()
+    db.session.add(collection)
+    db.session.commit()
+
     log.info("Updating: %r", collection)
     index_collection(collection)
 
@@ -79,9 +83,3 @@ def delete_collection(collection_id, wait=False):
 
     collection.delete(deleted_at=deleted_at)
     db.session.commit()
-
-
-def cleanup_collections():
-    """Reindex collections periodically."""
-    for collection in Collection.all():
-        update_collection(collection)

--- a/aleph/logic/entities.py
+++ b/aleph/logic/entities.py
@@ -62,7 +62,7 @@ def reindex_entities(block=5000):
     for collection in cq.yield_per(block):
         log.info("Indexing entities in: %r", collection)
         eq = db.session.query(Entity)
-        eq = eq.filter(Entity.collection == collection)
+        eq = eq.filter(Entity.collection_id == collection.id)
         for entity in eq.yield_per(block):
             # Use the one that's already loaded:
             entity.collection = collection
@@ -81,10 +81,10 @@ def bulk_load(config):
         if collection is None:
             collection = Collection.create({
                 'foreign_id': foreign_id,
-                'managed': True,
                 'label': data.get('label') or foreign_id,
                 'summary': data.get('summary'),
                 'category': data.get('category'),
+                'managed': True,
             })
 
         for role_fk in dict_list(data, 'roles', 'role'):

--- a/aleph/manage.py
+++ b/aleph/manage.py
@@ -187,13 +187,6 @@ def evilshit():
     upgrade()
 
 
-@manager.command
-def cleanup():
-    """Periodic system cleanup tasks."""
-    from aleph.logic import cleanup_system
-    cleanup_system()
-
-
 def main():
     manager.run()
 

--- a/aleph/model/collection.py
+++ b/aleph/model/collection.py
@@ -37,7 +37,8 @@ class Collection(db.Model, IdModel, SoftDeleteModel):
         self.countries = data.get('countries', [])
         creator = data.get('creator') or {}
         self.update_creator(creator.get('id'))
-        self.touch()
+        self.updated_at = datetime.utcnow()
+        db.session.add(self)
 
     def update_creator(self, role):
         """Set the creator (and admin) of a collection."""
@@ -49,10 +50,6 @@ class Collection(db.Model, IdModel, SoftDeleteModel):
         db.session.add(self)
         db.session.flush()
         Permission.grant(self, role, True, True)
-
-    def touch(self):
-        self.updated_at = datetime.utcnow()
-        db.session.add(self)
 
     @property
     def roles(self):

--- a/aleph/model/common.py
+++ b/aleph/model/common.py
@@ -1,11 +1,24 @@
 import uuid
+from banal import ensure_list
+from itertools import chain
 from datetime import datetime
+from normality import stringify
+
 
 from aleph.core import db
 
 
 def make_textid():
     return uuid.uuid4().hex
+
+
+def string_set(*lists):
+    """Make a list of clean strings."""
+    # Used by entity for foreign_ids.
+    items = chain(*[ensure_list(l) for l in lists])
+    items = [stringify(i) for i in items]
+    items = [i for i in items if i is not None]
+    return list(set(items))
 
 
 class IdModel(object):

--- a/aleph/model/document.py
+++ b/aleph/model/document.py
@@ -153,8 +153,16 @@ class Document(db.Model, DatedModel, Metadata):
     def texts(self):
         if self.title is not None:
             yield self.title
+        if self.file_name is not None:
+            yield self.file_name
+        if self.source_url is not None:
+            yield self.source_url
         if self.summary is not None:
             yield self.summary
+        if self.author is not None:
+            yield self.author
+        if self.generator is not None:
+            yield self.generator
         if self.status != self.STATUS_SUCCESS:
             return
         if self.body_text is not None:

--- a/aleph/model/document.py
+++ b/aleph/model/document.py
@@ -68,26 +68,13 @@ class Document(db.Model, DatedModel, Metadata):
         super(Document, self).__init__(**kw)
 
     def update(self, data):
-        self.title = data.get('title', self.meta.get('title'))
-        self.summary = data.get('summary', self.meta.get('summary'))
-        self.author = data.get('author', self.meta.get('author'))
-        self.crawler = data.get('crawler', self.meta.get('crawler'))
-        self.source_url = data.get('source_url', self.meta.get('source_url'))
-        self.file_name = data.get('file_name', self.meta.get('file_name'))
-        self.mime_type = data.get('mime_type', self.meta.get('mime_type'))
-        self.headers = data.get('headers', self.meta.get('headers', {}))
-        self.date = data.get('date', self.meta.get('date'))
-        self.authored_at = data.get('authored_at',
-                                    self.meta.get('authored_at'))
-        self.modified_at = data.get('modified_at',
-                                    self.meta.get('modified_at'))
-        self.published_at = data.get('published_at',
-                                     self.meta.get('published_at'))
-        self.retrieved_at = data.get('retrieved_at',
-                                     self.meta.get('retrieved_at'))
-        self.languages = data.get('languages', self.meta.get('languages'))
-        self.countries = data.get('countries', self.meta.get('countries'))
-        self.keywords = data.get('keywords', self.meta.get('keywords'))
+        props = ('title', 'summary', 'author', 'crawler', 'source_url',
+                 'file_name', 'mime_type', 'headers', 'date', 'authored_at',
+                 'modified_at', 'published_at', 'retrieved_at', 'languages',
+                 'countries', 'keywords')
+        for prop in props:
+            value = data.get(prop, self.meta.get(prop))
+            setattr(self, prop, value)
         db.session.add(self)
 
     def update_meta(self):

--- a/aleph/model/entity.py
+++ b/aleph/model/entity.py
@@ -102,6 +102,7 @@ class Entity(db.Model, UuidModel, SoftDeleteModel):
     def update(self, entity):
         data = entity.get('properties')
         if is_mapping(data):
+            data['name'] = [entity.get('name')]
             self.data = self.schema.validate(data)
         elif self.data is None:
             self.data = {}

--- a/aleph/model/entity.py
+++ b/aleph/model/entity.py
@@ -112,7 +112,6 @@ class Entity(db.Model, UuidModel, SoftDeleteModel):
         fid = [stringify(f) for f in entity.get('foreign_ids') or []]
         self.foreign_ids = list(set([f for f in fid if f is not None]))
         self.updated_at = datetime.utcnow()
-        # self.collection.touch()
         db.session.add(self)
 
     @classmethod
@@ -122,7 +121,6 @@ class Entity(db.Model, UuidModel, SoftDeleteModel):
         ent.id = make_textid()
         ent.collection = collection
         ent.update(data)
-        ent.collection.touch()
         return ent
 
     @classmethod

--- a/aleph/model/metadata.py
+++ b/aleph/model/metadata.py
@@ -69,6 +69,14 @@ class Metadata(object):
         self._meta_text('author', author)
 
     @property
+    def generator(self):
+        return self.meta.get('generator')
+
+    @generator.setter
+    def generator(self, generator):
+        self._meta_text('generator', generator)
+
+    @property
     def crawler(self):
         return self.meta.get('crawler')
 

--- a/aleph/search/__init__.py
+++ b/aleph/search/__init__.py
@@ -170,6 +170,7 @@ class SuggestEntitiesQuery(EntitiesQuery):
 
 
 class CombinedQuery(AuthzQuery):
+    TEXT_FIELDS = ['title^3', 'name^3', 'names^2', 'text']
     RETURN_FIELDS = set(DocumentsQuery.RETURN_FIELDS)
     RETURN_FIELDS = list(set(EntitiesQuery.RETURN_FIELDS).union(RETURN_FIELDS))
 

--- a/aleph/search/__init__.py
+++ b/aleph/search/__init__.py
@@ -17,7 +17,7 @@ log = logging.getLogger(__name__)
 
 
 class DocumentsQuery(AuthzQuery):
-    TEXT_FIELDS = ['title^3', 'summary', 'text']
+    TEXT_FIELDS = ['title^3', 'text']
     RETURN_FIELDS = ['collection_id', 'title', 'file_name', 'extension',
                      'languages', 'countries', 'source_url', 'created_at',
                      'updated_at', 'type', 'summary', 'status',
@@ -115,6 +115,7 @@ class AlertDocumentsQuery(EntityDocumentsQuery):
 
 
 class EntitiesQuery(AuthzQuery):
+    TEXT_FIELDS = ['name^3', 'names^2', 'text']
     RETURN_FIELDS = ['collection_id', 'roles', 'name', 'data', 'countries',
                      'schema', 'schemata', 'properties', 'created_at',
                      'updated_at', 'creator', '$bulk']

--- a/aleph/tests/test_entities.py
+++ b/aleph/tests/test_entities.py
@@ -24,7 +24,7 @@ class EntitiesTestCase(TestCase):
         self.ent = Entity.create({
             'schema': 'LegalEntity',
             'name': 'Winnie the Pooh',
-            'data': {
+            'properties': {
                 'country': 'pa',
                 'summary': 'a fictional teddy bear created by A. A. Milne',
                 'alias': [u'Puh der Bär', 'Pooh Bear']
@@ -33,7 +33,7 @@ class EntitiesTestCase(TestCase):
         self.other = Entity.create({
             'schema': 'LegalEntity',
             'name': 'Pu der Bär',
-            'data': {
+            'properties': {
                 'country': 'de',
                 'description': 'he is a bear',
                 'alias': [u'Puh der Bär']
@@ -50,7 +50,7 @@ class EntitiesTestCase(TestCase):
         self.ent.merge(self.other)
         db.session.flush()
         data = dict(self.ent.data)
-        assert 'bear' in data['description'], data
+        assert 'bear' in data['description'][0], data
         assert 'pa' in data['country'], data
         db.session.refresh(self.alert)
         assert self.alert.label == self.ent.name
@@ -67,6 +67,6 @@ class EntitiesTestCase(TestCase):
                                  data={},
                                  headers=headers,
                                  content_type='application/json')
-        data = res.json
-        assert 'bear' in data['data']['description']
-        assert 'pa' in data['data']['country']
+        data = res.json['properties']
+        assert 'bear' in data['description'][0], data
+        assert 'pa' in data['country'], data

--- a/aleph/tests/test_entities_api.py
+++ b/aleph/tests/test_entities_api.py
@@ -19,7 +19,7 @@ class EntitiesApiTestCase(TestCase):
         self.ent = Entity.create({
             'schema': 'LegalEntity',
             'name': 'Winnie the Pooh',
-            'data': {
+            'properties': {
                 'country': 'pa',
             }
         }, self.col)
@@ -101,7 +101,7 @@ class EntitiesApiTestCase(TestCase):
             'schema': 'Asset',
             'name': "Our house",
             'collection_id': self.col.id,
-            'data': {
+            'properties': {
                 'summary': "In the middle of our street"
             }
         }
@@ -110,7 +110,7 @@ class EntitiesApiTestCase(TestCase):
                                headers=headers,
                                content_type='application/json')
         assert res.status_code == 200, res.json
-        assert 'middle' in res.json['data']['summary'], res.json
+        assert 'middle' in res.json['properties']['summary'][0], res.json
 
     def test_create_nested(self):
         _, headers = self.login(is_admin=True)
@@ -119,7 +119,7 @@ class EntitiesApiTestCase(TestCase):
             'schema': 'Person',
             'name': "Osama bin Laden",
             'collection_id': self.col.id,
-            'data': {
+            'properties': {
                 'alias': ["Usama bin Laden", "Osama bin Ladin"],
                 'address': 'Home, Netherlands'
             }
@@ -129,7 +129,7 @@ class EntitiesApiTestCase(TestCase):
                                headers=headers,
                                content_type='application/json')
         assert res.status_code == 200, res.json
-        assert 2 == len(res.json['data'].get('alias', [])), res.json
+        assert 2 == len(res.json['properties'].get('alias', [])), res.json
 
     def test_merge_nested(self):
         _, headers = self.login(is_admin=True)
@@ -138,7 +138,7 @@ class EntitiesApiTestCase(TestCase):
             'schema': 'Person',
             'name': "Osama bin Laden",
             'collection_id': self.col.id,
-            'data': {
+            'properties': {
                 'alias': ["Usama bin Laden", "Osama bin Ladin"],
                 'address': 'Home, Netherlands'
             }
@@ -149,14 +149,14 @@ class EntitiesApiTestCase(TestCase):
                                content_type='application/json')
         assert res.status_code == 200, (res.status_code, res.json)
         data = res.json
-        data['data']['alias'] = ["Usama bin Laden", "Usama bin Ladin"]
+        data['properties']['alias'] = ["Usama bin Laden", "Usama bin Ladin"]
         url = '/api/2/entities/%s?merge=true' % data['id']
         res = self.client.post(url,
                                data=json.dumps(data),
                                headers=headers,
                                content_type='application/json')
         assert res.status_code == 200, (res.status_code, res.json)
-        assert 3 == len(res.json['data'].get('alias', [])), res.json
+        assert 3 == len(res.json['properties'].get('alias', [])), res.json
 
     def test_remove_nested(self):
         _, headers = self.login(is_admin=True)
@@ -165,7 +165,7 @@ class EntitiesApiTestCase(TestCase):
             'schema': 'Person',
             'name': "Osama bin Laden",
             'collection_id': self.col.id,
-            'data': {
+            'properties': {
                 'alias': ["Usama bin Laden", "Osama bin Ladin"]
             }
         }
@@ -175,15 +175,15 @@ class EntitiesApiTestCase(TestCase):
                                content_type='application/json')
         assert res.status_code == 200, (res.status_code, res.json)
         data = res.json
-        data['data']['alias'].pop()
-        assert 1 == len(data['data']['alias']), data
+        data['properties']['alias'].pop()
+        assert 1 == len(data['properties']['alias']), data
         url = '/api/2/entities/%s' % data['id']
         res = self.client.post(url,
                                data=json.dumps(data),
                                headers=headers,
                                content_type='application/json')
         assert res.status_code == 200, (res.status_code, res.json)
-        assert 1 == len(res.json['data'].get('alias', [])), res.json
+        assert 1 == len(res.json['properties'].get('alias', [])), res.json
 
     def test_delete_entity(self):
         _, headers = self.login(is_admin=True)
@@ -191,7 +191,7 @@ class EntitiesApiTestCase(TestCase):
         data = {
             'schema': 'Person',
             'name': "Osama bin Laden",
-            'data': {},
+            'properties': {},
             'collection_id': self.col.id
         }
         res = self.client.post(url,
@@ -214,7 +214,7 @@ class EntitiesApiTestCase(TestCase):
         data = {
             'schema': 'Person',
             'name': "Osama bin Laden",
-            'data': {},
+            'properties': {},
             'collection_id': self.col.id
         }
         res = self.client.post(url,

--- a/aleph/tests/test_xref.py
+++ b/aleph/tests/test_xref.py
@@ -34,7 +34,7 @@ class XrefTestCase(TestCase):
             'schema': 'Person',
             'name': 'Carlos Danger',
             'collection_id': self.coll_a.id,
-            'data': {
+            'properties': {
                 'nationality': 'US'
             }
         }
@@ -45,7 +45,7 @@ class XrefTestCase(TestCase):
             'schema': 'Person',
             'name': 'Carlos Danger',
             'collection_id': self.coll_b.id,
-            'data': {
+            'properties': {
                 'nationality': 'US'
             }
         }
@@ -56,7 +56,7 @@ class XrefTestCase(TestCase):
             'schema': 'Company',
             'name': 'Carlos Danger',
             'collection_id': self.coll_b.id,
-            'data': {
+            'properties': {
                 'nationality': 'GB'
             }
         }
@@ -67,7 +67,7 @@ class XrefTestCase(TestCase):
             'schema': 'Person',
             'name': 'Pure Risk',
             'collection_id': self.coll_b.id,
-            'data': {
+            'properties': {
                 'nationality': 'US'
             }
         }
@@ -91,7 +91,7 @@ class XrefTestCase(TestCase):
             'schema': 'Person',
             'name': 'Carlos Danger',
             'collection_id': self.coll_a.id,
-            'data': {
+            'properties': {
                 'nationality': 'US'
             }
         }
@@ -102,7 +102,7 @@ class XrefTestCase(TestCase):
             'schema': 'Person',
             'name': 'Carlos Danger',
             'collection_id': self.coll_b.id,
-            'data': {
+            'properties': {
                 'nationality': 'US'
             }
         }
@@ -113,7 +113,7 @@ class XrefTestCase(TestCase):
             'schema': 'Company',
             'name': 'Carlos Danger',
             'collection_id': self.coll_b.id,
-            'data': {
+            'properties': {
                 'nationality': 'GB'
             }
         }
@@ -124,7 +124,7 @@ class XrefTestCase(TestCase):
             'schema': 'Person',
             'name': 'Pure Risk',
             'collection_id': self.coll_b.id,
-            'data': {
+            'properties': {
                 'nationality': 'US'
             }
         }
@@ -136,7 +136,7 @@ class XrefTestCase(TestCase):
             'schema': 'Company',
             'name': 'Carlof Danger',
             'collection_id': self.coll_c.id,
-            'data': {
+            'properties': {
                 'nationality': 'FR'
             }
         }
@@ -147,7 +147,7 @@ class XrefTestCase(TestCase):
             'schema': 'Person',
             'name': 'Dorian Gray',
             'collection_id': self.coll_c.id,
-            'data': {
+            'properties': {
                 'nationality': 'GB'
             }
         }

--- a/aleph/tests/util.py
+++ b/aleph/tests/util.py
@@ -16,6 +16,7 @@ from aleph.oauth import oauth
 FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
 UI_URL = 'http://aleph.ui/'
 
+
 class TestCase(FlaskTestCase):
 
     # Expose faker since it should be easy to use

--- a/aleph/views/documents_api.py
+++ b/aleph/views/documents_api.py
@@ -49,6 +49,7 @@ def update(document_id):
     document.update(data)
     db.session.commit()
     update_document(document)
+    update_collection(document.collection)
     return view(document_id)
 
 

--- a/aleph/views/entities_api.py
+++ b/aleph/views/entities_api.py
@@ -85,8 +85,8 @@ def update(id):
     _, entity = get_entity(id, request.authz.WRITE)
     data = parse_request(schema=EntitySchema)
     if as_bool(request.args.get('merge')):
-        data['data'] = merge_data(data.get('data') or {},
-                                  entity.data or {})
+        data['properties'] = merge_data(data.get('properties') or {},
+                                        entity.data or {})
     entity.update(data)
     db.session.commit()
     update_entity(entity)

--- a/aleph/views/entities_api.py
+++ b/aleph/views/entities_api.py
@@ -45,8 +45,8 @@ def suggest():
 @blueprint.route('/api/2/entities', methods=['POST', 'PUT'])
 def create():
     data = parse_request(schema=EntitySchema)
-    collection = get_collection(data.get('collection_id'),
-                                request.authz.WRITE)
+    collection_id = data.get('collection_id')
+    collection = get_collection(collection_id, request.authz.WRITE)
     entity = Entity.create(data, collection)
     db.session.commit()
     update_entity(entity)
@@ -85,8 +85,8 @@ def update(id):
     _, entity = get_entity(id, request.authz.WRITE)
     data = parse_request(schema=EntitySchema)
     if as_bool(request.args.get('merge')):
-        data['properties'] = merge_data(data.get('properties') or {},
-                                        entity.data or {})
+        props = merge_data(data.get('properties'), entity.data)
+        data['properties'] = props
     entity.update(data)
     db.session.commit()
     update_entity(entity)

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -176,16 +176,6 @@ class EntitySchema(Schema, DatedSchema):
         return data
 
 
-class LinkSchema(Schema, DatedSchema):
-    id = String(dump_only=True)
-    collection_id = Integer(dump_only=True, required=True)
-    name = String(validate=Length(min=2, max=500), required=True)
-    foreign_ids = List(String())
-    countries = List(Country())
-    schema = SchemaName()
-    schemata = List(SchemaName())
-
-
 class DocumentReference(Schema):
     id = String()
     foreign_id = String()

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -213,6 +213,7 @@ class DocumentSchema(Schema, DatedSchema):
     file_name = String()
     file_size = Integer(dump_only=True)
     author = String()
+    generator = String()
     mime_type = String()
     extension = String(dump_only=True)
     encoding = String(dump_only=True)

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -16,6 +16,7 @@ from aleph.util import ensure_list
 
 
 class Category(String):
+    """A category of collections, e.g. leaks, court cases, sanctions list."""
 
     def _validate(self, value):
         categories = get_config('COLLECTION_CATEGORIES', {})
@@ -24,6 +25,7 @@ class Category(String):
 
 
 class Language(String):
+    """A valid language code."""
 
     def _validate(self, value):
         if not languages.validate(value):
@@ -31,6 +33,7 @@ class Language(String):
 
 
 class Country(String):
+    """A valid country code."""
 
     def _validate(self, value):
         if not countries.validate(value):
@@ -38,6 +41,7 @@ class Country(String):
 
 
 class PartialDate(String):
+    """Any valid prefix of an ISO 8661 datetime string."""
 
     def _validate(self, value):
         if not dates.validate(value):
@@ -195,7 +199,6 @@ class DocumentSchema(Schema, DatedSchema):
     parent = Nested(DocumentReference())
     uploader_id = Integer(dump_only=True)
     error_message = String(dump_only=True)
-    # title = String(validate=Length(min=2, max=5000), missing=None)
     title = String()
     summary = String()
     countries = List(Country(), missing=[])
@@ -264,6 +267,7 @@ class MatchCollectionsSchema(Schema, DatedSchema):
 
 
 class SearchResultSchema(object):
+    """Can either be a Document or an Entity."""
 
     def dump(self, data, many=False):
         results = []

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -161,8 +161,7 @@ class EntitySchema(Schema, DatedSchema):
     countries = List(Country(), dump_only=True)
     schema = SchemaName(required=True)
     schemata = List(SchemaName(), dump_only=True)
-    data = Dict()
-    properties = Dict(dump_only=True)
+    properties = Dict()
     bulk = Boolean(dump_only=True)
 
     @post_dump

--- a/contrib/devwrapper.sh
+++ b/contrib/devwrapper.sh
@@ -1,10 +1,6 @@
 #!/bin/bash
 
 echo "Aleph environment is being set up: $(hostname -i)"
-if [ -d "/aleph/node_modules" ]; then
-  echo 1>&2 "You have a local node_modules directory. Please delete this."
-  exit 127
-fi
 
 if [ -f "/aleph/settings.py" ]; then
   echo 1>&2 "Found settings.py, adding to ALEPH_SETTINGS."

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,8 +33,9 @@ services:
   app:
     build: .
     command: /bin/bash
-    expose:
-      - 5000
+    hostname: alephdev
+    ports:
+      - "5000"
     links:
       - postgres
       - elasticsearch

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -62,7 +62,7 @@ services:
       - postgres
       - elasticsearch
       - rabbitmq
-      - unoservice
+      - worker
     volumes:
       - "./build/logs/beat:/var/log"
       - "./build/data/beat:/var/lib/"
@@ -88,7 +88,7 @@ services:
       - postgres
       - elasticsearch
       - rabbitmq
-      - unoservice
+      - worker
     volumes:
       - "./build/logs/web:/var/log"
       - "./build/archive:/archive"

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ cryptography >= 2.1.3
 pylru >= 1.0.9
 pyjwt >= 1.5.3
 
-followthemoney >= 0.3.2
+followthemoney >= 0.3.3
 fingerprints >= 0.3.2
 storagelayer >= 0.2.1
 exactitude >= 2.1.1

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ setup(
     description="Document sifting web frontend",
     long_description="",
     classifiers=[
-        "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
@@ -23,6 +22,7 @@ setup(
     install_requires=[],
     test_suite='nose.collector',
     entry_points={
+        'aleph.init': [],
         'aleph.analyzers': [
             'lang = aleph.analyze.language:LanguageAnalyzer',
             'emails = aleph.analyze.regex:EMailAnalyzer',
@@ -30,7 +30,6 @@ setup(
             'corasick = aleph.analyze.corasick_entity:AhoCorasickEntityAnalyzer',  # noqa
             'polyglot = aleph.analyze.polyglot_entity:PolyglotEntityAnalyzer'
         ],
-        'aleph.init': [],
         'console_scripts': [
             'aleph = aleph.manage:main',
         ]


### PR DESCRIPTION
This makes API-created entities behave like bulk-loaded ones, in that they will have many values for each property (e.g. aliases, addresses, phone numbers, birthdates). I still worry that this will make the UI a little harder, but it gets lots of bonus points for consistency. 