### PR TITLE
Adding Toolbar to Document view

### DIFF
--- a/ui/src/components/DocumentScreen/DocumentContent.jsx
+++ b/ui/src/components/DocumentScreen/DocumentContent.jsx
@@ -9,6 +9,7 @@ import PdfViewer from './viewers/PdfViewer';
 import ImageViewer from './viewers/ImageViewer';
 import FolderViewer from './viewers/FolderViewer';
 import EmailHeadersViewer from './viewers/EmailHeadersViewer';
+import DocumentToolbar from './DocumentToolbar';
 
 import './DocumentContent.css';
 
@@ -18,6 +19,9 @@ class DocumentContent extends Component {
 
     return (
       <DualPane.ContentPane>
+      
+        <DocumentToolbar/>
+      
         {document.status === 'fail' && (
           <section className="PartialError">
             <div className="pt-non-ideal-state">

--- a/ui/src/components/DocumentScreen/DocumentContent.jsx
+++ b/ui/src/components/DocumentScreen/DocumentContent.jsx
@@ -16,11 +16,18 @@ import './DocumentContent.css';
 class DocumentContent extends Component {
   render() {
     const { document, fragId } = this.props;
-
+    
+    let download 
+    
+    // @TODO If email w/ attachments then pass them as array of download options
+    if (document.links && document.links.file) {
+      download = { name: '', url: document.links.file }
+    }
+    
     return (
       <DualPane.ContentPane>
       
-        <DocumentToolbar/>
+        <DocumentToolbar download={download}/>
       
         {document.status === 'fail' && (
           <section className="PartialError">

--- a/ui/src/components/DocumentScreen/DocumentInfo.jsx
+++ b/ui/src/components/DocumentScreen/DocumentInfo.jsx
@@ -25,7 +25,7 @@ class DocumentInfo extends Component {
             {document.links && document.links.file &&
               <div className="pt-button-group pt-fill document_info_button">
                 <AnchorButton
-                    href={session.token ? `${document.links.file}?api_key=${session.token}` : document.links.file}
+                    href={(session && session.token) ? `${document.links.file}?api_key=${session.token}` : document.links.file}
                     className="document_info_anchor_button"
                     download={document.file_name}>
                     <i className="fa fa-download document_info_icon" aria-hidden="true"/>

--- a/ui/src/components/DocumentScreen/DocumentToolbar.jsx
+++ b/ui/src/components/DocumentScreen/DocumentToolbar.jsx
@@ -1,21 +1,85 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
+import { Popover, PopoverInteractionKind, Position } from "@blueprintjs/core";
 
 import './DocumentToolbar.css';
 
-export default class extends React.Component {
+class DocumentToolbar extends React.Component {
   render() {
     return (
       <div className="document-content-toolbar">
-        <button type="button" className="pt-button" disabled>
-          <span className="pt-icon-standard pt-icon-download"></span>
-          <span><FormattedMessage id="document.download" defaultMessage="Download"/></span>
-        </button>
+        <DownloadButton download={this.props.download} session={this.props.session}/>
         <div className="pt-input-group" style={{maxWidth: 200, float: 'right'}}>
           <span className="pt-icon pt-icon-search"></span>
           <input className="pt-input" disabled type="search" placeholder="Search in document" dir="auto"/>
         </div>
       </div>
     );
+  }
+}
+
+const mapStateToProps = state => ({
+  session: state.session,
+});
+
+export default connect(mapStateToProps)(DocumentToolbar);
+
+/*
+ * Expects a 'download' prop with the values {name: '', url: ''}
+ * 
+ * May also be passed an array of similar objects if there are multiple download
+ * options, the first item in the array will be the default download action.
+ */
+export class DownloadButton extends React.Component {
+  render() {
+      
+    if (this.props.session && this.props.download) {
+      if (Array.isArray(this.props.download)) {
+        // If passed an array, rrender Download button with multiple options
+        let popoverContent = (
+            <ul className="pt-menu">
+              {this.props.download.map((item,i) => {
+                return <li key={i}><a className="pt-menu-item" href={item.url}>{item.name}</a></li>
+              })}
+            </ul>
+          )
+        return (
+          <div className="pt-button-group">
+            <a href={this.props.session.token ? `${this.props.download[0].url}?api_key=${this.props.session.token}` : this.props.download[0].url} className="pt-button">
+              <span className="pt-icon-standard pt-icon-download"></span>
+              <span><FormattedMessage id="document.download" defaultMessage="Download"/></span>
+            </a>
+           <Popover
+            content={popoverContent}
+            interactionKind={PopoverInteractionKind.CLICK}
+            position={Position.BOTTOM_RIGHT}
+            modifiers={{
+              arrow: { enabled: false },
+              preventOverflow: { enabled: false, boundariesElement: "scrollParent" }
+            }}
+            >
+              <a type="button" className="pt-button pt-icon-caret-down"></a>
+            </Popover>
+          </div>
+        );
+      } else {
+        // Render Download button with single button
+        return (
+          <a href={this.props.session.token ? `${this.props.download.url}?api_key=${this.props.session.token}` : this.props.download.url} type="button" className="pt-button">
+            <span className="pt-icon-standard pt-icon-download"></span>
+            <span><FormattedMessage id="document.download" defaultMessage="Download"/></span>
+          </a>
+        );
+      }
+    } else {
+      // Render disabled control
+      return (
+        <button type="button" className="pt-button" disabled>
+          <span className="pt-icon-standard pt-icon-download"></span>
+          <span><FormattedMessage id="document.download" defaultMessage="Download"/></span>
+        </button>
+      );
+    }
   }
 }

--- a/ui/src/components/DocumentScreen/DocumentToolbar.jsx
+++ b/ui/src/components/DocumentScreen/DocumentToolbar.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { FormattedMessage } from 'react-intl';
+
+import './DocumentToolbar.css';
+
+export default class extends React.Component {
+  render() {
+    return (
+      <div className="document-content-toolbar">
+        <button type="button" className="pt-button" disabled>
+          <span className="pt-icon-standard pt-icon-download"></span>
+          <span><FormattedMessage id="document.download" defaultMessage="Download"/></span>
+        </button>
+        <div className="pt-input-group" style={{maxWidth: 200, float: 'right'}}>
+          <span className="pt-icon pt-icon-search"></span>
+          <input className="pt-input" disabled type="search" placeholder="Search in document" dir="auto"/>
+        </div>
+      </div>
+    );
+  }
+}

--- a/ui/src/components/DocumentScreen/DocumentToolbar.scss
+++ b/ui/src/components/DocumentScreen/DocumentToolbar.scss
@@ -1,0 +1,9 @@
+@import "src/app/variables.scss";
+
+.document-content-toolbar {
+  border-bottom: 1px solid $aleph-border-color;
+  padding-bottom: 0.75em;
+  margin-bottom: 1em;
+  clear: both;
+  overflow: auto;
+}


### PR DESCRIPTION
Just a PR to confirm the DocumentToolbar - a consistent toolbar for all Document views where we can put actions scoped to a document - is heading in the right direction.

<img width="1478" alt="screen shot 2018-02-13 at 17 26 44" src="https://user-images.githubusercontent.com/595695/36161260-7c8d096e-10e3-11e8-8845-cbdf58c42eb6.png">

1. The Download button works.
2. The DownloadButton component also accepts an array (where it makes sense to have multiple download options - such as for emails with attachments or MS Office Documents with both native versions and PDF versions) but this is not used _yet_.
3. The "Search in document" control is there as a placeholder but is disabled and not wired up.