### PR TITLE
Entity View and Document View now consistent

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -11,7 +11,10 @@ want to execute it as a stand-alone application, run the following commands:
 * `npm start` - React app at [http://localhost:3000](http://localhost:3000)
 
 Be sure to have the environment variable ``REACT_APP_API_ENDPOINT`` pointed
-at an Aleph 2 instance with CORS enabled.
+at an Aleph 2 instance with CORS enabled. To do this, you can create a `.env`
+file in the root of the ui folder that contains something like the following:
+
+  REACT_APP_API_ENDPOINT=http://localhost:5000/api/2
 
 ## Translation
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,6 +7,7 @@
     "axios": "^0.16.2",
     "bourbon": "^4.3.2",
     "classnames": "^2.2.5",
+    "dotenv": "^5.0.0",
     "filesize": "^3.5.11",
     "font-awesome": "^4.7.0",
     "jwt-decode": "latest",

--- a/ui/src/app/App.jsx
+++ b/ui/src/app/App.jsx
@@ -22,6 +22,8 @@ import { logout } from 'src/actions/sessionActions';
 
 import './App.css';
 
+require('dotenv').config();
+
 // have blueprint handle focus properly
 FocusStyleManager.onlyShowFocusOnTabs();
 

--- a/ui/src/components/DocumentScreen/DocumentCollection.jsx
+++ b/ui/src/components/DocumentScreen/DocumentCollection.jsx
@@ -1,0 +1,79 @@
+import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
+
+import Category from 'src/components/common/Category';
+import Language from 'src/components/common/Language';
+import Country from 'src/components/common/Country';
+import Role from 'src/components/common/Role';
+import Date from 'src/components/common/Date';
+
+
+class CollectionInfo extends Component {
+  render() {
+    const { collection } = this.props;
+
+    return (
+      <React.Fragment>
+        <h1 style={{margin: 0, border: 0}}>
+          {collection.label}
+        </h1>
+        <p>{collection.summary}</p>
+        <ul className='info-sheet'>
+          <li>
+            <span className="key">
+              <FormattedMessage id="collection.category" defaultMessage="Category"/>
+            </span>
+            <span className="value">
+              <Category collection={collection} />
+            </span>
+          </li>
+          { collection.creator && (
+            <li>
+              <span className="key">
+                <FormattedMessage id="collection.creator" defaultMessage="Manager"/>
+              </span>
+              <span className="value">
+                <Role.Label role={collection.creator} />
+              </span>
+            </li>
+          )}
+          { collection.languages && !!collection.languages.length && (
+            <li>
+              <span className="key">
+                <FormattedMessage id="collection.languages" defaultMessage="Language"/>
+              </span>
+              <span className="value">
+                <Language.List codes={collection.languages} />
+              </span>
+            </li>
+          )}
+          { collection.countries && !!collection.countries.length && (
+            <li>
+              <span className="key">
+                <FormattedMessage id="collection.countries" defaultMessage="Country"/>
+              </span>
+              <span className="value">
+                <Country.List codes={collection.countries} truncate={10} />
+              </span>
+            </li>
+          )}
+          <li>
+            <span className="key">
+              <FormattedMessage id="collection.updated_at" defaultMessage="Last updated"/>
+            </span>
+            <span className="value">
+              <Date value={collection.updated_at} />
+            </span>
+          </li>
+        </ul>
+      </React.Fragment>
+    );
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  return {};
+}
+
+export default connect(mapStateToProps)(CollectionInfo);

--- a/ui/src/components/DocumentScreen/DocumentContent.jsx
+++ b/ui/src/components/DocumentScreen/DocumentContent.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { FormattedMessage } from 'react-intl';
 
 import DualPane from 'src/components/common/DualPane';
@@ -13,7 +13,7 @@ import DocumentToolbar from './DocumentToolbar';
 
 import './DocumentContent.css';
 
-class DocumentContent extends Component {
+class DocumentContent extends React.Component {
   render() {
     const { document, fragId } = this.props;
     

--- a/ui/src/components/DocumentScreen/DocumentInfo.jsx
+++ b/ui/src/components/DocumentScreen/DocumentInfo.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { injectIntl, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { Tab, Tabs, Icon } from "@blueprintjs/core";
 
 import Entity from 'src/components/EntityScreen/Entity';
 import EntityInfoTags from 'src/components/EntityScreen/EntityInfoTags';
 import DualPane from 'src/components/common/DualPane';
 import DocumentMetadata from 'src/components/DocumentScreen/DocumentMetadata';
-import DocumentCollection from 'src/components/DocumentScreen/DocumentCollection';
+import CollectionInfo from 'src/components/common/Collection/CollectionInfo';
+import URL from 'src/components/common/URL';
 
 import './DocumentInfo.css';
 
@@ -49,7 +50,19 @@ class DocumentInfo extends React.Component {
                     <Icon icon="graph"/> <FormattedMessage id="document.info.source" defaultMessage="Source"/>
                   </React.Fragment>
                 }
-                panel={<DocumentCollection collection={document.collection}/>}
+                panel={
+                  <React.Fragment>
+                  <CollectionInfo collection={document.collection}/>
+                  {document.source_url && (
+                    <ul className='info-sheet'>
+                      <li>
+                        <span className="key"><FormattedMessage id="document.info.source_url" defaultMessage="Document Source URL"/></span>
+                        <span className="value"><URL value={document.source_url} /></span>
+                      </li>
+                    </ul>
+                  )}
+                  </React.Fragment>
+                }
               />
               <Tab id="tags"
                 title={
@@ -71,5 +84,4 @@ const mapStateToProps = state => ({
   session: state.session,
 });
 
-DocumentInfo = injectIntl(DocumentInfo)
 export default connect(mapStateToProps)(DocumentInfo);

--- a/ui/src/components/DocumentScreen/DocumentInfo.jsx
+++ b/ui/src/components/DocumentScreen/DocumentInfo.jsx
@@ -1,39 +1,75 @@
-import React, {Component} from 'react';
-import {connect} from 'react-redux';
-import {FormattedMessage} from 'react-intl';
+import React from 'react';
+import { connect } from 'react-redux';
+import { injectIntl, FormattedMessage } from 'react-intl';
+import { Tab, Tabs, Icon } from "@blueprintjs/core";
 
 import Entity from 'src/components/EntityScreen/Entity';
 import EntityInfoTags from 'src/components/EntityScreen/EntityInfoTags';
 import DualPane from 'src/components/common/DualPane';
 import DocumentMetadata from 'src/components/DocumentScreen/DocumentMetadata';
-import CollectionCard from 'src/components/CollectionScreen/CollectionCard';
+import DocumentCollection from 'src/components/DocumentScreen/DocumentCollection';
 
 import './DocumentInfo.css';
 
-class DocumentInfo extends Component {
-    render() {
-        const {document} = this.props;
+class DocumentInfo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTabId: 'overview'
+    };
+    this.handleTabChange = this.handleTabChange.bind(this);
+  }
+  
+  handleTabChange(activeTabId: TabId) {
+    this.setState({ activeTabId });
+  }
 
-        return (
-          <DualPane.InfoPane className="DocumentInfo">
-            <h1>
-              <Entity.Label entity={document} addClass={true}/>
-            </h1>
-            <DocumentMetadata document={document}/>
-            <h2>
-              <FormattedMessage id="collection.section" defaultMessage="Origin"/>
-            </h2>
-            <div>
-              <CollectionCard collection={document.collection}/>
-            </div>
-            <EntityInfoTags entity={document} />
-          </DualPane.InfoPane>
-        );
-    }
+  render() {
+    const {document} = this.props;
+    return (
+      <DualPane.InfoPane className="DocumentInfo">
+        <div className="PaneHeading">
+          <h1 style={{margin: 0, border: 0}}>
+            <Entity.Label entity={document} addClass={true}/>
+          </h1>
+        </div>
+        <div className="PaneContent">
+          <Tabs id="TabsExample"  large="true" onChange={this.handleTabChange} selectedTabId={this.state.activeTabId}>
+              <Tab id="overview"
+                title={
+                  <React.Fragment>
+                    <Icon icon="info-sign"/> <FormattedMessage id="document.info.overview" defaultMessage="Overview"/>
+                  </React.Fragment>
+                }
+                panel={<DocumentMetadata document={document}/>} 
+              />
+              <Tab id="source" 
+                title={
+                  <React.Fragment>
+                    <Icon icon="graph"/> <FormattedMessage id="document.info.source" defaultMessage="Source"/>
+                  </React.Fragment>
+                }
+                panel={<DocumentCollection collection={document.collection}/>}
+              />
+              <Tab id="tags"
+                title={
+                  <React.Fragment>
+                    <Icon icon="tag"/> <FormattedMessage id="document.info.tags" defaultMessage="Related Tags"/>
+                  </React.Fragment>
+                }
+                panel={<EntityInfoTags entity={document} />}
+              />
+              <Tabs.Expander />
+          </Tabs>
+        </div>
+      </DualPane.InfoPane>
+    );
+  }
 }
 
 const mapStateToProps = state => ({
   session: state.session,
 });
 
+DocumentInfo = injectIntl(DocumentInfo)
 export default connect(mapStateToProps)(DocumentInfo);

--- a/ui/src/components/DocumentScreen/DocumentInfo.scss
+++ b/ui/src/components/DocumentScreen/DocumentInfo.scss
@@ -29,7 +29,7 @@
   padding: 10px 20px 20px 20px;
 }
 
-.pt-tab-list .pt-icon {
+.DualPane .InfoPane .pt-tab-list .pt-icon {
   padding-bottom: 20px;
   padding-right: 20px;
 }

--- a/ui/src/components/DocumentScreen/DocumentInfo.scss
+++ b/ui/src/components/DocumentScreen/DocumentInfo.scss
@@ -17,5 +17,19 @@
 }
 
 .DualPane .InfoPane.DocumentInfo {
+  padding: 0;
+}
+
+.DualPane .InfoPane.DocumentInfo .PaneHeading {
   background: $aleph-sidebar-background;
+  padding: 40px 20px;
+}
+
+.DualPane .InfoPane.DocumentInfo .PaneContent {
+  padding: 10px 20px 20px 20px;
+}
+
+.pt-tab-list .pt-icon {
+  padding-bottom: 20px;
+  padding-right: 20px;
 }

--- a/ui/src/components/DocumentScreen/DocumentMetadata.jsx
+++ b/ui/src/components/DocumentScreen/DocumentMetadata.jsx
@@ -56,14 +56,6 @@ class DocumentMetadata extends Component {
             </span>
           </li>
         )}
-        {document.source_url && (
-          <li>
-            <span className="key">
-              <FormattedMessage id="document.source_url" defaultMessage="Source URL"/>
-            </span>
-            <span className="value"><URL value={document.source_url} /></span>
-          </li>
-        )}
         {document.author && (
           <li>
             <span className="key">

--- a/ui/src/components/DocumentScreen/DocumentRelatedScreen.jsx
+++ b/ui/src/components/DocumentScreen/DocumentRelatedScreen.jsx
@@ -32,7 +32,7 @@ class DocumentRelatedScreen extends Component {
       return <ScreenLoading />;
     }
     const context = { exclude: document.id };
-
+console.log(document)
     return (
       <Screen>
         <Helmet>
@@ -54,10 +54,10 @@ class DocumentRelatedScreen extends Component {
           </li>
         </Breadcrumbs>
         <DualPane>
-          <DocumentInfo document={document} />
           <DualPane.ContentPane>
             <SearchContext context={context} />
           </DualPane.ContentPane>
+          <DocumentInfo document={document} />
         </DualPane>
       </Screen>
     );

--- a/ui/src/components/DocumentScreen/DocumentRelatedScreen.jsx
+++ b/ui/src/components/DocumentScreen/DocumentRelatedScreen.jsx
@@ -32,7 +32,7 @@ class DocumentRelatedScreen extends Component {
       return <ScreenLoading />;
     }
     const context = { exclude: document.id };
-console.log(document)
+
     return (
       <Screen>
         <Helmet>

--- a/ui/src/components/DocumentScreen/DocumentToolbar.jsx
+++ b/ui/src/components/DocumentScreen/DocumentToolbar.jsx
@@ -11,15 +11,21 @@ import './DocumentToolbar.css';
 class DocumentToolbar extends React.Component {
   constructor(props) {
     super(props);
+    
+    let searchPlaceholder = this.props.intl.formatMessage({id: "document.file.search", defaultMessage: "Search document" });
+    let searchEnabled = false;
+    
+    if (this.props.document.children !== undefined && this.props.document.children > 0) {
+      searchPlaceholder = this.props.intl.formatMessage({id: "document.folder.search", defaultMessage: "Search folder" })
+      searchEnabled = true
+    }
 
     this.state = {
       queryText: '',
+      searchPlaceholder: searchPlaceholder,
+      searchEnabled: searchEnabled
     };
-    
-    this.searchPlaceholder = this.props.intl.formatMessage({id: "document.file.search", defaultMessage: "Search document" })
-    if (this.props.document.children !== undefined && this.props.document.children > 0)
-      this.searchPlaceholder = this.props.intl.formatMessage({id: "document.folder.search", defaultMessage: "Search folder" })
-      
+
     this.onChangeSearchQuery = this.onChangeSearchQuery.bind(this);
     this.onSubmitSearch = this.onSubmitSearch.bind(this);
   }
@@ -57,7 +63,7 @@ class DocumentToolbar extends React.Component {
         <form onSubmit={this.onSubmitSearch} style={{maxWidth: 200, float: 'right'}}>
           <div className="pt-input-group">
             <span className="pt-icon pt-icon-search"></span>
-            <input className="pt-input" type="search" placeholder={this.searchPlaceholder} onChange={this.onChangeSearchQuery} value={this.state.queryText} dir="auto"/>
+            <input className="pt-input" type="search" disabled={!this.state.searchEnabled} placeholder={this.state.searchPlaceholder} onChange={this.onChangeSearchQuery} value={this.state.queryText} dir="auto"/>
           </div>
         </form>
       </div>

--- a/ui/src/components/EntityScreen/EntityContent.jsx
+++ b/ui/src/components/EntityScreen/EntityContent.jsx
@@ -1,18 +1,85 @@
 import React, { Component } from 'react';
+import { connect } from 'react-redux';
+import { FormattedMessage, FormattedNumber } from 'react-intl';
+import _ from 'lodash';
 
+import Property from './Property';
+import Entity from './Entity';
+import EntityInfoTags from './EntityInfoTags';
 import DualPane from 'src/components/common/DualPane';
+import Date from 'src/components/common/Date';
+import Schema from 'src/components/common/Schema';
+import CollectionCard from 'src/components/CollectionScreen/CollectionCard';
 import EntityReferences from './EntityReferences';
+import { fetchEntityReferences } from '../../actions/index';
+
+import './EntityContent.css';
 
 class EntityContent extends Component {
-  render() {
+  componentDidMount() {
     const { entity } = this.props;
+    if(!this.props.references && entity && entity.id) {
+      this.props.fetchEntityReferences(entity);
+    }
+  }
+
+  render() {
+    const { references, entity, schema } = this.props;
+
+    const properties = _.values(schema.properties).filter((prop) => {
+      if (prop.caption) {
+        return false;
+      }
+      return prop.featured || !!entity.properties[prop.name];
+    });
 
     return (
       <DualPane.ContentPane>
-        <EntityReferences entity={entity} />
+        <div className="EntityContent">
+      
+          <span className="muted">
+            <Schema.Icon schema={entity.schema}/>{' '}<Schema.Name schema={entity.schema}/>
+          </span>
+
+          <h1>
+            <Entity.Label entity={entity} addClass={true}/>
+          </h1>
+        
+          <ul className="info-sheet">
+            <li>
+            </li>
+            { properties.map((prop) => (
+              <li key={prop.name}>
+                <span className="key">
+                  <Property.Name model={prop} />
+                </span>
+                <span className="value">
+                  <Property.Values model={prop} values={entity.properties[prop.name]} />
+                </span>
+              </li>
+            ))}
+            <li>
+              <span className="key">
+                <FormattedMessage id="entity.updated" defaultMessage="Last updated"/>
+              </span>
+              <span className="value">
+                <Date value={entity.updated_at} />
+              </span>
+            </li>
+          </ul>
+          
+          <EntityReferences entity={entity} />
+        </div>
       </DualPane.ContentPane>
     );
   }
 }
 
-export default EntityContent;
+const mapStateToProps = (state, ownProps) => {
+  return {
+    references: state.entityReferences[ownProps.entity.id],
+    schema: state.metadata.schemata[ownProps.entity.schema]
+  };
+};
+
+export default connect(mapStateToProps, {fetchEntityReferences})(EntityContent);

--- a/ui/src/components/EntityScreen/EntityContent.scss
+++ b/ui/src/components/EntityScreen/EntityContent.scss
@@ -1,0 +1,24 @@
+@import "src/app/variables.scss";
+
+.EntityContent {
+  font-size: 1.2em;
+  margin: auto;
+  padding: 10px;
+  max-width: 1024px;
+}
+
+.EntityContent h1 {
+  font-size: 2em;
+  line-height: 1.2em;
+  margin: 0.3em 0 0 0;
+}
+
+.EntityContent h2 {
+  font-weight: 600;
+  font-size: 1.5em;
+  margin: 0.5em 0;
+}
+
+.EntityContent .muted {
+  color: $aleph-greyed-text;
+}

--- a/ui/src/components/EntityScreen/EntityInfo.jsx
+++ b/ui/src/components/EntityScreen/EntityInfo.jsx
@@ -1,7 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import { connect } from 'react-redux';
 import { FormattedMessage, FormattedNumber } from 'react-intl';
+import { Tab, Tabs, Icon } from "@blueprintjs/core";
 import _ from 'lodash';
+
 
 import Property from './Property';
 import Entity from './Entity';
@@ -9,12 +11,24 @@ import EntityInfoTags from './EntityInfoTags';
 import DualPane from 'src/components/common/DualPane';
 import Date from 'src/components/common/Date';
 import Schema from 'src/components/common/Schema';
-import CollectionCard from 'src/components/CollectionScreen/CollectionCard';
+import CollectionInfo from 'src/components/common/Collection/CollectionInfo';
 import { fetchEntityReferences } from '../../actions/index';
 
 import './EntityInfo.css';
 
-class EntityInfo extends Component {
+class EntityInfo extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeTabId: 'source'
+    };
+    this.handleTabChange = this.handleTabChange.bind(this);
+  }
+  
+  handleTabChange(activeTabId: TabId) {
+    this.setState({ activeTabId });
+  }
+  
   componentDidMount() {
     const { entity } = this.props;
     if(!this.props.references && entity && entity.id) {
@@ -33,68 +47,34 @@ class EntityInfo extends Component {
     });
   
     return (
-      <DualPane.InfoPane>
-        <h1>
-          <Entity.Label entity={entity} />
-        </h1>
-
-        <ul className="info-sheet">
-          <li>
-            <span className="key"><FormattedMessage id="entity.type" defaultMessage="Type"/></span>
-            <span className="value">
-              <Schema.Icon schema={entity.schema}/>
-              <Schema.Name schema={entity.schema}/>
-            </span>
-          </li>
-          { properties.map((prop) => (
-            <li key={prop.name}>
-              <span className="key">
-                <Property.Name model={prop} />
-              </span>
-              <span className="value">
-                <Property.Values model={prop} values={entity.properties[prop.name]} />
-              </span>
-            </li>
-          ))}
-          <li>
-            <span className="key">
-              <FormattedMessage id="entity.updated" defaultMessage="Last updated"/>
-            </span>
-            <span className="value">
-              <Date value={entity.updated_at} />
-            </span>
-          </li>
-        </ul>
-
-        <h2>
-          <FormattedMessage id="collection.section.origin" defaultMessage="Origin"/>
-        </h2>
-        <div>
-          <CollectionCard collection={entity.collection} />
+      <DualPane.InfoPane className="EntityInfo">
+        <div className="PaneHeading">
+          <h1 style={{margin: 0, border: 0}}>
+            <Entity.Label entity={entity} addClass={true}/>
+          </h1>
         </div>
-
-        { references && references.results && !!references.results.length && (
-          <div className="references">
-            <h2>
-              <FormattedMessage id="collection.section.links" defaultMessage="Relationships"/>
-            </h2>
-            <ul className="info-rank">
-              { references.results.map((ref) => (
-                <li key={ref.property.qname}>
-                  <span className="key">
-                    <Schema.Icon schema={ref.schema} />
-                    <Property.Reverse model={ref.property} />
-                  </span>
-                  <span className="value">
-                    <FormattedNumber value={ref.count} />
-                  </span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        )}
-
-        <EntityInfoTags entity={entity} />
+        <div className="PaneContent">
+          <Tabs id="TabsExample"  large="true" onChange={this.handleTabChange} selectedTabId={this.state.activeTabId}>
+              <Tab id="source" 
+                title={
+                  <React.Fragment>
+                    <Icon icon="graph"/> <FormattedMessage id="document.info.source" defaultMessage="Source"/>
+                  </React.Fragment>
+                }
+                panel={<CollectionInfo collection={entity.collection}/>}
+              />
+              <Tab id="tags"
+                title={
+                  <React.Fragment>
+                    <Icon icon="tag"/> <FormattedMessage id="document.info.tags" defaultMessage="Related Tags"/>
+                  </React.Fragment>
+                }
+                panel={<EntityInfoTags entity={entity} />}
+              />
+              <Tabs.Expander />
+          </Tabs>
+        </div>
+        
       </DualPane.InfoPane>
     );
   }

--- a/ui/src/components/EntityScreen/EntityInfo.scss
+++ b/ui/src/components/EntityScreen/EntityInfo.scss
@@ -1,1 +1,19 @@
 @import "src/app/variables.scss";
+
+.DualPane .InfoPane.EntityInfo {
+  padding: 0;
+}
+
+.DualPane .InfoPane.EntityInfo .PaneHeading {
+  background: $aleph-sidebar-background;
+  padding: 40px 20px;
+}
+
+.DualPane .InfoPane.EntityInfo .PaneContent {
+  padding: 10px 20px 20px 20px;
+}
+
+.DualPane .InfoPane .pt-tab-list .pt-icon {
+  padding-bottom: 20px;
+  padding-right: 20px;
+}

--- a/ui/src/components/EntityScreen/EntityInfoTags.jsx
+++ b/ui/src/components/EntityScreen/EntityInfoTags.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import {Link} from 'react-router-dom';
-import { FormattedMessage, FormattedNumber } from 'react-intl';
+import { FormattedNumber } from 'react-intl';
 
 import Tag from 'src/components/common/Tag';
 import { fetchEntityTags } from '../../actions/index';
@@ -32,9 +32,6 @@ class EntityInfoTags extends Component {
   
     return (
       <div className="tags">
-        <h2>
-          <FormattedMessage id="entity.section.tags" defaultMessage="Related tags"/>
-        </h2>
         <ul className="info-rank">
           { tags.results.map((tag) => (
             <li key={tag.id}>

--- a/ui/src/components/EntityScreen/EntityReferencesTable.jsx
+++ b/ui/src/components/EntityScreen/EntityReferencesTable.jsx
@@ -69,9 +69,9 @@ class EntityReferencesTable extends Component {
 
     return (
       <section className="EntityReferencesTable">
-        <h1>
+        <h2>
           <Property.Reverse model={property} />
-        </h1>
+        </h2>
         <table className="data-table">
           <thead>
             <tr>

--- a/ui/src/components/EntityScreen/EntityRelatedScreen.jsx
+++ b/ui/src/components/EntityScreen/EntityRelatedScreen.jsx
@@ -51,10 +51,10 @@ class EntityScreen extends Component {
           </li>
         </Breadcrumbs>
         <DualPane>
-          <EntityInfo entity={entity} />
           <DualPane.ContentPane>
             <SearchContext context={context} />
           </DualPane.ContentPane>
+          <EntityInfo entity={entity} />
         </DualPane>
       </Screen>
     );

--- a/ui/src/components/EntityScreen/index.jsx
+++ b/ui/src/components/EntityScreen/index.jsx
@@ -50,8 +50,8 @@ class EntityScreen extends Component {
           </li>
         </Breadcrumbs>
         <DualPane>
-          <EntityInfo entity={entity} />
           <EntityContent entity={entity} />
+          <EntityInfo entity={entity} />
         </DualPane>
       </Screen>
     );

--- a/ui/src/components/common/Collection/CollectionInfo.jsx
+++ b/ui/src/components/common/Collection/CollectionInfo.jsx
@@ -11,12 +11,16 @@ import Date from 'src/components/common/Date';
 
 class CollectionInfo extends Component {
   render() {
-    const { collection } = this.props;
+    const { document, collection } = this.props;
+    
+    // If collection data it hasn't loaded yet don't attempt to draw anything
+    if (!collection)
+      return null
 
     return (
       <React.Fragment>
         <h1 style={{margin: 0, border: 0}}>
-          {collection.label}
+          {collection.label || null}
         </h1>
         <p>{collection.summary}</p>
         <ul className='info-sheet'>


### PR DESCRIPTION
# Change Log

1. Entity view now looks like document view with metadata on the right.
2. Entity and Document "related" view now also render with metadata on the right. 
3. There is a new tabbed info sidebar which structures the file metadata much better.
4. The entity pages are a very rough "in progress" version but with no loss of functionality. We have a template to improve them but have not worked on it yet.
5. File search now only works in folder or email view (disabled on a file, as that doesn't exist yet).


With regard to the Entity and Document "related" screens (e.g. https://beta.data.occrp.org/entities/{id}/related) clicking a related tag in the sidebar should take to a search view, and we will remove the "related" screens in future.

The only places there are panels on the left are:
1. The Collection homepage - and we can tackle that after Edit Collection and Search are merged in.
2. The account management page - which we can tackle any time separately.

# Example Screenshots

<img width="1495" alt="screen shot 2018-02-20 at 18 36 24" src="https://user-images.githubusercontent.com/595695/36439383-068971d2-166d-11e8-91d2-d855f9560a70.png">
<img width="1805" alt="screen shot 2018-02-20 at 18 03 45" src="https://user-images.githubusercontent.com/595695/36438626-c7c8639c-166a-11e8-88f9-516117150dd9.png">
<img width="1804" alt="screen shot 2018-02-20 at 18 03 52" src="https://user-images.githubusercontent.com/595695/36438627-c7ec24f8-166a-11e8-9f38-73023d5022fe.png">
<img width="1802" alt="screen shot 2018-02-20 at 18 05 09" src="https://user-images.githubusercontent.com/595695/36438628-c80eb874-166a-11e8-87d6-7ea19f2f62a7.png">
