### PR TITLE
Facet Counts, DocumentInfo toolbar, Homepage

### DIFF
--- a/ui/src/components/Facet/SearchFacet.jsx
+++ b/ui/src/components/Facet/SearchFacet.jsx
@@ -43,9 +43,10 @@ class SearchFacet extends Component {
   }
 
   fetchIfNeeded() {
-    const { fetchFacet, facetQuery, isBlocked } = this.props;
+    const { fetchFacet, facetQuery, isBlocked, isOpen } = this.props;
     const key = facetQuery.toKey();
-    if (!isBlocked && this.state.key !== key) {
+    
+    if (isOpen && !isBlocked && this.state.key !== key) {
       this.setState({ key: key });
       fetchFacet({ query: facetQuery });
     }
@@ -107,12 +108,12 @@ class SearchFacet extends Component {
 
     return (
       <div className="SearchFacet">
-        <div className={c('opener', { clickable: !!facet.total, active: isFiltered })} onClick={this.onToggleOpen} style={{position: 'relative'}}>
+        <div className={c('opener clickable', { active: !isUpdating && isFiltered })} onClick={this.onToggleOpen} style={{position: 'relative'}}>
           <Icon icon={`caret-right`} className={c('caret', {rotate: isOpen})} />
           <span className="FacetName">
             <span className={`FacetIcon pt-icon pt-icon-${icon}`}/>  
             {label} 
-          </span>     
+          </span>
             
           {isFiltered && (
             <React.Fragment>
@@ -128,16 +129,12 @@ class SearchFacet extends Component {
             </React.Fragment>
           )}
 
-          {!isFiltered && (
+          {isOpen && !isFiltered && (
             <React.Fragment>
-              {isUpdating && (
-                <span className="pt-tag pt-small pt-round pt-minimal">…</span>
-              )}
-
               {facet.total === 0 && (
                 <span className="pt-tag pt-small pt-round pt-minimal">0</span>
               )}
-
+              
               {facet.total > 0 && (
                 <span className="pt-tag pt-small pt-round pt-intent-primary">
                   <FormattedNumber value={facet.total} />
@@ -146,12 +143,13 @@ class SearchFacet extends Component {
             </React.Fragment>
           )} 
         </div>
-        <Collapse isOpen={isOpen}>
+          <Collapse isOpen={isOpen} className={c({updating: isUpdating})}>
           {facet.values !== undefined && (
             <CheckboxList items={facet.values}
                           selectedItems={current}
-                          onItemClick={this.onSelect}>
-              {hasMoreValues && (
+                          onItemClick={this.onSelect}
+                          >
+              {!isUpdating && hasMoreValues && (
                 <a className="ShowMore" onClick={this.showMore}>
                   <FormattedMessage id="search.facets.showMore"
                                     defaultMessage="Show more…"
@@ -160,7 +158,7 @@ class SearchFacet extends Component {
               )}
             </CheckboxList>
           )}
-          {(isExpanding && isOpen) && (
+          {((isUpdating || isExpanding) && isOpen) && (
             <Spinner className="pt-small spinner" />
           )}
         </Collapse>

--- a/ui/src/components/Facet/SearchFacet.scss
+++ b/ui/src/components/Facet/SearchFacet.scss
@@ -86,4 +86,8 @@
     margin-top: $aleph-grid-size;
     font-weight: bold;
   }
+  
+  .updating {
+    opacity: 0.5;
+  }
 }

--- a/ui/src/screens/DocumentScreen/DocumentInfo.jsx
+++ b/ui/src/screens/DocumentScreen/DocumentInfo.jsx
@@ -1,8 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { FormattedMessage } from 'react-intl';
 import { Tab, Tabs, Button } from "@blueprintjs/core";
 
+import getPath from 'src/util/getPath';
 import URL from 'src/components/common/URL';
 import { selectEntityTags } from 'src/selectors';
 import DualPane from 'src/components/common/DualPane';
@@ -40,6 +42,12 @@ class DocumentInfo extends React.Component {
               onClick={toggleMaximise}>
               <FormattedMessage id="preview" defaultMessage="Preview"/>
             </Button>
+            {doc.links && doc.links.ui && (
+              <Link to={getPath(doc.links.ui)} className="pt-button button-link">
+                <span className={`pt-icon-document`}/>
+                <FormattedMessage id="sidebar.open" defaultMessage="Open"/>
+              </Link>
+            )}
             <DownloadButton document={doc}/>
             <CloseButton/>
           </Toolbar>

--- a/ui/src/screens/HomeScreen/HomeScreen.jsx
+++ b/ui/src/screens/HomeScreen/HomeScreen.jsx
@@ -103,11 +103,13 @@ class HomeScreen extends Component {
                   />
                 </ControlGroup>
               </form>
+              {/*}
               <div className="calls-to-action">
                 <Link className="pt-button pt-large pt-icon-database" to="/collections">
                   <FormattedMessage id='home.explore' defaultMessage="Browse sources" />
                 </Link>
               </div>
+              */}
             </div>
           </div>
         </section>

--- a/ui/src/screens/HomeScreen/HomeScreen.scss
+++ b/ui/src/screens/HomeScreen/HomeScreen.scss
@@ -53,7 +53,7 @@
   }
 
   .homepage-summary {
-    margin-bottom: 0.5em;
+    margin-bottom: 0.75em;
     font-size: $pt-font-size-large * 2.2;
     min-height: $pt-font-size-large * 3;
     color: white;


### PR DESCRIPTION
* Now only fetches facet counts if facet menu is open for a significant performance improvement.
* Now displays the Open button on DocumentInfo toolbar when a  preview is open in non-maximised mode.
* Removed the ‘Browse sources’ button from the homepage by request.