### PR TITLE
Bulk indexing API

### DIFF
--- a/aleph/index/util.py
+++ b/aleph/index/util.py
@@ -6,7 +6,6 @@ from elasticsearch import TransportError
 
 from aleph.core import es
 from aleph.util import backoff
-from aleph.model import Permission
 
 log = logging.getLogger(__name__)
 

--- a/aleph/logic/entities/__init__.py
+++ b/aleph/logic/entities/__init__.py
@@ -8,7 +8,7 @@ from aleph.index import entities as index
 from aleph.index.core import entities_index
 from aleph.index.util import authz_query, field_filter_query
 from aleph.logic.notifications import flush_notifications
-from aleph.logic.entities.bulk import bulk_load, bulk_load_query  # noqa
+from aleph.logic.entities.bulk import bulk_load, bulk_load_query, bulk_write  # noqa
 
 log = logging.getLogger(__name__)
 BULK_PAGE = 500

--- a/aleph/logic/entities/bulk.py
+++ b/aleph/logic/entities/bulk.py
@@ -1,5 +1,7 @@
 import logging
+from banal import is_mapping
 from followthemoney import model
+from followthemoney.exc import InvalidData
 
 from aleph.core import celery
 from aleph.model import Collection
@@ -64,3 +66,31 @@ def bulk_load_query(collection_id, query):
     index.index_bulk(collection, entities)
     # Update collection stats
     index_collection(collection)
+
+
+def bulk_write(collection, items):
+    """Write a set of entities - given as raw dicts - to the index in bulk
+    mode. This will perform validation but is dangerous as it means the
+    application has no control over key generation and a few other aspects
+    of building the entity.
+    """
+    entities = {}
+    for item in items:
+        if not is_mapping(item):
+            raise InvalidData("Failed to read input data")
+
+        entity = model.get_proxy(item)
+        if entity.id is None:
+            raise InvalidData("No ID for entity")
+
+        if entity.id in entities:
+            entities[entity.id].merge(entity)
+        else:
+            entities[entity.id] = entity
+
+        if len(entities) >= BULK_PAGE:
+            index.index_bulk(collection, entities)
+            entities = {}
+
+    if len(entities):
+        index.index_bulk(collection, entities)

--- a/aleph/tests/test_entities_api.py
+++ b/aleph/tests/test_entities_api.py
@@ -16,13 +16,14 @@ class EntitiesApiTestCase(TestCase):
         super(EntitiesApiTestCase, self).setUp()
         self.rolex = self.create_user(foreign_id='user_3')
         self.col = self.create_collection()
-        self.ent = Entity.create({
+        self.data = {
             'schema': 'LegalEntity',
             'properties': {
                 'name': 'Winnie the Pooh',
                 'country': 'pa',
             }
-        }, self.col)
+        }
+        self.ent = Entity.create(self.data, self.col)
         db.session.commit()
         index_entity(self.ent)
         self.flush_index()

--- a/aleph/views/collections_api.py
+++ b/aleph/views/collections_api.py
@@ -1,3 +1,4 @@
+from banal import ensure_list
 from flask import Blueprint, request
 from werkzeug.exceptions import BadRequest
 from followthemoney import model
@@ -10,7 +11,7 @@ from aleph.logic.collections import create_collection, generate_sitemap
 from aleph.logic.collections import delete_collection, update_collection
 from aleph.logic.collections import delete_entities, delete_documents
 from aleph.logic.documents import process_documents
-from aleph.logic.entities import bulk_load_query
+from aleph.logic.entities import bulk_load_query, bulk_write
 from aleph.logic.audit import record_audit
 from aleph.index.util import refresh_index
 from aleph.index.core import collections_index
@@ -84,6 +85,14 @@ def mapping_process(id):
             bulk_load_query.apply_async([collection.id, query], priority=6)
         except InvalidMapping as invalid:
             raise BadRequest(invalid)
+    return ('', 204)
+
+
+@blueprint.route('/api/2/collections/<int:id>/_bulk', methods=['POST'])
+def bulk(id):
+    collection = get_db_collection(id, request.authz.WRITE)
+    entities = ensure_list(request.get_json(force=True))
+    bulk_write(collection, entities)
     return ('', 204)
 
 


### PR DESCRIPTION
This is an API suggested in conversation with @Ueland - for writing bulk entities using the REST API. Here's the mechanism:

``POST /api/2/collections/453/_bulk``

The expected body is a JSON array of FollowTheMoney entities with the following fields: 

* ``id`` - an ID, unique to the current collection (best practice is to put the collections foreign_id) into key values as a SHA1.
* ``schema`` - name of an FTM schema, e.g. ``LegalEntity``.
* ``properties`` - a dict with property values