### PR TITLE
Update Elastic to 6.5.2

### DIFF
--- a/platform/elasticsearch/Dockerfile
+++ b/platform/elasticsearch/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.0
+FROM docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.2
 RUN bin/elasticsearch-plugin install analysis-icu
 
 COPY k8s-entrypoint.sh /k8s-entrypoint.sh


### PR DESCRIPTION
Latest version - https://www.elastic.co/guide/en/elasticsearch/reference/6.5/release-notes-6.5.2.html