### PR TITLE
Non ideal state suggestion

### DIFF
--- a/ui/src/components/SearchAlert/SearchAlert.jsx
+++ b/ui/src/components/SearchAlert/SearchAlert.jsx
@@ -22,6 +22,14 @@ const messages = defineMessages({
 
 
 class SearchAlert extends React.Component {
+  static doesAlertExist({queryText, session, alerts}){
+    if (!session.loggedIn || !alerts || !alerts.results || !queryText) {
+      return false;
+    }
+    return !!alerts.results.some((a) => {
+      return a.query && a.query.trim() === queryText.trim();
+    });
+  }
   constructor(props) {
     super(props);
     this.state = {updating: false};
@@ -42,13 +50,7 @@ class SearchAlert extends React.Component {
   }
 
   alertExists() {
-    const { queryText, session, alerts } = this.props;
-    if (!session.loggedIn || !alerts || !alerts.results || !queryText) {
-      return false;
-    }
-    return !!alerts.results.some((a) => {
-      return a.query && a.query.trim() === queryText.trim();
-    });
+    return SearchAlert.doesAlertExist(this.props)
   }
 
   async onToggleAlert(event) {

--- a/ui/src/components/SuggestAlert/SuggestAlert.js
+++ b/ui/src/components/SuggestAlert/SuggestAlert.js
@@ -1,0 +1,36 @@
+import React, { PureComponent } from 'react';
+import connect from 'react-redux/es/connect/connect';
+import {Callout, Tag} from '@blueprintjs/core';
+import {FormattedMessage} from 'react-intl';
+import SearchAlert from 'src/components/SearchAlert/SearchAlert';
+import {selectAlerts, selectSession} from 'src/selectors';
+
+class SuggestAlert extends PureComponent{
+  render(){
+    const { queryText, session} = this.props;
+    if (!session.loggedIn || !queryText || !queryText.trim().length || SearchAlert.doesAlertExist(this.props)) {
+      return null;
+    }
+
+    return (<Callout>
+      <FormattedMessage
+        id="alert.suggest.text"
+        defaultMessage={`or get notified {alertComponent} when {queryText} related data will be added.`}
+        values={{alertComponent: <SearchAlert queryText={queryText}/>, queryText:<Tag large>{queryText}</Tag>}}
+      />
+
+    </Callout>)
+  }
+}
+
+const mapStateToProps = (state) => {
+  return {
+    alerts: selectAlerts(state),
+    session: selectSession(state),
+  }
+};
+
+
+SuggestAlert = connect(mapStateToProps)(SuggestAlert)
+export {SuggestAlert};
+export default SuggestAlert;

--- a/ui/src/components/SuggestAlert/SuggestAlert.js
+++ b/ui/src/components/SuggestAlert/SuggestAlert.js
@@ -15,7 +15,7 @@ class SuggestAlert extends PureComponent{
     return (<Callout>
       <FormattedMessage
         id="alert.suggest.text"
-        defaultMessage={`or get notified {alertComponent} when {queryText} related data will be added.`}
+        defaultMessage={`Get notified {alertComponent} when data related to {queryText} is added.`}
         values={{alertComponent: <SearchAlert queryText={queryText}/>, queryText:<Tag large>{queryText}</Tag>}}
       />
 

--- a/ui/src/components/common/ErrorSection.jsx
+++ b/ui/src/components/common/ErrorSection.jsx
@@ -30,7 +30,7 @@ class ErrorSection extends PureComponent {
 
   render() {
     const { error, metadata } = this.props;
-    const { title = '', description = '', visual = 'error' } = this.props;
+    const { title = '', description = '', visual = 'error', resolver } = this.props;
     const message = error === undefined ? title : error.message;
 
     return (
@@ -41,7 +41,7 @@ class ErrorSection extends PureComponent {
                               toggleDialog={this.onSignIn} />
         <div className='ErrorSection'>
           <div className='inner-div'>
-            <NonIdealState visual={visual} title={message} description={description} />
+            <NonIdealState action={resolver} visual={visual} title={message} description={description} />
           </div>
         </div>
       </React.Fragment>

--- a/ui/src/screens/SearchScreen/SearchScreen.jsx
+++ b/ui/src/screens/SearchScreen/SearchScreen.jsx
@@ -4,7 +4,7 @@ import {withRouter} from 'react-router';
 import queryString from 'query-string';
 import {defineMessages, injectIntl, FormattedNumber, FormattedMessage} from 'react-intl';
 import Waypoint from 'react-waypoint';
-import { Icon } from '@blueprintjs/core';
+import { Icon} from '@blueprintjs/core';
 
 import Query from 'src/app/Query';
 import { queryEntities } from 'src/actions';
@@ -13,6 +13,7 @@ import { DualPane, SectionLoading, SignInCallout, ErrorSection, Breadcrumbs } fr
 import EntityTable from 'src/components/EntityTable/EntityTable';
 import SearchFacets from 'src/components/Facet/SearchFacets';
 import QueryTags from 'src/components/QueryTags/QueryTags';
+import SuggestAlert from "src/components/SuggestAlert/SuggestAlert";
 import Screen from 'src/components/Screen/Screen';
 import togglePreview from 'src/util/togglePreview';
 
@@ -274,6 +275,7 @@ class SearchScreen extends React.Component {
             {result.total === 0 && (
               <ErrorSection visual="search"
                             title={intl.formatMessage(messages.no_results_title)}
+                            resolver={<SuggestAlert queryText={query.state.q}/>}
                             description={intl.formatMessage(messages.no_results_description)}/>
             )}
             {!result.isLoading && result.next && (


### PR DESCRIPTION
>4. [Search Screen] Do not show empty pages like "No search result" or "This folder is empty"(for Cases) instead offer users to "Set an Alert" and "Upload files"

This PR partially **for search** implements 4) point from #513 issue, the part  **for cases** will not be implemented for next version.

In cases where there is no search result matching to query users will be suggested to set an alert for the term, if an alert already set for the term suggestion will not appear.

![image](https://user-images.githubusercontent.com/3075886/50134790-39915600-02ab-11e9-9379-567f122beefc.png)
