### PR TITLE
[Hotfix] Collection toolbar critical bug

### DIFF
--- a/ui/src/components/Collection/CollectionToolbar.jsx
+++ b/ui/src/components/Collection/CollectionToolbar.jsx
@@ -3,7 +3,7 @@ import { connect } from "react-redux";
 import { withRouter } from "react-router";
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
-import { Button, Menu, Position, Popover } from "@blueprintjs/core";
+import { Button, Menu, MenuItem, MenuDivider, Position, Popover } from "@blueprintjs/core";
 
 import { Toolbar, CloseButton } from 'src/components/Toolbar';
 import CollectionEditDialog from 'src/dialogs/CollectionEditDialog/CollectionEditDialog';
@@ -61,28 +61,28 @@ class CollectionToolbar extends Component {
           {collection.writeable &&
             <React.Fragment>
               <Popover content={<Menu>
-                <Menu.Item
+                <MenuItem
                   icon="cog"
                   onClick={this.toggleSettings}
                   text={<FormattedMessage id="collection.info.edit_button" defaultMessage="Settings"/>} />
-                <Menu.Item
+                <MenuItem
                   icon="key"
                   onClick={this.toggleAccess}
                   text={<FormattedMessage id="collection.info.share" defaultMessage="Share"/>}
                 />
-                <Menu.Divider />
-                <Menu.Item
+                <MenuDivider />
+                <MenuItem
                   icon="search-around"
                   onClick={this.toggleXref}
                   text={<FormattedMessage id="collection.info.xref" defaultMessage="Cross-reference"/>}
                 />
-                <Menu.Item
+                <MenuItem
                   icon="automatic-updates"
                   onClick={this.toggleAnalyze}
                   text={<FormattedMessage id="collection.info.analyze" defaultMessage="Re-analyze"/>}
                 />
                 <Menu.Divider />
-                <Menu.Item
+                <MenuItem
                   icon="trash"
                   intent="danger"
                   onClick={this.toggleDelete}


### PR DESCRIPTION
### Bug 
The issue was reproducible only in `data.occrp.org`
When the user clicks on `Manage...` button in the collection page
then the whole app crashes into a white page.

### Reason
Debugging showed `Menu.Item` variable as `undefined` which supposed to be an alias for `MenuItem` component `blueprint@3.x.x`. Most probably this is because of missing `package-lock.json` file.

### Resolution
Instead of using `Menu.Item` alias use `MenuItem` component directly.


### for @pudo
 I think event we have a fix for now but we still shall dig deeper into this issue to find the origins.

Big thanks to @uhhhuh for reporting about the bug
