### PR TITLE
Ignore empty directories

### DIFF
--- a/services/elasticsearch/k8s-entrypoint.sh
+++ b/services/elasticsearch/k8s-entrypoint.sh
@@ -6,6 +6,10 @@
 mkdir -p /secrets
 echo "create keystore"
 /usr/share/elasticsearch/bin/elasticsearch-keystore create
+
+# Do not run the following for-loop if /secrets is empty
+shopt -s nullglob
+
 for SECRETFILE in /secrets/*; do
     KEYNAME=$(basename $SECRETFILE);
     echo "$KEYNAME from $SECRETFILE";


### PR DESCRIPTION
Currently if the secrets directory is empty (as is the case with a brand-new installation), elasticsearch crashes because it is passed a literal asterisk with `elasticsearch-keystore add-file * /secrets/*`.

Desired behavior is to either call elasticsearch-keystore with each keyfile (like `elasticsearch-keystore add-file foo /secrets/foo`), or, if there are no keyfiles, to not call `elasticsearch-keystore add-file` at all.

This change skips the for-loop if the secrets directory is empty.