### PR TITLE
improve status update timeouts

### DIFF
--- a/ui/src/components/Collection/CollectionStatus.jsx
+++ b/ui/src/components/Collection/CollectionStatus.jsx
@@ -39,10 +39,13 @@ class CollectionStatus extends Component {
   }
 
   fetchStatus() {
-    const { collection, status } = this.props;
-    this.props.fetchCollectionStatus(collection);
-    const duration = status.pending === 0 ? 6000 : 2000;
-    this.timeout = setTimeout(this.fetchStatus, duration);
+    const { collection } = this.props;
+    this.props.fetchCollectionStatus(collection)
+      .finally(() => {
+        const { status } = this.props;
+        const duration = status.pending === 0 ? 6000 : 2000;
+        this.timeout = setTimeout(this.fetchStatus, duration);
+      });
   }
 
   render() {

--- a/ui/src/components/Document/DocumentManager.jsx
+++ b/ui/src/components/Document/DocumentManager.jsx
@@ -26,18 +26,23 @@ export class DocumentManager extends Component {
 
   componentDidMount() {
     this.refreshPending();
-    this.interval = setInterval(() => this.refreshPending(), 2000);
   }
 
   componentWillUnmount() {
-    clearInterval(this.interval);
+    clearTimeout(this.timeout);
+  }
+
+  scheduleNextRefresh() {
+    this.timeout = setTimeout(() => this.refreshPending(), 2000);
   }
 
   refreshPending() {
     const { hasPending, query, result } = this.props;
     if (!result.isLoading && result.total !== undefined && hasPending) {
       const updateQuery = query.limit(result.results.length);
-      this.props.queryEntities({ query: updateQuery });
+      this.props.queryEntities({ query: updateQuery }).finally(() => this.scheduleNextRefresh());
+    } else {
+      this.scheduleNextRefresh();
     }
   }
 


### PR DESCRIPTION
fetch collection status: call next fetch after the previous one finished to avoid a pile of unfinished requests in case the server is unable to respond in 2 or 6 seconds