### PR TITLE
Handle processing errors in document view mode

### DIFF
--- a/ui/src/components/Document/DocumentViewMode.jsx
+++ b/ui/src/components/Document/DocumentViewMode.jsx
@@ -20,6 +20,12 @@ const PdfViewer = lazy(() => import(/* webpackChunkName: 'base' */ 'src/viewers/
 export class DocumentViewMode extends React.Component {
   renderContent() {
     const { document, queryText, activeMode } = this.props;
+    const processingError = document.getProperty('processingError');
+
+    if (processingError && processingError.length) {
+      return <DefaultViewer document={document} queryText={queryText} />;
+    }
+
     if (document.schema.isA('Email')) {
       if (activeMode === 'browse') {
         return (

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -57,6 +57,7 @@ class EntityViews extends React.Component {
     const hasDocumentViewMode = hasViewer || (!hasBrowseMode && !hasTextMode);
     const hasViewMode = entity.schema.isDocument() && hasDocumentViewMode;
     const refs = !references.results ? [] : references.results.filter(ref => !ref.reverse.hidden);
+    const processingError = entity.getProperty('processingError');
 
     return (
       <Tabs
@@ -143,7 +144,7 @@ class EntityViews extends React.Component {
             }
           />
         ))}
-        { entity.schema.isDocument() && (
+        { entity.schema.isDocument() && (!processingError || !processingError.length) && (
           <Tab
             id="tags"
             disabled={tags.total < 1}


### PR DESCRIPTION
@pudo I was able to reproduce this issue in production, but not locally (even with the same invalid test file)

Based on what I observed in the network requests in production, this fix should display the appropriate processing error message if there is one and hide the mentions tab in that case, but I'd appreciate your double check that the logic is sound :)