### PR TITLE
Add CORS support.

### DIFF
--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -172,6 +172,11 @@ def jsonify(obj, status=200, headers=None, encoder=JSONEncoder):
         data = '%s && %s(%s)' % (cb, cb, data)
         # mime cf. https://stackoverflow.com/questions/24528211/
         mimetype = 'application/javascript'
+    headers = headers or {}
+    # CORS support
+    headers['Access-Control-Allow-Methods'] = 'GET, POST, PUT, DELETE, OPTIONS'
+    headers['Access-Control-Allow-Headers'] = 'Origin, Accept, Content-Type, X-Requested-With, X-CSRF-Token'
+    headers['Access-Control-Allow-Origin'] = '*'
     return Response(data,
                     headers=headers,
                     status=status,


### PR DESCRIPTION
Fixes #914.

This adds CORS for all origins on all endpoints which use the `jsonify` helper. Given that JSONP support was already implemented there, these endpoints were already accessible from any origin via JSONP, so this should not change the policy.