### PR TITLE
Replace react-intl-cra

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "@babel/plugin-proposal-decorators": "^7.6.0",
+    "@formatjs/cli": "^1.1.18",
     "@svgr/webpack": "4.3.3",
     "babel-eslint": "^10.0.3",
     "babel-jest": "24.9.0",
@@ -98,7 +99,7 @@
   ],
   "scripts": {
     "translate": "npm run messages && npm run json2pot && npm run po2json",
-    "messages": "react-intl-cra 'src/**/*.{js,jsx}' -o i18n/messages.json",
+    "messages": "formatjs extract --out-file i18n/messages.json 'src/**/*.{js,jsx}'",
     "json2pot": "react-intl-po json2pot 'i18n/messages.json' -o 'i18n/messages.pot'",
     "po2json": "react-intl-po po2json 'i18n/translations/*.po' -m 'i18n/messages.json' -o src/content/translations.json",
     "start": "node scripts/start.js",

--- a/ui/package.json
+++ b/ui/package.json
@@ -76,7 +76,6 @@
     "postcss-safe-parser": "^4.0.1",
     "react-app-polyfill": "^1.0.4",
     "react-dev-utils": "^10.0.0",
-    "react-intl-cra": "^0.3.4",
     "react-intl-po": "^2.2.2",
     "redux-logger": "^3.0.6",
     "resolve": "^1.10.0",


### PR DESCRIPTION
Replaces deprecated react-intl-cra packege with formatjs's internal cli command to extract messages and output to json file

Resolves #901 