### PR TITLE
use pandoc over openoffice/http to convert documents into pdf's

### DIFF
--- a/services/ingest-file/Dockerfile
+++ b/services/ingest-file/Dockerfile
@@ -93,6 +93,8 @@ RUN apt-get -qq -y update \
         libtiff-tools ghostscript librsvg2-bin \
         # pdf processing toolkit
         poppler-utils poppler-data pst-utils \
+        # document conversion
+        pandoc texlive \
     && apt-get -qq -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/services/ingest-file/requirements.txt
+++ b/services/ingest-file/requirements.txt
@@ -17,6 +17,7 @@ tesserocr==2.5.0
 spacy==2.2.3
 fingerprints==0.6.6
 fasttext==0.9.1
+pypandoc==1.4
 
 # Development
 nose==1.3.7


### PR DESCRIPTION
This pull request is a humble attempt to use pandoc over convert-document/openoffice for document conversion to pdf. Using pandoc would get rid of the convert-document service as a whole, document conversion happens as a sub- process of the file-ingestors themselves.

Unfortunately, I couldn't test the code since I didn't manage to get the docker dev environment to run. I thought to share the changes despite the lack of testing to see if there is principal interest from your side.

`pandoc` has to be installed and in path. The `PYPANDOC_PANDOC` environment variable can be used to point to the location of the `pandoc` binary.