### PR TITLE
Include table csv link in serialized mapping object

### DIFF
--- a/aleph/tests/test_mappings_api.py
+++ b/aleph/tests/test_mappings_api.py
@@ -16,7 +16,7 @@ class MappingAPITest(TestCase):
 
     def setUp(self):
         super(MappingAPITest, self).setUp()
-        self.col = self.create_collection(data={'foreign_id': 'map1'})
+        self.col = self.create_collection(foreign_id='map1')
         _, self.headers = self.login(is_admin=True)
         self.rolex = self.create_user(foreign_id='user_3')
         _, self.headers_x = self.login(foreign_id='user_3')
@@ -178,6 +178,16 @@ class MappingAPITest(TestCase):
         url = "/api/2/entities?filter:collection_id=%s&filter:schemata=LegalEntity" % self.col.id  # noqa
         res = self.client.get(url, headers=self.headers)
         assert res.json['total'] == 15, res.json
+
+        url = "/api/2/collections/%s/mappings/%s/export" % (self.col.id, mapping_id)  # noqa
+        res = self.client.get(url, headers=self.headers)
+        assert res.status_code == 200, res
+        mapping_yaml = "entities:\n      person:\n        keys:\n        "
+        "- name\n        - nationality\n        properties:\n          "
+        "gender:\n            column: gender\n          name:\n            "
+        "column: name\n          nationality:\n            "
+        "column: nationality\n        schema: Person\n"
+        assert mapping_yaml in res.json['yaml'], res.json
 
         url = "/api/2/collections/%s/mappings/%s" % (self.col.id, mapping_id)  # noqa
         res = self.client.delete(url, headers=self.headers_x)

--- a/aleph/validation/schema/mapping.yml
+++ b/aleph/validation/schema/mapping.yml
@@ -29,3 +29,8 @@ Mapping:
       nullable: true
     query:
       type: object
+    links:
+      type: object
+      properties:
+        table_csv:
+          type: string

--- a/aleph/views/mappings_api.py
+++ b/aleph/views/mappings_api.py
@@ -9,9 +9,8 @@ from aleph.model import Mapping
 from aleph.search import QueryParser, DatabaseQueryResult
 from aleph.queues import queue_task, OP_FLUSH_MAPPING, OP_LOAD_MAPPING
 from aleph.views.serializers import MappingSerializer
-from aleph.views.util import get_db_collection, parse_request, jsonify
+from aleph.views.util import get_db_collection, parse_request
 from aleph.views.util import get_index_entity, get_session_id, obj_or_404
-from aleph.logic.mapping import export_mapping
 
 
 blueprint = Blueprint('mappings_api', __name__)
@@ -152,48 +151,6 @@ def view(collection_id, mapping_id):
     get_db_collection(collection_id, request.authz.WRITE)
     mapping = obj_or_404(Mapping.by_id(mapping_id))
     return MappingSerializer.jsonify(mapping)
-
-
-@blueprint.route('/api/2/collections/<int:collection_id>/mappings/<int:mapping_id>/export', methods=['GET'])  # noqa
-def export(collection_id, mapping_id):
-    """Export the mapping as a yaml file.
-    ---
-    get:
-      summary: Export the mapping as a yaml file.
-      parameters:
-      - description: The collection id.
-        in: path
-        name: collection_id
-        required: true
-        schema:
-          minimum: 1
-          type: integer
-        example: 2
-      - description: The mapping id.
-        in: path
-        name: mapping_id
-        required: true
-        schema:
-          minimum: 1
-          type: integer
-        example: 2
-      responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                properties:
-                  yaml:
-                    type: string
-                type: object
-          description: OK
-      tags:
-      - Collection
-      - Mapping
-    """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
-    mapping = obj_or_404(Mapping.by_id(mapping_id))
-    return jsonify({'yaml': export_mapping(collection, mapping)})
 
 
 @blueprint.route('/api/2/collections/<int:collection_id>/mappings/<int:mapping_id>', methods=['POST', 'PUT'])  # noqa

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -11,6 +11,7 @@ from aleph.core import url_for
 from aleph.model import Role, Collection, Document, Entity, Events
 from aleph.model import Alert, Diagram
 from aleph.logic import resolver
+from aleph.logic.mapping import get_table_csv_link
 from aleph.logic.util import collection_url, entity_url, archive_url
 from aleph.views.util import jsonify
 
@@ -353,4 +354,11 @@ class NotificationSerializer(Serializer):
 
 
 class MappingSerializer(Serializer):
-    pass
+    def _serialize(self, obj):
+        links = {
+            # Link gets invalidated after a certain period (~ 24 hours right
+            # now) and does not expose user's api key
+            'table_csv': get_table_csv_link(obj['table_id'])
+        }
+        obj['links'] = links
+        return obj


### PR DESCRIPTION
cc @kjacks 

Some notes:
- The `csv_url` in the generated mapping yaml is a signed Google Storage URL and it expires after a while (24 hours by default). So the mapping when run with ftm cli will not work after that period.
- When used in dev mode, local filesystem is used for blob storage. So the csv_url is a file path inside the container. So if the user wants to run the mapping with ftm cli, they'll have to do it inside a container (`make shell` will give you one)
- I'm not quite sure about the return type. Should I directly return the yaml content or should I return it as json? or is it fine as it is?
- Also, the only additional data the endpoint is returning is the signed url for the csv file. May be if we include that in the mapping view response, we won't need a separate endpoint for export? Wdyt @kjacks?