### PR TITLE
Entity suggest tweaks

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@alephdata/followthemoney": "1.27.7",
-    "@alephdata/vislib": "^1.6.3",
+    "@alephdata/vislib": "^1.6.4",
     "@blueprintjs/core": "^3.18.1",
     "@blueprintjs/datetime": "^3.15.1",
     "@blueprintjs/icons": "3.14.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@alephdata/followthemoney": "1.27.7",
-    "@alephdata/vislib": "^1.6.2",
+    "@alephdata/vislib": "^1.6.3",
     "@blueprintjs/core": "^3.18.1",
     "@blueprintjs/datetime": "^3.15.1",
     "@blueprintjs/icons": "3.14.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@alephdata/followthemoney": "1.27.7",
-    "@alephdata/vislib": "^1.6.4",
+    "@alephdata/vislib": "^1.6.5",
     "@blueprintjs/core": "^3.18.1",
     "@blueprintjs/datetime": "^3.15.1",
     "@blueprintjs/icons": "3.14.0",

--- a/ui/src/components/Diagram/DiagramEditor.jsx
+++ b/ui/src/components/Diagram/DiagramEditor.jsx
@@ -83,13 +83,18 @@ class DiagramEditor extends React.Component {
     const { diagram, location, selectQueryResults } = this.props;
     const query = queryEntitySuggest(location, diagram.collection, schema, queryText);
 
+    // check if query results are in results cache
     const results = selectQueryResults(query);
     if (results) {
       this.entitySuggestPromise = null;
       return results;
     }
 
-    this.props.queryEntities({ query });
+    console.log('entitySuggestTimeout', this.entitySuggestTimeout);
+    clearTimeout(this.entitySuggestTimeout);
+    this.entitySuggestTimeout = setTimeout(() => {
+      this.props.queryEntities({ query });
+    }, 150);
 
     return new Promise((resolve) => {
       this.entitySuggestPromise = { query, promiseResolve: resolve };

--- a/ui/src/components/Diagram/DiagramEditor.jsx
+++ b/ui/src/components/Diagram/DiagramEditor.jsx
@@ -90,7 +90,7 @@ class DiagramEditor extends React.Component {
       return results;
     }
 
-    console.log('entitySuggestTimeout', this.entitySuggestTimeout);
+    // throttle entities query request
     clearTimeout(this.entitySuggestTimeout);
     this.entitySuggestTimeout = setTimeout(() => {
       this.props.queryEntities({ query });

--- a/ui/src/components/Diagram/DiagramEditor.jsx
+++ b/ui/src/components/Diagram/DiagramEditor.jsx
@@ -3,7 +3,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { VisGraph, EntityManager, GraphConfig, GraphLayout, Viewport } from '@alephdata/vislib';
-import { createEntity, deleteEntity, queryEntities, updateDiagram, updateEntity } from 'src/actions';
+import { createEntity, queryEntities, updateDiagram, updateEntity } from 'src/actions';
 import { processApiEntity } from 'src/components/Diagram/util';
 import { queryEntitySuggest } from 'src/queries';
 import { selectLocale, selectModel, selectEntitiesResult } from 'src/selectors';
@@ -23,7 +23,6 @@ class DiagramEditor extends React.Component {
       model: props.model,
       createEntity: this.createEntity.bind(this),
       updateEntity: this.updateEntity.bind(this),
-      deleteEntity: this.deleteEntity.bind(this),
       getEntitySuggestions: this.getEntitySuggestions.bind(this),
     });
 
@@ -128,18 +127,6 @@ class DiagramEditor extends React.Component {
     }
   }
 
-  async deleteEntity(entityId) {
-    const { onStatusChange } = this.props;
-
-    onStatusChange(updateStates.IN_PROGRESS);
-    try {
-      await this.props.deleteEntity(entityId);
-      onStatusChange(updateStates.SUCCESS);
-    } catch {
-      onStatusChange(updateStates.ERROR);
-    }
-  }
-
   updateLayout(layout, options) {
     const { diagram, onStatusChange } = this.props;
     this.setState({ layout });
@@ -222,7 +209,6 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = {
   createEntity,
-  deleteEntity,
   queryEntities,
   updateDiagram,
   updateEntity,


### PR DESCRIPTION
- throttles autocomplete entity query request
- deletion of entities no longer cascades to delete from collection
- prevents creation of vertices with empty caption in vertex create dialog
- improves error-catching in vertex create dialog createEntity request

Outstanding issue: entities added to network diagrams have their `proof` property populated with a reference to their source document entity in Aleph. This creates a dangling entity reference, unless vislib automatically creates a `Document` entity for this source document, which seems less than ideal.
Vislib could hide/ignore properties with 'Document' range, but this would probably necessitate a change to FTM...