### PR TITLE
Use SQL database to cache OCR/doc-conv results

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -38,10 +38,6 @@ networkx==2.4
 zipstream==1.1.4
 tabulate==0.8.7
 
-grpcio==1.29.0
-google-cloud-storage==1.29.0
-google-cloud-logging==1.15.0
-
 # Testing dependencies
 factory-boy==2.12.0
 Faker==4.1.0
@@ -51,3 +47,4 @@ coveralls
 
 # Tracing and logging libraries
 python-json-logger==0.1.11
+google-cloud-logging==1.15.0

--- a/services/ingest-file/ingestors/cli.py
+++ b/services/ingest-file/ingestors/cli.py
@@ -51,7 +51,7 @@ def _ingest_path(db, conn, dataset, path, languages=[]):
     context = {'languages': languages}
     job = Job.create(conn, dataset)
     stage = job.get_stage(OP_INGEST)
-    manager = Manager(stage, context)
+    manager = Manager(db, stage, context)
     path = ensure_path(path)
     if path is not None:
         if path.is_file():

--- a/services/ingest-file/ingestors/settings.py
+++ b/services/ingest-file/ingestors/settings.py
@@ -1,4 +1,5 @@
 from servicelayer import env
+from servicelayer import settings as sls
 from ftmstore import settings as sts
 
 TESTING = False
@@ -28,3 +29,6 @@ NER_DEFAULT_MODEL = 'xx'
 
 # Use the environment variable set in aleph.env
 sts.DATABASE_URI = env.get('ALEPH_DATABASE_URI', sts.DATABASE_URI)
+
+# Also store cached values in the SQL database
+sls.TAGS_DATABASE_URI = sts.DATABASE_URI

--- a/services/ingest-file/ingestors/support/cache.py
+++ b/services/ingest-file/ingestors/support/cache.py
@@ -16,12 +16,6 @@ class CacheSupport(object):
             CacheSupport._tags = Tags('ingest_cache')
         return CacheSupport._tags
 
-    def get_tag(self, key):
-        self.tags.get(key)
-
-    def set_tag(self, key, value):
-        self.tags.set(key, value)
-
     def cache_key(self, *parts):
         return make_key(*parts)
 

--- a/services/ingest-file/ingestors/support/convert.py
+++ b/services/ingest-file/ingestors/support/convert.py
@@ -19,7 +19,7 @@ class DocumentConvertSupport(CacheSupport, TempFileSupport):
 
     def document_to_pdf(self, file_path, entity):
         key = self.cache_key('pdf', entity.first('contentHash'))
-        pdf_hash = self.get_cache_value(key)
+        pdf_hash = self.get_tag(key)
         if pdf_hash is not None:
             file_name = entity_filename(entity, extension='pdf')
             path = self.manager.load(pdf_hash, file_name=file_name)
@@ -32,7 +32,7 @@ class DocumentConvertSupport(CacheSupport, TempFileSupport):
         if pdf_file is not None:
             content_hash = self.manager.store(pdf_file)
             entity.set('pdfHash', content_hash)
-            self.set_cache_value(key, content_hash)
+            self.set_tag(key, content_hash)
         return pdf_file
 
     def _document_to_pdf(self, file_path, entity):

--- a/services/ingest-file/ingestors/support/convert.py
+++ b/services/ingest-file/ingestors/support/convert.py
@@ -19,7 +19,7 @@ class DocumentConvertSupport(CacheSupport, TempFileSupport):
 
     def document_to_pdf(self, file_path, entity):
         key = self.cache_key('pdf', entity.first('contentHash'))
-        pdf_hash = self.get_tag(key)
+        pdf_hash = self.tags.get(key)
         if pdf_hash is not None:
             file_name = entity_filename(entity, extension='pdf')
             path = self.manager.load(pdf_hash, file_name=file_name)
@@ -32,7 +32,7 @@ class DocumentConvertSupport(CacheSupport, TempFileSupport):
         if pdf_file is not None:
             content_hash = self.manager.store(pdf_file)
             entity.set('pdfHash', content_hash)
-            self.set_tag(key, content_hash)
+            self.tags.set(key, content_hash)
         return pdf_file
 
     def _document_to_pdf(self, file_path, entity):

--- a/services/ingest-file/ingestors/support/ocr.py
+++ b/services/ingest-file/ingestors/support/ocr.py
@@ -27,7 +27,7 @@ class OCRSupport(CacheSupport):
         languages = sorted(set(languages or []))
         data_key = sha1(data).hexdigest()
         key = self.cache_key('ocr', data_key, *languages)
-        text = self.get_cache_value(key)
+        text = self.get_tag(key)
         if text is not None:
             log.info('OCR: %s chars cached', len(text))
             return stringify(text)
@@ -39,7 +39,7 @@ class OCRSupport(CacheSupport):
                 settings._ocr_service = LocalOCRService()
 
         text = settings._ocr_service.extract_text(data, languages=languages)
-        self.set_cache_value(key, text)
+        self.set_tag(key, text)
         if text is not None:
             log.info('OCR: %s chars (from %s bytes)',
                      len(text), len(data))

--- a/services/ingest-file/ingestors/support/ocr.py
+++ b/services/ingest-file/ingestors/support/ocr.py
@@ -27,7 +27,7 @@ class OCRSupport(CacheSupport):
         languages = sorted(set(languages or []))
         data_key = sha1(data).hexdigest()
         key = self.cache_key('ocr', data_key, *languages)
-        text = self.get_tag(key)
+        text = self.tags.get(key)
         if text is not None:
             log.info('OCR: %s chars cached', len(text))
             return stringify(text)
@@ -39,8 +39,8 @@ class OCRSupport(CacheSupport):
                 settings._ocr_service = LocalOCRService()
 
         text = settings._ocr_service.extract_text(data, languages=languages)
-        self.set_tag(key, text)
         if text is not None:
+            self.tags.set(key, text)
             log.info('OCR: %s chars (from %s bytes)',
                      len(text), len(data))
         return stringify(text)

--- a/services/ingest-file/requirements.txt
+++ b/services/ingest-file/requirements.txt
@@ -3,15 +3,11 @@ normality==2.0.0
 pantomime==0.4.0
 followthemoney==1.33.0
 followthemoney-store[postgresql]==2.1.7
-servicelayer[google,amazon]==1.11.1
+servicelayer[google,amazon]==1.12.1
 languagecodes==1.0.5
 countrytagger==0.1.2
 pyicu==2.5
-
-grpcio==1.29.0
 google-cloud-vision==1.0.0
-google-cloud-storage==1.28.1
-
 tesserocr==2.5.1
 spacy==2.2.4
 fingerprints==1.0.1


### PR DESCRIPTION
We want this to be long-lived and stable. This would store the ingest cache in the same database as the FTM_STORE. It's a bit messy, but better than having yet another piece of infrastructure flying around. 