### PR TITLE
Filter and facet on date values

### DIFF
--- a/aleph/index/util.py
+++ b/aleph/index/util.py
@@ -125,6 +125,9 @@ def field_filter_query(field, values):
         return {'ids': {'values': values}}
     if field in ['names']:
         field = 'fingerprints'
+    if field.startswith(('gt:', 'gte:', 'lt:', 'lte:')):
+        op, field = field.split(':', 1)
+        return {'range': {field: {op: values[0]}}}
     if len(values) == 1:
         # if field in ['addresses']:
         #     field = '%s.text' % field

--- a/aleph/search/facet.py
+++ b/aleph/search/facet.py
@@ -12,6 +12,7 @@ class Facet(object):
         self.parser = parser
         self.data = self.extract(aggregations, name, 'values')
         self.cardinality = self.extract(aggregations, name, 'cardinality')
+        self.intervals = self.extract(aggregations, name, 'intervals')
 
     def extract(self, aggregations, name, sub):
         if aggregations is None:
@@ -61,6 +62,22 @@ class Facet(object):
             data['values'] = sorted(results,
                                     key=lambda k: k['count'],
                                     reverse=True)
+
+        if self.parser.get_facet_interval(self.name):
+            results = []
+            for bucket in self.intervals.get('buckets', []):
+                key = str(bucket.get('key_as_string'))
+                count = bucket.pop('doc_count', 0)
+                if count > 0:
+                    results.append({
+                        'id': key,
+                        'label': key,
+                        'count': count,
+                        'active': key in active
+                    })
+            data['intervals'] = sorted(results,
+                                       key=lambda k: k['count'],
+                                       reverse=True)
         return data
 
 

--- a/aleph/search/parser.py
+++ b/aleph/search/parser.py
@@ -161,6 +161,14 @@ class SearchQueryParser(QueryParser):
             return False
         return self.getbool('facet_values:%s' % name, True)
 
+    def get_facet_interval(self, name):
+        """Interval to facet on when faceting on date properties
+
+        See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#calendar_intervals   # noqa
+        for available options for possible values
+        """
+        return self.get('facet_interval:%s' % name)
+
     def to_dict(self):
         parser = super(SearchQueryParser, self).to_dict()
         parser['facet_filters'] = list(self.facet_filters)

--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -3,7 +3,9 @@ from pprint import pprint, pformat  # noqa
 from followthemoney.types import registry
 
 from aleph.core import es
-from aleph.index.util import NUMERIC_TYPES, authz_query, field_filter_query
+from aleph.index.util import (
+    NUMERIC_TYPES, authz_query, field_filter_query, DATE_FORMAT
+)
 from aleph.search.result import SearchQueryResult
 from aleph.search.parser import SearchQueryParser
 from aleph.index.entities import get_field_type
@@ -128,6 +130,17 @@ class Query(object):
                 facet_aggregations[agg_name] = {
                     'cardinality': {
                         'field': facet_name
+                    }
+                }
+
+            interval = self.parser.get_facet_interval(facet_name)
+            if interval is not None:
+                agg_name = '%s.intervals' % facet_name
+                facet_aggregations[agg_name] = {
+                    'date_histogram': {
+                        'field': facet_name,
+                        'calendar_interval': interval,
+                        'format': DATE_FORMAT
                     }
                 }
 

--- a/aleph/tests/test_base_api.py
+++ b/aleph/tests/test_base_api.py
@@ -39,4 +39,4 @@ class BaseApiTestCase(TestCase):
         res = self.client.get('/api/2/statistics', headers=headers)
         assert res.status_code == 200, res
         assert res.json['collections'] == 2, res.json
-        assert res.json['things'] == 21, res.json
+        assert res.json['things'] == 23, res.json

--- a/aleph/tests/test_search_query.py
+++ b/aleph/tests/test_search_query.py
@@ -70,7 +70,8 @@ class QueryTestCase(TestCase):
             ('filter:key1', 'foo'),
             ('filter:key1', 'bar'),
             ('filter:key2', 'blah'),
-            ('filter:key2', 'blahblah')
+            ('filter:key2', 'blahblah'),
+            ('filter:gte:date', '2018'),
         ])
 
         self.assertEqual(q.get_filters(), [
@@ -82,6 +83,13 @@ class QueryTestCase(TestCase):
             {
                 'terms': {
                     'key2': ['blah', 'blahblah']
+                }
+            },
+            {
+                'range': {
+                    'date': {
+                        'gte': '2018'
+                    }
                 }
             }
         ])

--- a/aleph/tests/test_stream_api.py
+++ b/aleph/tests/test_stream_api.py
@@ -15,4 +15,4 @@ class StreamApiTestCase(TestCase):
         res = self.client.get('/api/2/entities/_stream', headers=headers)
         assert res.status_code == 200, res
         lines = len(res.data.split(b'\n'))
-        assert 24 == lines, lines
+        assert 26 == lines, lines

--- a/aleph/tests/util.py
+++ b/aleph/tests/util.py
@@ -156,6 +156,21 @@ class TestCase(unittest.TestCase):
             'schema': 'Person',
             'properties': {
                 'name': ['Banana'],
+                'birthDate': '1970-08-21'
+            }
+        }, self.private_coll)
+        self._banana2 = self.create_entity({
+            'schema': 'Person',
+            'properties': {
+                'name': ['Banana'],
+                'birthDate': '1970-03-21'
+            }
+        }, self.private_coll)
+        self._banana3 = self.create_entity({
+            'schema': 'Person',
+            'properties': {
+                'name': ['Banana'],
+                'birthDate': '1970-05-21'
             }
         }, self.private_coll)
         user = Role.by_foreign_id(Role.SYSTEM_USER)


### PR DESCRIPTION
fixes #721 

The url looks like `/entities?filter:schema=Message&filter:gte:properties.date=2018-03-01&filter:lte:properties.date=2018-03-05&facet=properties.date&facet_interval:properties.date=day`

Uses `date_histogram` aggregation with (calendar intervals)[https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#calendar_intervals] for faceting. So we can facet on minutes up to years.