### PR TITLE
Fix/router redirects

### DIFF
--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -66,8 +66,8 @@ class Router extends Component {
           <Redirect from="/collections/:collectionId/documents" to="/datasets/:collectionId" />
           <Route path="/datasets/:collectionId" exact component={CollectionScreen} />
           <Redirect from="/collections/:collectionId" to="/datasets/:collectionId" />
-          <Redirect from="/collections/:collectionId/xref/:otherId" to="/datasets/:collectionId?filter:match_collection_id=:otherId#mode=xref" />
-          <Redirect from="/datasets/:collectionId/xref/:otherId" to="/datasets/:collectionId?filter:match_collection_id=:otherId#mode=xref" />
+          <Redirect from="/collections/:collectionId/xref/:otherId" to="/datasets/:collectionId\?filter\:match_collection_id=:otherId#mode=xref" />
+          <Redirect from="/datasets/:collectionId/xref/:otherId" to="/datasets/:collectionId\?filter\:match_collection_id=:otherId#mode=xref" />
           <Route path="/diagrams/:diagramId" exact component={DiagramScreen} />
           <Route path="/diagrams" exact component={DiagramIndexScreen} />
           <Route path="/search" exact component={SearchScreen} />


### PR DESCRIPTION
currently a url like https://aleph.occrp.org/datasets/1/xref/2 is broken because of a misconfigured `Redirect` in `ui/src/app/Router.jsx`

escaping the `:` and `?` characters (when they are not meant to be related to a variable) fixes this