### PR TITLE
Added API Profiling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-COMPOSE=docker-compose -f docker-compose.dev.yml 
+COMPOSE=docker-compose -f docker-compose.dev.yml
 APPDOCKER=$(COMPOSE) run --rm app
 INGESTDOCKER=$(COMPOSE) run --rm ingest-file
 ALEPH_TAG=latest

--- a/aleph/core.py
+++ b/aleph/core.py
@@ -2,6 +2,7 @@ import logging
 from banal import ensure_list
 from urllib.parse import urlparse, urljoin
 from werkzeug.local import LocalProxy
+from werkzeug.middleware.profiler import ProfilerMiddleware
 from flask import Flask, request
 from flask import url_for as flask_url_for
 from flask_sqlalchemy import SQLAlchemy
@@ -47,7 +48,11 @@ def create_app(config={}):
         'FLASK_SKIP_DOTENV': True,
         'FLASK_DEBUG': settings.DEBUG,
         'BABEL_DOMAIN': 'aleph',
+        'PROFILE': settings.PROFILE,
     })
+
+    if settings.PROFILE:
+        app.wsgi_app = ProfilerMiddleware(app.wsgi_app, restrictions=[30])
 
     migrate.init_app(app, db, directory=settings.ALEMBIC_DIR)
     configure_oauth(app, cache=get_cache())

--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -14,6 +14,8 @@ APP_DIR = os.path.abspath(os.path.dirname(__file__))
 
 # Show error messages to the user.
 DEBUG = env.to_bool('ALEPH_DEBUG', False)
+# Profile requests
+PROFILE = env.to_bool('ALEPH_PROFILE', False)
 # Propose HTTP caching to the user agents.
 CACHE = env.to_bool('ALEPH_CACHE', not DEBUG)
 # Puts the system into read-only mode and displays a warning.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -123,6 +123,7 @@ services:
     - "./site:/aleph/site"
     environment:
       ALEPH_DEBUG: 'true'
+      ALEPH_PROFILE: 'false'
       ALEPH_SECRET_KEY: 'development'
     env_file:
     - aleph.env


### PR DESCRIPTION
This pull request adds a `ALEPH_PROFILE` env flag that enables the werkzeug profiler middleware. This is useful for finding slow portions of the code and understanding the code-paths associated with various API requests.