### PR TITLE
When filtering dates, put all filters for a field in a single range query

### DIFF
--- a/aleph/index/util.py
+++ b/aleph/index/util.py
@@ -121,15 +121,16 @@ def field_filter_query(field, values):
         return {"ids": {"values": values}}
     if field in ["names"]:
         field = "fingerprints"
-    if field.startswith(("gt:", "gte:", "lt:", "lte:")):
-        op, field = field.split(":", 1)
-        return {"range": {field: {op: values[0]}}}
     if len(values) == 1:
         # if field in ['addresses']:
         #     field = '%s.text' % field
         #     return {'match_phrase': {field: values[0]}}
         return {"term": {field: values[0]}}
     return {"terms": {field: values}}
+
+
+def range_filter_query(field, ops):
+    return {"range": {field: ops}}
 
 
 def query_delete(index, query, sync=False, **kwargs):

--- a/aleph/tests/test_search_api.py
+++ b/aleph/tests/test_search_api.py
@@ -83,8 +83,8 @@ class SearchApiTestCase(TestCase):
         assert res.json["total"] == 1, res.json
 
         res = self.client.get(
-            self.url + "&filter:gte:properties.birthDate=1970-05-08"  # noqa
-            "&filter:lt:properties.birthDate=1971-01-01",
+            self.url + "&filter:gte:dates=1970||/y"  # noqa
+            "&filter:lte:dates=1970||/y",
             headers=headers,
         )
         assert res.status_code == 200, res
@@ -103,8 +103,8 @@ class SearchApiTestCase(TestCase):
         assert res.json["total"] == 3, res.json
         facets = res.json["facets"]["properties.birthDate"]["intervals"]
         assert facets[0]["label"].startswith("1969"), facets
-        assert facets[0]["count"] == 0, facets
-        assert facets[1]["count"] == 3, facets
+        assert facets[0]["count"] == 1, facets
+        assert facets[1]["count"] == 2, facets
         assert len(facets) == 3, facets
 
     def test_boolean_query(self):

--- a/aleph/tests/util.py
+++ b/aleph/tests/util.py
@@ -170,7 +170,8 @@ class TestCase(unittest.TestCase):
             {
                 "schema": "Person",
                 "properties": {
-                    "name": ["Banana ba Nana"], "birthDate": "1970-05-21"
+                    "name": ["Banana ba Nana"], "birthDate": "1969-05-21",
+                    "deathDate": "1972-04-23"
                 },
             },
             self.private_coll,


### PR DESCRIPTION
Grouping all conditions in a single query prevents ES from
considering entities with multiple date values that match one of
the individual conditions separately but not all the conditions at
once.