### PR TITLE
Expand entityset API

### DIFF
--- a/aleph/model/common.py
+++ b/aleph/model/common.py
@@ -1,6 +1,7 @@
 import uuid
 import logging
 from datetime import datetime, date
+from sqlalchemy import false
 
 from aleph.core import db
 
@@ -16,6 +17,14 @@ def iso_text(obj):
     if isinstance(obj, (date, datetime)):
         return obj.isoformat()
     return obj
+
+
+def query_like(column, text):
+    if text is None or len(text) < 3:
+        return false()
+    text = text.replace("%", " ").replace("_", " ")
+    text = "%%%s%%" % text
+    return column.ilike(text)
 
 
 class IdModel(object):

--- a/aleph/tests/test_entitysets_api.py
+++ b/aleph/tests/test_entitysets_api.py
@@ -147,9 +147,9 @@ class EntitySetAPITest(TestCase):
         res = self.client.get(url, headers=self.headers)
         assert res.status_code == 404, res
 
-    def test_entityset_items_query(self):
+    def test_entityset_entities_query(self):
         url = "/api/2/entitysets"
-        res = self.client.post(url, json=self.input_data, headers=self.headers)  # noqa
+        res = self.client.post(url, json=self.input_data, headers=self.headers)
         assert res.status_code == 200, res
         validate(res.json, "EntitySet")
         ent_id = self.input_data["entities"][0]["id"]
@@ -158,13 +158,12 @@ class EntitySetAPITest(TestCase):
         entityset_id = res.json["id"]
 
         entityset2_data = self._load_data_for_import("royal-family-v2.vis")
-        res = self.client.post(url, json=entityset2_data, headers=self.headers)  # noqa
+        res = self.client.post(url, json=entityset2_data, headers=self.headers)
         assert res.status_code == 200, res
         validate(res.json, "EntitySet")
         entityset2_id = res.json["id"]
 
         query_url = "/api/2/entitysets/%s/entities?filter:schemata=%s"
-
         url = query_url % (entityset_id, "Thing")
         res = self.client.get(url, headers=self.headers)
         assert res.status_code == 200, res
@@ -188,6 +187,36 @@ class EntitySetAPITest(TestCase):
         assert res.status_code == 200, res
         validate(res.json, "EntitiesResponse")
         assert len(res.json["results"]) == 2, len(res.json["results"])
+
+    def test_entityset_items_query(self):
+        url = "/api/2/entitysets"
+        res = self.client.post(url, json=self.input_data, headers=self.headers)
+        assert res.status_code == 200, res
+        entityset_id = res.json["id"]
+
+        url = "/api/2/entitysets/%s/items" % entityset_id
+        res = self.client.get(url, headers=self.headers)
+        assert res.status_code == 200, res
+        validate(res.json, "EntitySetItemResponse")
+        assert len(res.json["results"]) == 7, len(res.json["results"])
+
+        fst = res.json["results"][0]
+        fst["judgement"] = "negative"
+        res = self.client.post(url, json=fst)
+        assert res.status_code == 403, res
+        res = self.client.post(url, json=fst, headers=self.headers)
+        assert res.status_code == 200, res
+        assert res.json["judgement"] == "negative", res
+
+        res = self.client.get(url, headers=self.headers)
+        assert len(res.json["results"]) == 7, len(res.json["results"])
+
+        fst["judgement"] = "no_judgement"
+        res = self.client.post(url, json=fst, headers=self.headers)
+        assert res.status_code == 204, res
+
+        res = self.client.get(url, headers=self.headers)
+        assert len(res.json["results"]) == 6, len(res.json["results"])
 
     def test_create_empty(self):
         data = {
@@ -239,8 +268,8 @@ class EntitySetAPITest(TestCase):
                 "type": "timeline",
                 "collection_id": str(self.col.id),
             },
-            {"label": "Diagram", "type": "diagram", "collection_id": str(self.col.id),},
-            {"label": "Generic", "type": "generic", "collection_id": str(self.col.id),},
+            {"label": "Diagram", "type": "diagram", "collection_id": str(self.col.id)},
+            {"label": "Generic", "type": "generic", "collection_id": str(self.col.id)},
         )
         url = "/api/2/entitysets"
         for eset in entitysets:

--- a/aleph/validation/schema/entity.yml
+++ b/aleph/validation/schema/entity.yml
@@ -1,7 +1,7 @@
 EntitiesResponse:
   type: object
   allOf:
-    - $ref: '#/components/schemas/QueryResponse'
+    - $ref: "#/components/schemas/QueryResponse"
   properties:
     links:
       properties:
@@ -10,16 +10,16 @@ EntitiesResponse:
       type: object
     results:
       items:
-        $ref: '#/components/schemas/Entity'
+        $ref: "#/components/schemas/Entity"
       type: array
 
 Entity:
   type: object
   allOf:
-  - $ref: '#/components/schemas/DatedModel'
+    - $ref: "#/components/schemas/DatedModel"
   properties:
     collection:
-      $ref: '#/components/schemas/Collection'
+      $ref: "#/components/schemas/Collection"
     countries:
       type: array
       items:
@@ -86,6 +86,8 @@ EntityUpdate:
   required: ["schema"]
   type: object
   properties:
+    id:
+      type: string
     collection_id:
       type: string
       nullable: true
@@ -98,13 +100,13 @@ EntityUpdate:
 EntityCreate:
   type: object
   allOf:
-    - $ref: '#/components/schemas/EntityUpdate'
+    - $ref: "#/components/schemas/EntityUpdate"
   # required: ["collection_id"]
   properties:
     collection_id:
       type: string
     collection:
-      $ref: '#/components/schemas/Collection'
+      $ref: "#/components/schemas/Collection"
     foreign_id:
       type: string
 
@@ -146,6 +148,6 @@ EntityExpand:
     count:
       type: integer
     entities:
-        type: array
-        items:
-          $ref: '#/components/schemas/Entity'
+      type: array
+      items:
+        $ref: "#/components/schemas/Entity"

--- a/aleph/validation/schema/entityset.yml
+++ b/aleph/validation/schema/entityset.yml
@@ -13,12 +13,12 @@ EntitySetBase:
     layout:
       type: object
       allOf:
-      - $ref: '#/components/schemas/DiagramLayout'
+        - $ref: "#/components/schemas/DiagramLayout"
 
 EntitySetUpdate:
   type: object
   allOf:
-  - $ref: '#/components/schemas/EntitySetBase'
+    - $ref: "#/components/schemas/EntitySetBase"
   properties:
     entities:
       type: array
@@ -29,7 +29,7 @@ EntitySetUpdate:
 EntitySetCreate:
   type: object
   allOf:
-  - $ref: '#/components/schemas/EntitySetBase'
+    - $ref: "#/components/schemas/EntitySetBase"
   properties:
     collection_id:
       type: string
@@ -38,24 +38,24 @@ EntitySetCreate:
       items:
         type: object
         allOf:
-        - $ref: '#/components/schemas/EntityUpdate'
+          - $ref: "#/components/schemas/EntityUpdate"
         properties:
           id:
             type: string
             format: entity_id
-        required: ['id', 'schema', 'properties']
-  required: ['label', 'type', 'collection_id']
+        required: ["id", "schema", "properties"]
+  required: ["label", "type", "collection_id"]
 
 EntitySet:
   type: object
   allOf:
-  - $ref: '#/components/schemas/DatedModel'
-  - $ref: '#/components/schemas/EntitySetBase'
+    - $ref: "#/components/schemas/DatedModel"
+    - $ref: "#/components/schemas/EntitySetBase"
   properties:
     collection:
       type: object
       allOf:
-      - $ref: '#/components/schemas/Collection'
+        - $ref: "#/components/schemas/Collection"
     role_id:
       type: string
       readOnly: true
@@ -64,38 +64,41 @@ EntitySet:
       items:
         type: object
         allOf:
-        - $ref: '#/components/schemas/EntityUpdate'
+          - $ref: "#/components/schemas/EntityUpdate"
         properties:
           id:
             type: string
             format: entity_id
-        required: ['id', 'schema']
+        required: ["id", "schema"]
     writeable:
       type: boolean
       readOnly: true
-  required: ['collection', 'role_id', 'label', 'type', 'writeable']
+  required: ["collection", "role_id", "label", "type", "writeable"]
 
 Judgement:
   type: string
-  enum: ['positive', 'negative', 'unsure', 'no_judgement']
+  enum: ["positive", "negative", "unsure", "no_judgement"]
 
-EntitySetItemAdd:
+EntitySetItemUpdate:
   type: object
   properties:
     entity_id:
       type: string
+    entity:
+      type: object
+      allOf:
+        - $ref: "#/components/schemas/Entity"
     compared_to_entity_id:
       type: string
     judgement:
       type: string
       allOf:
-      - $ref: '#/components/schemas/Judgement'
-  required: ['entity_id']
+        - $ref: "#/components/schemas/Judgement"
 
 EntitySetItem:
   type: object
   allOf:
-  - $ref: '#/components/schemas/DatedModel'
+    - $ref: "#/components/schemas/DatedModel"
   properties:
     entityset_id:
       type: string
@@ -104,11 +107,26 @@ EntitySetItem:
     entity:
       type: object
       allOf:
-      - $ref: '#/components/schemas/Entity'
+        - $ref: "#/components/schemas/Entity"
     compared_to_entity_id:
       type: string
     judgement:
       type: string
       allOf:
-      - $ref: '#/components/schemas/Judgement'
-  required: ['entityset_id', 'entity']
+        - $ref: "#/components/schemas/Judgement"
+  required: ["entityset_id", "entity"]
+
+EntitySetItemResponse:
+  type: object
+  allOf:
+    - $ref: "#/components/schemas/QueryResponse"
+  properties:
+    links:
+      properties:
+        export:
+          type: string
+      type: object
+    results:
+      items:
+        $ref: "#/components/schemas/EntitySetItem"
+      type: array

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -291,16 +291,12 @@ class EntitySetSerializer(Serializer):
     def _serialize(self, obj):
         collection_id = obj.pop("collection_id", None)
         entity_ids = obj.pop("entities", [])
-        obj.update(
-            {
-                "shallow": False,
-                "writeable": request.authz.can(collection_id, request.authz.WRITE),
-                "collection": self.resolve(
-                    Collection, collection_id, CollectionSerializer
-                ),  # noqa
-                "entities": [],
-            }
+        obj["shallow"] = False
+        obj["writeable"] = request.authz.can(collection_id, request.authz.WRITE)
+        obj["collection"] = self.resolve(
+            Collection, collection_id, CollectionSerializer
         )
+        obj["entities"] = []
         for ent_id in entity_ids:
             entity = self.resolve(Entity, ent_id, EntitySerializer)
             if entity is not None:
@@ -315,17 +311,12 @@ class EntitySetItemSerializer(Serializer):
 
     def _serialize(self, obj):
         collection_id = obj.pop("collection_id", None)
-        entity_id = obj.pop("entity_id", [])
-        obj.update(
-            {
-                "shallow": False,
-                "writeable": request.authz.can(collection_id, request.authz.WRITE),
-                "collection": self.resolve(
-                    Collection, collection_id, CollectionSerializer
-                ),  # noqa
-                "entity": self.resolve(Entity, entity_id, EntitySerializer),
-            }
+        entity_id = obj.pop("entity_id", None)
+        obj["entity"] = self.resolve(Entity, entity_id, EntitySerializer)
+        obj["collection"] = self.resolve(
+            Collection, collection_id, CollectionSerializer
         )
+        obj["writeable"] = request.authz.can(collection_id, request.authz.WRITE)
         return obj
 
 
@@ -341,7 +332,7 @@ class EntitySetIndexSerializer(Serializer):
                 "writeable": request.authz.can(collection_id, request.authz.WRITE),
                 "collection": self.resolve(
                     Collection, collection_id, CollectionSerializer
-                ),  # noqa
+                ),
             }
         )
         return obj
@@ -380,4 +371,3 @@ class MappingSerializer(Serializer):
     def _serialize(self, obj):
         obj["links"] = {}
         return obj
-

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -11,7 +11,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 from servicelayer.jobs import Job
 
 from aleph.authz import Authz
-from aleph.model import Collection
+from aleph.model import Collection, EntitySet
 from aleph.validation import get_validator
 from aleph.index.entities import get_entity as _get_index_entity
 from aleph.index.collections import get_collection as _get_index_collection
@@ -87,6 +87,12 @@ def get_db_collection(collection_id, action=Authz.READ):
     collection = obj_or_404(Collection.by_id(collection_id))
     require(request.authz.can(collection.id, action))
     return collection
+
+
+def get_entityset(entityset_id, action=Authz.READ):
+    eset = obj_or_404(EntitySet.by_id(entityset_id))
+    require(request.authz.can(eset.collection_id, action))
+    return eset
 
 
 def get_nested_collection(data, action=Authz.READ):


### PR DESCRIPTION
This expands the entity set API like this:

* `GET /api/2/entitysets/YADA/items` - returns a database-backed, paginated index of the entity set items, including judgement and authorship metadata
* `POST /api/2/entitysets/YADA/items` - lets you create or update one item, for example to modify the judgement. If the judgement is set to `no_judgement`, that implements item deletion. (is that too weird??)
* `GET /api/2/entitysets/YADA/entities` - returns a search-backed entities endpoint for search on all items with judgement `positive`. 
* `POST /api/2/entitysets/YADA/entities` - this is where it gets weird. This actually implements full entity upsert, but the entities added here will be added to the entity set, too. 

I haven't currently implemented an explicit `DELETE` API. Deletion can be performed by doing `POST /api/2/entitysets/YADA/items` with a JSON body like this:

```
{"entity_id": "banana", "judgement": "no_judgement"}
```
