### PR TITLE
Fix for Docker on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Ensure bash scripts to be run in Docker have UNIX-style line endings.
+# Without this, the bash scripts will fail to run in Docker on Windows
+# as the COPY step in the Dockerfile will keep Windows-style line endings.
+services/*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 # Without this, the bash scripts will fail to run in Docker on Windows
 # as the COPY step in the Dockerfile will keep Windows-style line endings.
 services/**/*.sh text eol=lf
+contrib/**/*.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
 # Ensure bash scripts to be run in Docker have UNIX-style line endings.
 # Without this, the bash scripts will fail to run in Docker on Windows
 # as the COPY step in the Dockerfile will keep Windows-style line endings.
-services/*.sh text eol=lf
+services/**/*.sh text eol=lf


### PR DESCRIPTION
This allows the elasticsearch container to start on Windows. Without this fix, it fails on startup due to k8s-entrypoint.sh having Windows-style line endings (which the bash running in the container doesn't understand). 

Most of the project then seems to run fine (including the API), except for the UI which "fails to compile".