### PR TITLE
Add tests and type annotations to authentication logic

### DIFF
--- a/aleph/__init__.py
+++ b/aleph/__init__.py
@@ -5,7 +5,7 @@ from pkg_resources import get_distribution
 
 __version__ = get_distribution("aleph").version
 
-from yaml import YAMLLoadWarning
+from yaml import YAMLLoadWarning  # type: ignore
 
 warnings.filterwarnings("ignore", category=YAMLLoadWarning)
 

--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -27,10 +27,6 @@ class Authz:
     e.g. in the context of notifications.
     """
 
-    # TODO(AD): Remove after switching all code to ActionEnum
-    READ = "read"
-    WRITE = "write"
-
     PREFIX = "aauthz"
 
     _JWT_TOKENS_VALIDITY_DURATION = timedelta(days=1)

--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -184,10 +184,13 @@ class _JtwToken:
     @classmethod
     def from_str(cls, token_as_str: str) -> "_JtwToken":
         try:
-            data = jwt.decode(token_as_str, key=settings.SECRET_KEY, verify=True)
-            return cls(**data)
+            token_as_dict = jwt.decode(token_as_str, key=settings.SECRET_KEY, verify=True)
+            # TODO(AD): Validate the type of each field at runtime as this is attacker-controlled data, or consider
+            # using pydantic?
+            token = cls(**token_as_dict)
+            return token
+
         except (jwt.InvalidTokenError, TypeError):
-            log.exception("LOL")
             raise InvalidJwtToken()
 
     def to_bytes(self) -> bytes:

--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -142,7 +142,9 @@ class Authz:
             raise Unauthorized()
 
         # TODO(AD): is_admin and is_blocked are already in the DB so it seems dangerous to take them from a JWT token
-        return cls(role_id=parsed_token.u, roles=set(parsed_token.r), is_admin=parsed_token.a, is_blocked=parsed_token.b,)
+        return cls(
+            role_id=parsed_token.u, roles=set(parsed_token.r), is_admin=parsed_token.a, is_blocked=parsed_token.b,
+        )
 
     def __repr__(self) -> str:
         return "<Authz(%s)>" % self.id
@@ -203,6 +205,6 @@ class _JtwToken(pydantic.BaseModel):
 
     def to_str(self) -> str:
         token_as_dict = self.dict(exclude_none=True)
-        return jwt.encode(
-            payload=token_as_dict, key=settings.SECRET_KEY, algorithm=Authz._JWT_TOKENS_ALGORITHM
-        ).decode("utf-8")
+        return jwt.encode(payload=token_as_dict, key=settings.SECRET_KEY, algorithm=Authz._JWT_TOKENS_ALGORITHM).decode(
+            "utf-8"
+        )

--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, asdict
 from enum import Enum
-from typing import List, Set, Dict, Optional
+from typing import List, Set, Dict, Optional, Union
 import pydantic
 
 import jwt
@@ -98,17 +98,17 @@ class Authz:
             return False
         return self.logged_in
 
-    def can_write_role(self, role_id: int) -> bool:
+    def can_write_role(self, role_id: Union[int, str]) -> bool:
         if not self.session_write:
             return False
         if self.is_admin:
             return True
-        return role_id in self.private_roles
+        return int(role_id) in self.private_roles
 
-    def can_read_role(self, role_id: int) -> bool:
+    def can_read_role(self, role_id: Union[int, str]) -> bool:
         if self.is_admin:
             return True
-        return role_id in self.roles
+        return int(role_id) in self.roles
 
     @property
     def role(self) -> Role:

--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -184,7 +184,7 @@ class _JtwToken:
     @classmethod
     def from_str(cls, token_as_str: str) -> "_JtwToken":
         try:
-            token_as_dict = jwt.decode(token_as_str, key=settings.SECRET_KEY, verify=True)
+            token_as_dict = jwt.decode(jwt=token_as_str, key=settings.SECRET_KEY, verify=True, algorithms=["H256"])
             # TODO(AD): Validate the type of each field at runtime as this is attacker-controlled data, or consider
             # using pydantic?
             token = cls(**token_as_dict)
@@ -194,4 +194,4 @@ class _JtwToken:
             raise InvalidJwtToken()
 
     def to_bytes(self) -> bytes:
-        return jwt.encode(asdict(self), settings.SECRET_KEY)
+        return jwt.encode(payload=asdict(self), key=settings.SECRET_KEY, algorithm="H256")

--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -1,7 +1,10 @@
+from dataclasses import dataclass, asdict
+from enum import Enum
+from typing import List, Set, Dict, Optional
+
 import jwt
 import json
 import logging
-from banal import ensure_list
 from datetime import datetime, timedelta
 from werkzeug.exceptions import Unauthorized
 
@@ -11,39 +14,45 @@ from aleph.model import Collection, Role, Permission
 log = logging.getLogger(__name__)
 
 
-class Authz(object):
+class ActionEnum(str, Enum):
+    READ = "read"
+    WRITE = "write"
+
+
+class Authz:
     """Hold the authorization information for a user.
 
     This is usually attached to a request, but can also be used separately,
     e.g. in the context of notifications.
     """
 
+    # TODO(AD): Remove after switching all code to ActionEnum
     READ = "read"
     WRITE = "write"
-    PREFIX = "aauthz"
 
-    def __init__(self, role_id, roles, is_admin=False, is_blocked=False):
+    PREFIX = "aauthz"
+    _JWT_TOKENS_VALIDITY_DURATION = timedelta(days=1)
+
+    def __init__(self, role_id: Optional[int], roles: Set[int], is_admin: bool = False, is_blocked: bool = False):
         self.id = role_id
         self.logged_in = role_id is not None
-        self.roles = set(ensure_list(roles))
+        self.roles = roles
         self.is_admin = is_admin
         self.is_blocked = is_blocked
         self.in_maintenance = settings.MAINTENANCE
         self.session_write = not self.in_maintenance and self.logged_in
         self.session_write = not is_blocked and self.session_write
-        self._collections = {}
+        self._collections: Dict[ActionEnum, List[Collection]] = {}
 
-    def collections(self, action):
+    def collections(self, action: ActionEnum) -> List[Collection]:
         if action in self._collections:
-            return self._collections.get(action)
+            return self._collections[action]
         key = cache.key(action, self.id)
         collections = cache.kv.hget(self.PREFIX, key)
         if collections:
             collections = json.loads(collections)
             self._collections[action] = collections
-            log.debug(
-                "[C] Authz: %s (%s): %d collections", self, action, len(collections)
-            )
+            log.debug("[C] Authz: %s (%s): %d collections", self, action, len(collections))
             return collections
 
         if self.is_admin:
@@ -51,9 +60,9 @@ class Authz(object):
         else:
             q = db.session.query(Permission.collection_id)
             q = q.filter(Permission.role_id.in_(self.roles))
-            if action == self.READ:
+            if action == ActionEnum.READ:
                 q = q.filter(Permission.read == True)  # noqa
-            if action == self.WRITE:
+            if action == ActionEnum.WRITE:
                 q = q.filter(Permission.write == True)  # noqa
             q = q.distinct()
             # log.info("Query: %s - roles: %s", q, self.roles)
@@ -63,10 +72,10 @@ class Authz(object):
         self._collections[action] = collections
         return collections
 
-    def can(self, collection, action):
+    def can(self, collection, action: ActionEnum) -> bool:
         """Query permissions to see if the user can perform the specified
         action on the given collection."""
-        if action == self.WRITE and not self.session_write:
+        if action == ActionEnum.WRITE and not self.session_write:
             return False
         if self.is_admin:
             return True
@@ -82,69 +91,63 @@ class Authz(object):
             return False
         return collection in self.collections(action)
 
-    def can_stream(self):
+    def can_stream(self) -> bool:
         return self.logged_in
 
-    def can_bulk_import(self):
+    def can_bulk_import(self) -> bool:
         if not self.session_write:
             return False
         return self.logged_in
 
-    def can_write_role(self, role_id):
-        if not self.session_write or role_id is None:
+    def can_write_role(self, role_id: int) -> bool:
+        if not self.session_write:
             return False
         if self.is_admin:
             return True
-        try:
-            return int(role_id) in self.private_roles
-        except (ValueError, TypeError):
-            return False
+        return role_id in self.private_roles
 
-    def can_read_role(self, role_id):
+    def can_read_role(self, role_id: int) -> bool:
         if self.is_admin:
             return True
-        return int(role_id) in self.roles
-
-    def match(self, roles):
-        """See if there's overlap in roles."""
-        roles = ensure_list(roles)
-        if not len(roles):
-            return False
-        return self.roles.intersection(roles) > 0
+        return role_id in self.roles
 
     @property
-    def role(self):
+    def role(self) -> Role:
         return Role.by_id(self.id)
 
     @property
-    def private_roles(self):
+    def private_roles(self) -> Set[int]:
         if not self.logged_in:
             return set()
         return self.roles.difference(Role.public_roles())
 
-    def to_token(self, scope=None, role=None):
-        exp = datetime.utcnow() + timedelta(days=1)
-        payload = {
-            "u": self.id,
-            "exp": exp,
-            "r": list(self.roles),
-            "a": self.is_admin,
-            "b": self.is_blocked,
-        }
-        if scope is not None:
-            payload["s"] = scope
-        if role is not None:
-            role = role.to_dict()
-            role.pop("created_at", None)
-            role.pop("updated_at", None)
-            payload["role"] = role
-        return jwt.encode(payload, settings.SECRET_KEY)
+    def to_token(self, scope: Optional[str] = None) -> bytes:
+        if self.id is None:
+            raise ValueError("Cannot create a JWT token for a None role_id")
 
-    def __repr__(self):
+        token = _JtwToken(
+            u=self.id,
+            exp=datetime.utcnow() + self._JWT_TOKENS_VALIDITY_DURATION,
+            r=self.roles,
+            a=self.is_admin,
+            b=self.is_blocked,
+            s=scope,
+        )
+        return token.to_bytes()
+
+    @classmethod
+    def from_token(cls, jwt_token: str, request_path: str) -> "Authz":
+        parsed_token = _JtwToken.from_str(jwt_token)
+        if parsed_token.s and parsed_token.s != request_path:
+            raise Unauthorized()
+
+        return cls(role_id=parsed_token.u, roles=parsed_token.r, is_admin=parsed_token.a, is_blocked=parsed_token.b,)
+
+    def __repr__(self) -> str:
         return "<Authz(%s)>" % self.id
 
     @classmethod
-    def from_role(cls, role):
+    def from_role(cls, role: Optional[Role]) -> "Authz":
         roles = set([Role.load_id(Role.SYSTEM_GUEST)])
         if role is None:
             return cls(None, roles)
@@ -156,24 +159,36 @@ class Authz(object):
         return cls(role.id, roles, is_admin=role.is_admin, is_blocked=role.is_blocked)
 
     @classmethod
-    def from_token(cls, token, scope=None):
-        if token is None:
-            return
-        try:
-            data = jwt.decode(token, key=settings.SECRET_KEY, verify=True)
-            if "s" in data and data.get("s") != scope:
-                raise Unauthorized()
-            return cls(
-                data.get("u"), data.get("r"), data.get("a", False), data.get("b", False)
-            )
-        except (jwt.DecodeError, TypeError):
-            return
-
-    @classmethod
-    def flush(cls):
+    def flush(cls) -> None:
         cache.kv.delete(cls.PREFIX)
 
     @classmethod
-    def flush_role(cls, role_id):
-        keys = [cache.key(a, role_id) for a in (cls.READ, cls.WRITE)]
+    def flush_role(cls, role_id) -> None:
+        keys = [cache.key(a, role_id) for a in ActionEnum]
         cache.kv.hdel(cls.PREFIX, *keys)
+
+
+class InvalidJwtToken(Exception):
+    pass
+
+
+@dataclass(frozen=True)
+class _JtwToken:
+    u: int  # role ID
+    r: Set[int]  # role IDs  # TODO(AD): Is this required or optional?
+    exp: datetime  # Expiration date; automatically checked by the JWT library but must be present here
+    a: bool = False  # is_admin
+    b: bool = False  # is_blocked
+    s: Optional[str] = None  # Scope ie. request path the token is valid for; None means all paths are authorized
+
+    @classmethod
+    def from_str(cls, token_as_str: str) -> "_JtwToken":
+        try:
+            data = jwt.decode(token_as_str, key=settings.SECRET_KEY, verify=True)
+            return cls(**data)
+        except (jwt.InvalidTokenError, TypeError):
+            log.exception("LOL")
+            raise InvalidJwtToken()
+
+    def to_bytes(self) -> bytes:
+        return jwt.encode(asdict(self), settings.SECRET_KEY)

--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -128,6 +128,7 @@ class Authz:
             a=self.is_admin,
             b=self.is_blocked,
             s=scope,
+            role=self.role.to_dict(),
         )
         return token.to_str()
 
@@ -171,6 +172,19 @@ class InvalidJwtToken(Exception):
     pass
 
 
+class _RoleField(pydantic.BaseModel):
+    id: int
+    type: str
+    name: str
+    label: str
+    email: Optional[str]
+    locale: Optional[str]
+    is_admin: bool
+    is_muted: bool
+    is_tester: bool
+    has_password: bool
+
+
 class _JtwToken(pydantic.BaseModel):
     u: int  # role ID
     r: List[int]  # role IDs  # TODO(AD): Is this required or optional?
@@ -178,6 +192,7 @@ class _JtwToken(pydantic.BaseModel):
     a: bool = False  # is_admin
     b: bool = False  # is_blocked
     s: Optional[str] = None  # Scope ie. request path the token is valid for; None means all paths are authorized
+    role: _RoleField
 
     @classmethod
     def from_str(cls, token_as_str: str) -> "_JtwToken":

--- a/aleph/core.py
+++ b/aleph/core.py
@@ -27,7 +27,7 @@ from aleph.oauth import configure_oauth
 NONE = "'none'"
 log = logging.getLogger(__name__)
 
-db = SQLAlchemy()
+db: SQLAlchemy = SQLAlchemy()
 migrate = Migrate()
 mail = Mail()
 babel = Babel()

--- a/aleph/core.py
+++ b/aleph/core.py
@@ -157,7 +157,7 @@ def url_for(*a, **kw):
         authorize = kw.pop("_authorize", False)
         relative = kw.pop("_relative", False)
         path = flask_url_for(*a, **kw)
-        if authorize is True and hasattr(request, "authz"):
+        if authorize is True and hasattr(request, "authz") and request.authz.logged_in:
             token = request.authz.to_token(scope=path)
             query = list(ensure_list(query))
             query.append(("api_key", token))

--- a/aleph/index/util.py
+++ b/aleph/index/util.py
@@ -6,6 +6,7 @@ from elasticsearch.helpers import streaming_bulk
 from followthemoney.types import registry
 from servicelayer.util import backoff, service_retries
 
+from aleph.authz import ActionEnum
 from aleph.core import es, settings
 
 log = logging.getLogger(__name__)
@@ -95,7 +96,7 @@ def authz_query(authz, field="collection_id"):
     # Hot-wire authorization entirely for admins.
     if authz.is_admin:
         return {"match_all": {}}
-    collections = authz.collections(authz.READ)
+    collections = authz.collections(ActionEnum.READ)
     if not len(collections):
         return {"match_none": {}}
     return {"terms": {field: collections}}

--- a/aleph/logic/entities.py
+++ b/aleph/logic/entities.py
@@ -8,6 +8,7 @@ from followthemoney.types import registry
 from followthemoney.helpers import inline_names
 from followthemoney.exc import InvalidData
 
+from aleph.authz import ActionEnum
 from aleph.core import db, cache
 from aleph.model import Entity, Document, EntitySetItem, Mapping
 from aleph.index import entities as index
@@ -71,7 +72,7 @@ def check_write_entity(entity, authz):
     collection_id = entity.get("collection_id", collection_id)
     if not entity.get("mutable"):
         return False
-    return authz.can(collection_id, authz.WRITE)
+    return authz.can(collection_id, ActionEnum.WRITE)
 
 
 def refresh_entity(collection, entity_id):

--- a/aleph/logic/notifications.py
+++ b/aleph/logic/notifications.py
@@ -6,7 +6,7 @@ from followthemoney import model
 from followthemoney.util import get_entity_id
 
 from aleph.core import cache, es, settings
-from aleph.authz import Authz
+from aleph.authz import Authz, ActionEnum
 from aleph.model import Collection, Entity, Role, Alert, EntitySet
 from aleph.model import Event, Events
 from aleph.logic.mail import email_role
@@ -55,7 +55,7 @@ def get_role_channels(role):
         authz = Authz.from_role(role)
         for role_id in authz.roles:
             channels.append(channel_tag(role_id, Role))
-        for coll_id in authz.collections(authz.READ):
+        for coll_id in authz.collections(ActionEnum.READ):
             channels.append(channel_tag(coll_id, Collection))
     cache.set_list(key, channels, expires=3600 * 2)
     return channels

--- a/aleph/model/entityset.py
+++ b/aleph/model/entityset.py
@@ -5,6 +5,7 @@ from normality import stringify
 from sqlalchemy.dialects.postgresql import JSONB
 from banal import ensure_list
 
+from aleph.authz import ActionEnum
 from aleph.core import db
 from aleph.model import Role, Collection
 from aleph.model.common import SoftDeleteModel
@@ -73,7 +74,7 @@ class EntitySet(db.Model, SoftDeleteModel):
 
     @classmethod
     def by_authz(cls, authz, types=None, prefix=None):
-        ids = authz.collections(authz.READ)
+        ids = authz.collections(ActionEnum.READ)
         q = cls.by_type(types)
         q = q.filter(cls.collection_id.in_(ids))
         if prefix is not None:

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -75,7 +75,7 @@ class Role(db.Model, IdModel, SoftDeleteModel):
         return True
 
     @property
-    def label(self):
+    def label(self) -> str:
         return anonymize_email(self.name, self.email)
 
     def update(self, data):

--- a/aleph/search/__init__.py
+++ b/aleph/search/__init__.py
@@ -1,4 +1,6 @@
 import logging
+from typing import ClassVar, List, Union, Dict
+
 from flask_babel import gettext
 from werkzeug.exceptions import BadRequest
 
@@ -37,7 +39,7 @@ class EntitiesQuery(Query):
     PREFIX_FIELD = "names.text"
     SKIP_FILTERS = ["schema", "schemata"]
     INCLUDE_FIELDS = PROXY_INCLUDES
-    SORT_DEFAULT = []
+    SORT_DEFAULT: ClassVar[List[Union[str, Dict[str, str]]]] = []
 
     def get_index(self):
         schemata = self.parser.getlist("filter:schema")

--- a/aleph/search/__init__.py
+++ b/aleph/search/__init__.py
@@ -4,6 +4,7 @@ from typing import ClassVar, List, Union, Dict
 from flask_babel import gettext
 from werkzeug.exceptions import BadRequest
 
+from aleph.authz import ActionEnum
 from aleph.index.indexes import entities_read_index
 from aleph.index.collections import collections_index
 from aleph.index.xref import xref_index
@@ -26,7 +27,7 @@ class CollectionsQuery(Query):
     def get_filters(self):
         filters = super(CollectionsQuery, self).get_filters()
         if self.parser.getbool("filter:writeable"):
-            ids = self.parser.authz.collections(self.parser.authz.WRITE)
+            ids = self.parser.authz.collections(ActionEnum.WRITE)
             filters.append({"ids": {"values": ids}})
         return filters
 

--- a/aleph/search/facet.py
+++ b/aleph/search/facet.py
@@ -1,6 +1,7 @@
 from followthemoney import model
 from followthemoney.types import registry
 
+from aleph.authz import ActionEnum
 from aleph.model import Collection
 from aleph.logic import resolver
 
@@ -95,7 +96,7 @@ class CategoryFacet(Facet):
 class CollectionFacet(Facet):
     def expand(self, keys):
         for key in keys:
-            if self.parser.authz.can(key, self.parser.authz.READ):
+            if self.parser.authz.can(key, ActionEnum.READ):
                 resolver.queue(self.parser, Collection, key)
         resolver.resolve(self.parser)
 

--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -1,5 +1,7 @@
 import logging
 from pprint import pprint, pformat  # noqa
+from typing import List, Union, Dict, ClassVar, Optional
+
 from followthemoney.types import registry
 from banal import ensure_list
 
@@ -27,18 +29,18 @@ def convert_filters(filters):
 
 class Query(object):
     RESULT_CLASS = SearchQueryResult
-    INCLUDE_FIELDS = None
+    INCLUDE_FIELDS: ClassVar[Optional[List[str]]] = None
     EXCLUDE_FIELDS = None
     TEXT_FIELDS = ["text"]
     PREFIX_FIELD = "name"
-    SKIP_FILTERS = []
+    SKIP_FILTERS: ClassVar[List[str]] = []
     AUTHZ_FIELD = "collection_id"
     SORT_FIELDS = {
         "label": "label.kw",
         "name": "name.kw",
         "score": "_score",
     }
-    SORT_DEFAULT = ["_score"]
+    SORT_DEFAULT: ClassVar[List[Union[str, Dict[str, str]]]] = ["_score"]
 
     def __init__(self, parser):
         self.parser = parser

--- a/aleph/tests/test_authentication.py
+++ b/aleph/tests/test_authentication.py
@@ -24,7 +24,7 @@ class _MockFlaskRequest:
     ) -> None:
         self.path = path
         self.headers = {}
-        self.args = TypeConversionDict()
+        self.args: Dict[str, str] = TypeConversionDict()
 
         if authorization_header:
             self.headers["Authorization"] = authorization_header
@@ -50,7 +50,7 @@ def create_jwt_token(
     if expiration_date:
         final_payload["exp"] = expiration_date
 
-    return jwt.encode(payload=final_payload, key=final_key, algorithm=algorithm).decode("utf-8")
+    return jwt.encode(payload=final_payload, key=final_key, algorithm=algorithm).decode("utf-8")  # type: ignore
 
 
 class AuthenticationTestCase(TestCase):

--- a/aleph/tests/test_authentication.py
+++ b/aleph/tests/test_authentication.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+from typing import Optional, Dict, Any
+import unittest
+
+import jwt
+
+from aleph import settings
+from aleph.authz import _JtwToken, InvalidJwtToken, Authz
+
+
+_SECRET_KEY_FOR_TESTS = "test_suite_secret"
+
+
+def create_jwt_token(
+    payload: Optional[Dict[str, Any]] = None,
+    key: Optional[str] = _SECRET_KEY_FOR_TESTS,
+    algorithm: str = Authz._JWT_TOKENS_ALGORITHM,
+    expiration_date: Optional[datetime] = datetime.utcnow() + Authz._JWT_TOKENS_VALIDITY_DURATION,
+) -> str:
+    final_payload = payload.copy() if payload else {"u": 1, "r": [2, 3]}
+    if expiration_date:
+        final_payload["exp"] = expiration_date
+
+    return jwt.encode(payload=final_payload, key=key, algorithm=algorithm).decode("utf-8")
+
+
+class JwtTokenTestCase(unittest.TestCase):
+
+    _PREVIOUS_SECRET_KEY = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls._PREVIOUS_SECRET_KEY = settings.SECRET_KEY
+        # Configure the secret key for the tests
+        settings.SECRET_KEY = _SECRET_KEY_FOR_TESTS
+
+    def test_from_str(self):
+        # Given a valid token
+        token = create_jwt_token()
+
+        # When parsing the token
+        parsed_token = _JtwToken.from_str(token)
+
+        # It succeeds
+        assert parsed_token
+        assert parsed_token.u == 1
+        assert parsed_token.r == [2, 3]
+        assert parsed_token.a is False
+        assert parsed_token.b is False
+        assert parsed_token.s is None
+
+    def test_to_str(self):
+        # Given a valid token that's already parsed
+        token = create_jwt_token(
+            payload={
+                # The order here must match the order of the field in _JtwToken for this test to work
+                "u": 1,
+                "r": [2, 3],
+                "exp": 1000000000,
+                "a": False,
+                "b": True,
+            }
+        )
+        parsed_token = _JtwToken.from_str(token)
+
+        # When serializing it to a string, it succeeds and the right value is returned
+        assert token == parsed_token.to_str()
+
+    def test_from_str_none_algoritm(self):
+        # Given a token generated with the insecure "none" algorithm
+        token = create_jwt_token(key=None, algorithm="none")
+
+        # When parsing the token, it fails
+        with self.assertRaises(InvalidJwtToken):
+            _JtwToken.from_str(token)
+
+    def test_from_str_invalid_secret(self):
+        # Given a token generated with the wrong secret key
+        token = create_jwt_token(key="wrong key")
+
+        # When parsing the token, it fails
+        with self.assertRaises(InvalidJwtToken):
+            _JtwToken.from_str(token)
+
+    def test_from_str_invalid_type_in_token(self):
+        # Given a token with a field that has an invalid type
+        token = create_jwt_token(payload={"u": "not an int", "r": [2, 3]})
+
+        # When parsing the token, it fails
+        with self.assertRaises(InvalidJwtToken):
+            _JtwToken.from_str(token)
+
+    def test_from_str_missing_expiration(self):
+        # Given a token generated that's missing an expiration date
+        token = create_jwt_token(expiration_date=None)
+
+        # When parsing the token, it fails
+        with self.assertRaises(InvalidJwtToken):
+            _JtwToken.from_str(token)
+
+    @classmethod
+    def tearDownClass(cls):
+        # Put back the original secret key
+        settings.SECRET_KEY = cls._PREVIOUS_SECRET_KEY

--- a/aleph/tests/test_authentication.py
+++ b/aleph/tests/test_authentication.py
@@ -46,11 +46,11 @@ def create_jwt_token(
     else:
         final_key = key
 
-    role_id = 1
-    final_payload = payload.copy() if payload else {"u": role_id, "r": [2, 3]}
+    final_payload = payload.copy() if payload else {"u": 1, "r": [2, 3]}
     if expiration_date:
         final_payload["exp"] = expiration_date
 
+    role_id = final_payload["u"]
     final_payload["role"] = {
         "id": role_id,
         "type": "user",

--- a/aleph/tests/test_authentication.py
+++ b/aleph/tests/test_authentication.py
@@ -68,12 +68,26 @@ def create_jwt_token(
 
 
 class AuthenticationTestCase(TestCase):
-    def test_valid_jwt_token(self):
+    def test_valid_jwt_token_in_header(self):
         # Given a request with a valid JWT token passed via the Authorization header
         role = RoleFactory.create()
         db.session.commit()
         token = create_jwt_token(payload={"u": role.id, "r": []})
         request = _MockFlaskRequest(authorization_header=f"JwtToken {token}")
+
+        # When authenticating the request
+        auth_info = _authenticate_request(request)
+
+        # It succeeds and it gets authenticated as the corresponding role
+        assert auth_info.role.id == role.id
+        assert auth_info.logged_in
+
+    def test_valid_jwt_token_in_url(self):
+        # Given a request with a valid JWT token passed via the URL
+        role = RoleFactory.create()
+        db.session.commit()
+        token = create_jwt_token(payload={"u": role.id, "r": []})
+        request = _MockFlaskRequest(api_key_in_url=token)
 
         # When authenticating the request
         auth_info = _authenticate_request(request)

--- a/aleph/tests/test_authentication.py
+++ b/aleph/tests/test_authentication.py
@@ -3,17 +3,39 @@ from typing import Optional, Dict, Any
 import unittest
 
 import jwt
+from werkzeug.datastructures import TypeConversionDict
+from werkzeug.exceptions import Unauthorized
 
 from aleph import settings
 from aleph.authz import _JtwToken, InvalidJwtToken, Authz
 
+from aleph.core import db
+from aleph.tests.factories.models import RoleFactory
+from aleph.tests.util import TestCase
+from aleph.views.context import _authenticate_request
 
-_SECRET_KEY_FOR_TESTS = "test_suite_secret"
+
+class _MockFlaskRequest:
+    """Replicates the API of flask.Request needed for the tests in this file.
+    """
+
+    def __init__(
+        self, path: str = "/path", authorization_header: Optional[str] = None, api_key_in_url: Optional[str] = None
+    ) -> None:
+        self.path = path
+        self.headers = {}
+        self.args = TypeConversionDict()
+
+        if authorization_header:
+            self.headers["Authorization"] = authorization_header
+
+        if api_key_in_url:
+            self.args["api_key"] = api_key_in_url
 
 
 def create_jwt_token(
+    key: Optional[str],
     payload: Optional[Dict[str, Any]] = None,
-    key: Optional[str] = _SECRET_KEY_FOR_TESTS,
     algorithm: str = Authz._JWT_TOKENS_ALGORITHM,
     expiration_date: Optional[datetime] = datetime.utcnow() + Authz._JWT_TOKENS_VALIDITY_DURATION,
 ) -> str:
@@ -24,19 +46,124 @@ def create_jwt_token(
     return jwt.encode(payload=final_payload, key=key, algorithm=algorithm).decode("utf-8")
 
 
+class AuthenticationTestCase(TestCase):
+    def test_valid_jwt_token(self):
+        # Given a request with a valid JWT token passed via the Authorization header
+        role = RoleFactory.create()
+        db.session.commit()
+        token = create_jwt_token(key=settings.SECRET_KEY, payload={"u": role.id, "r": []})
+        request = _MockFlaskRequest(authorization_header=f"JwtToken {token}")
+
+        # When authenticating the request
+        auth_info = _authenticate_request(request)
+
+        # It succeeds and it gets authenticated as the corresponding role
+        assert auth_info.role.id == role.id
+
+    def test_invalid_jwt_token(self):
+        # Given a request with an invalid JWT token passed via the Authorization header
+        RoleFactory.create()
+        db.session.commit()
+        request = _MockFlaskRequest(authorization_header="JwtToken invalidtoken")
+
+        # When authenticating the request
+        auth_info = _authenticate_request(request)
+
+        # It gets authenticated as the unauthenticated role
+        assert auth_info.role is None
+
+    def test_valid_jwt_token_with_scope(self):
+        # Given a request with a valid JWT token passed via the Authorization header
+        role = RoleFactory.create()
+        db.session.commit()
+        token = create_jwt_token(
+            key=settings.SECRET_KEY,
+            payload={
+                "u": role.id,
+                "r": [],
+                # And the token is scoped to a specific path
+                "s": "the_path/",
+            },
+        )
+        request = _MockFlaskRequest(
+            # And the request is for the same path
+            path="the_path/",
+            authorization_header=f"JwtToken {token}",
+        )
+
+        # When authenticating the request
+        auth_info = _authenticate_request(request)
+
+        # It succeeds and it gets authenticated as the corresponding role
+        assert auth_info.role.id == role.id
+
+    def test_invalid_jwt_token_because_wrong_scope(self):
+        # Given a request with a valid JWT token passed via the Authorization header
+        role = RoleFactory.create()
+        db.session.commit()
+        token = create_jwt_token(
+            key=settings.SECRET_KEY,
+            payload={
+                "u": role.id,
+                "r": [],
+                # And the token is scoped to a specific path
+                "s": "the_path/",
+            },
+        )
+        request = _MockFlaskRequest(
+            # But the request is for a different path
+            path="different_path/",
+            authorization_header=f"JwtToken {token}",
+        )
+
+        # When authenticating the request, it fails with an Unauthorized exception
+        with self.assertRaises(Unauthorized):
+            _authenticate_request(request)
+
+    def test_valid_api_key_in_url(self):
+        # Given a request with a valid API key passed via the URL
+        role = RoleFactory.create()
+        db.session.commit()
+        request = _MockFlaskRequest(api_key_in_url=role.api_key)
+
+        # When authenticating the request
+        auth_info = _authenticate_request(request)
+
+        # It succeeds and it gets authenticated as the corresponding role
+        assert auth_info.role.id == role.id
+
+    def test_valid_api_key_in_header(self):
+        # Given a request with a valid API key passed via the Authorization header
+        role = RoleFactory.create()
+        db.session.commit()
+        request = _MockFlaskRequest(authorization_header=f"ApiKey {role.api_key}")
+
+        # When authenticating the request
+        auth_info = _authenticate_request(request)
+
+        # It succeeds and it gets authenticated as the corresponding role
+        assert auth_info.role.id == role.id
+
+    def test_invalid_api_key(self):
+        # Given a request with an invalid API key
+        role = RoleFactory.create()
+        db.session.commit()
+        request = _MockFlaskRequest(api_key_in_url="invalid value")
+
+        # When authenticating the request
+        auth_info = _authenticate_request(request)
+
+        # It gets authenticated as the unauthenticated role
+        assert auth_info.role is None
+
+
 class JwtTokenTestCase(unittest.TestCase):
 
-    _PREVIOUS_SECRET_KEY = None
-
-    @classmethod
-    def setUpClass(cls):
-        cls._PREVIOUS_SECRET_KEY = settings.SECRET_KEY
-        # Configure the secret key for the tests
-        settings.SECRET_KEY = _SECRET_KEY_FOR_TESTS
+    _SECRET_KEY = "test_suite_secret"
 
     def test_from_str(self):
         # Given a valid token
-        token = create_jwt_token()
+        token = create_jwt_token(key=self._SECRET_KEY)
 
         # When parsing the token
         parsed_token = _JtwToken.from_str(token)
@@ -52,6 +179,7 @@ class JwtTokenTestCase(unittest.TestCase):
     def test_to_str(self):
         # Given a valid token that's already parsed
         token = create_jwt_token(
+            key=self._SECRET_KEY,
             payload={
                 # The order here must match the order of the field in _JtwToken for this test to work
                 "u": 1,
@@ -59,7 +187,7 @@ class JwtTokenTestCase(unittest.TestCase):
                 "exp": 1000000000,
                 "a": False,
                 "b": True,
-            }
+            },
         )
         parsed_token = _JtwToken.from_str(token)
 
@@ -84,7 +212,7 @@ class JwtTokenTestCase(unittest.TestCase):
 
     def test_from_str_invalid_type_in_token(self):
         # Given a token with a field that has an invalid type
-        token = create_jwt_token(payload={"u": "not an int", "r": [2, 3]})
+        token = create_jwt_token(key=self._SECRET_KEY, payload={"u": "not an int", "r": [2, 3]})
 
         # When parsing the token, it fails
         with self.assertRaises(InvalidJwtToken):
@@ -92,13 +220,8 @@ class JwtTokenTestCase(unittest.TestCase):
 
     def test_from_str_missing_expiration(self):
         # Given a token generated that's missing an expiration date
-        token = create_jwt_token(expiration_date=None)
+        token = create_jwt_token(key=self._SECRET_KEY, expiration_date=None)
 
         # When parsing the token, it fails
         with self.assertRaises(InvalidJwtToken):
             _JtwToken.from_str(token)
-
-    @classmethod
-    def tearDownClass(cls):
-        # Put back the original secret key
-        settings.SECRET_KEY = cls._PREVIOUS_SECRET_KEY

--- a/aleph/tests/test_sessions_api.py
+++ b/aleph/tests/test_sessions_api.py
@@ -59,4 +59,5 @@ class SessionsApiTestCase(TestCase):
         res = self.client.post("/api/2/sessions/login", data=data)
         assert res.status_code == 200, res
         data = jwt.decode(res.json["token"], verify=False)
+        assert data["role"]["id"] == self.role.id, res
         assert data["u"] == self.role.id, res

--- a/aleph/tests/test_sessions_api.py
+++ b/aleph/tests/test_sessions_api.py
@@ -59,4 +59,4 @@ class SessionsApiTestCase(TestCase):
         res = self.client.post("/api/2/sessions/login", data=data)
         assert res.status_code == 200, res
         data = jwt.decode(res.json["token"], verify=False)
-        assert data["role"]["id"] == str(self.role.id), res
+        assert data["u"] == self.role.id, res

--- a/aleph/util.py
+++ b/aleph/util.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 import json
 import logging
+from typing import Optional
+
 from normality import stringify
 from datetime import datetime, date
 from flask_babel.speaklater import LazyString
@@ -10,10 +12,8 @@ from collections import abc
 log = logging.getLogger(__name__)
 
 
-def anonymize_email(name, email):
+def anonymize_email(name: str, email: Optional[str]) -> str:
     """Generate a simple label with both the name and email of a user."""
-    name = stringify(name)
-    email = stringify(email)
     if email is None:
         return name
     if "@" in email:

--- a/aleph/validation/spec.py
+++ b/aleph/validation/spec.py
@@ -35,12 +35,12 @@ header:
 
 ```Authorization: ApiKey 363af1e2b03b41c6b3adc604956e2f66```
 
-Alternatively, the API key can also be sent as a query parameter under the
-`api_key` key.
-
 Similarly, a JWT can be sent in the Authorization header, after it has been
 returned by the login and/or OAuth processes. Aleph does not use session
 cookies or any other type of stateful API.
+
+Alternatively, an API key or JWT token can also be sent as a query parameter
+under the `api_key` key.
 """
 
 spec_info = {

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -65,7 +65,7 @@ def _metadata_locale(locale):
     if settings.SINGLE_USER:
         role = Role.load_cli_user()
         authz = Authz.from_role(role)
-        data["token"] = authz.to_token(role=role)
+        data["token"] = authz.to_token()
     return jsonify(data)
 
 

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -11,7 +11,7 @@ from jwt import ExpiredSignatureError, DecodeError
 
 from aleph import __version__
 from aleph.core import settings, url_for
-from aleph.authz import Authz
+from aleph.authz import Authz, ActionEnum
 from aleph.model import Collection, Role
 from aleph.logic import resolver
 from aleph.logic.pages import load_pages
@@ -125,7 +125,7 @@ def statistics():
       - System
     """
     enable_cache()
-    collections = request.authz.collections(request.authz.READ)
+    collections = request.authz.collections(ActionEnum.READ)
     for collection_id in collections:
         resolver.queue(request, Collection, collection_id)
     resolver.resolve(request)

--- a/aleph/views/collections_api.py
+++ b/aleph/views/collections_api.py
@@ -2,7 +2,7 @@ from banal import ensure_list
 from flask import Blueprint, request
 
 from aleph.core import db, settings
-from aleph.authz import Authz
+from aleph.authz import Authz, ActionEnum
 from aleph.model import Collection
 from aleph.search import CollectionsQuery
 from aleph.queues import queue_task, get_status, cancel_queue
@@ -349,7 +349,7 @@ def status(collection_id):
       tags:
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.READ)
+    collection = get_db_collection(collection_id, ActionEnum.READ)
     request.rate_limit = None
     return jsonify(get_status(collection))
 

--- a/aleph/views/collections_api.py
+++ b/aleph/views/collections_api.py
@@ -183,7 +183,7 @@ def update(collection_id):
               schema:
                 $ref: '#/components/schemas/Collection'
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     data = parse_request("CollectionUpdate")
     sync = get_flag("sync")
     collection.update(data, request.authz)
@@ -222,7 +222,7 @@ def reingest(collection_id):
       tags:
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     job_id = get_session_id()
     data = {"index": get_flag("index", False)}
     queue_task(collection, OP_REINGEST, job_id=job_id, payload=data)
@@ -258,7 +258,7 @@ def reindex(collection_id):
       tags:
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     job_id = get_session_id()
     data = {"flush": get_flag("flush", False)}
     queue_task(collection, OP_REINDEX, job_id=job_id, payload=data)
@@ -303,7 +303,7 @@ def bulk(collection_id):
       tags:
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     require(request.authz.can_bulk_import())
     entities = ensure_list(request.get_json(force=True))
 
@@ -382,7 +382,7 @@ def cancel(collection_id):
       tags:
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     cancel_queue(collection)
     refresh_collection(collection_id)
     return ("", 204)
@@ -419,7 +419,7 @@ def delete(collection_id):
       tags:
         - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     keep_metadata = get_flag("keep_metadata", default=False)
     sync = get_flag("sync", default=True)
     delete_collection(collection, keep_metadata=keep_metadata, sync=sync)

--- a/aleph/views/context.py
+++ b/aleph/views/context.py
@@ -97,15 +97,15 @@ def _authenticate_request(request: flask.Request) -> Authz:
         else:
             received_auth_string = authorization_header
 
-        # Is it a JWT token?
+        # Is it an API key?
         try:
-            auth_info = _authenticate_via_jwt_token(received_auth_string, request.path)
-        except InvalidJwtToken:
-            # It's not - is it an API key then?
+            auth_info = _authenticate_via_api_key(received_auth_string)
+        except InvalidApiKey:
+            # It's not - is it a JWT token then?
             try:
-                auth_info = _authenticate_via_api_key(received_auth_string)
-            except InvalidApiKey:
-                # It's not a valid API key either; log the incident
+                auth_info = _authenticate_via_jwt_token(received_auth_string, request.path)
+            except InvalidJwtToken :
+                # It's not a valid JWT token either; log the incident
                 log.warning(
                     f'Received an invalid Auth header "{received_auth_string}" to access {request.path}'
                     f" from {_get_remote_ip()}"

--- a/aleph/views/context.py
+++ b/aleph/views/context.py
@@ -122,7 +122,7 @@ def _authenticate_request(request: flask.Request) -> Authz:
         except InvalidApiKey:
             # It's not a valid API key; log the incident
             log.warning(
-                f'Received an invalid API Key param "{api_key_in_url}\ to access {request.path}'
+                f'Received an invalid API Key param \"{api_key_in_url}\" to access {request.path}'
                 f" from {_get_remote_ip()}"
             )
             auth_info = Authz.from_role(role=None)

--- a/aleph/views/entities_api.py
+++ b/aleph/views/entities_api.py
@@ -5,6 +5,7 @@ from flask import Blueprint, request, Response
 from werkzeug.exceptions import NotFound
 from followthemoney import model
 
+from aleph.authz import ActionEnum
 from aleph.core import db, url_for
 from aleph.model import QueryLog
 from aleph.search import EntitiesQuery, MatchQuery
@@ -251,7 +252,7 @@ def create():
     entity_id = upsert_entity(data, collection, authz=request.authz, sync=True)
     db.session.commit()
     tag_request(entity_id=entity_id, collection_id=collection.id)
-    entity = get_index_entity(entity_id, request.authz.READ)
+    entity = get_index_entity(entity_id, ActionEnum.READ)
     return EntitySerializer.jsonify(entity)
 
 
@@ -281,7 +282,7 @@ def view(entity_id):
     """
     enable_cache()
     excludes = ["text", "numeric.*"]
-    entity = get_index_entity(entity_id, request.authz.READ, excludes=excludes)
+    entity = get_index_entity(entity_id, ActionEnum.READ, excludes=excludes)
     tag_request(collection_id=entity.get("collection_id"))
     proxy = model.get_proxy(entity)
     html = proxy.first("bodyHtml", quiet=True)
@@ -329,7 +330,7 @@ def similar(entity_id):
       - Entity
     """
     enable_cache()
-    entity = get_index_entity(entity_id, request.authz.READ)
+    entity = get_index_entity(entity_id, ActionEnum.READ)
     tag_request(collection_id=entity.get("collection_id"))
     entity = model.get_proxy(entity)
     result = MatchQuery.handle(request, entity=entity)
@@ -369,7 +370,7 @@ def references(entity_id):
       - Entity
     """
     enable_cache()
-    entity = get_index_entity(entity_id, request.authz.READ)
+    entity = get_index_entity(entity_id, ActionEnum.READ)
     tag_request(collection_id=entity.get("collection_id"))
     results = []
     for prop, total in entity_references(entity, request.authz):
@@ -410,7 +411,7 @@ def tags(entity_id):
       - Entity
     """
     enable_cache()
-    entity = get_index_entity(entity_id, request.authz.READ)
+    entity = get_index_entity(entity_id, ActionEnum.READ)
     tag_request(collection_id=entity.get("collection_id"))
     results = []
     for (field, value, total) in entity_tags(entity, request.authz):
@@ -547,7 +548,7 @@ def expand(entity_id):
       tags:
       - Entity
     """
-    entity = get_index_entity(entity_id, request.authz.READ)
+    entity = get_index_entity(entity_id, ActionEnum.READ)
     edge_types = request.args.getlist("edge_types")
     collection_id = entity.get("collection_id")
     tag_request(collection_id=collection_id)

--- a/aleph/views/entities_api.py
+++ b/aleph/views/entities_api.py
@@ -245,7 +245,7 @@ def create():
         - Entity
     """
     data = parse_request("EntityCreate")
-    collection = get_nested_collection(data, request.authz.WRITE)
+    collection = get_nested_collection(data, ActionEnum.WRITE)
     data.pop("id", None)
     if get_flag("validate", default=False):
         validate_entity(data)
@@ -457,11 +457,11 @@ def update(entity_id):
     """
     data = parse_request("EntityUpdate")
     try:
-        entity = get_index_entity(entity_id, request.authz.WRITE)
+        entity = get_index_entity(entity_id, ActionEnum.WRITE)
         require(check_write_entity(entity, request.authz))
-        collection = get_db_collection(entity.get("collection_id"), request.authz.WRITE)
+        collection = get_db_collection(entity.get("collection_id"), ActionEnum.WRITE)
     except NotFound:
-        collection = get_nested_collection(data, request.authz.WRITE)
+        collection = get_nested_collection(data, ActionEnum.WRITE)
     tag_request(collection_id=collection.id)
     data["id"] = entity_id
     if get_flag("validate", default=False):
@@ -491,8 +491,8 @@ def delete(entity_id):
       tags:
       - Entity
     """
-    entity = get_index_entity(entity_id, request.authz.WRITE)
-    collection = get_db_collection(entity.get("collection_id"), request.authz.WRITE)
+    entity = get_index_entity(entity_id, ActionEnum.WRITE)
+    collection = get_db_collection(entity.get("collection_id"), ActionEnum.WRITE)
     tag_request(collection_id=collection.id)
     sync = get_flag("sync", default=True)
     delete_entity(collection, entity, sync=sync)

--- a/aleph/views/entitysets_api.py
+++ b/aleph/views/entitysets_api.py
@@ -95,7 +95,7 @@ def create():
       - EntitySet
     """
     data = parse_request("EntitySetCreate")
-    collection = get_nested_collection(data, request.authz.WRITE)
+    collection = get_nested_collection(data, ActionEnum.WRITE)
     entityset = create_entityset(collection, data, request.authz)
     db.session.commit()
     return EntitySetSerializer.jsonify(entityset)
@@ -158,7 +158,7 @@ def update(entityset_id):
       tags:
       - EntitySet
     """
-    entityset = get_entityset(entityset_id, request.authz.WRITE)
+    entityset = get_entityset(entityset_id, ActionEnum.WRITE)
     data = parse_request("EntitySetUpdate")
     entityset.update(data)
     db.session.commit()
@@ -185,7 +185,7 @@ def delete(entityset_id):
       tags:
       - EntitySet
     """
-    entityset = get_entityset(entityset_id, request.authz.WRITE)
+    entityset = get_entityset(entityset_id, ActionEnum.WRITE)
     entityset.delete()
     db.session.commit()
     return ("", 204)
@@ -263,7 +263,7 @@ def entities_update(entityset_id):
       tags:
       - Entity
     """
-    entityset = get_entityset(entityset_id, request.authz.WRITE)
+    entityset = get_entityset(entityset_id, ActionEnum.WRITE)
     data = parse_request("EntityUpdate")
     entity_id = data.get("id", make_textid())
     try:
@@ -351,7 +351,7 @@ def item_update(entityset_id):
       tags:
       - EntitySetItem
     """
-    entityset = get_entityset(entityset_id, request.authz.WRITE)
+    entityset = get_entityset(entityset_id, ActionEnum.WRITE)
     data = parse_request("EntitySetItemUpdate")
     entity = data.pop("entity", {})
     entity_id = data.pop("entity_id", entity.get("id"))

--- a/aleph/views/ingest_api.py
+++ b/aleph/views/ingest_api.py
@@ -8,6 +8,7 @@ from werkzeug.exceptions import BadRequest
 from normality import safe_filename, stringify
 from servicelayer.archive.util import ensure_path
 
+from aleph.authz import ActionEnum
 from aleph.core import db, archive
 from aleph.model import Document, Entity, Events
 from aleph.queues import ingest_entity

--- a/aleph/views/ingest_api.py
+++ b/aleph/views/ingest_api.py
@@ -118,7 +118,7 @@ def ingest_upload(collection_id):
       - Ingest
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     job_id = get_session_id()
     sync = get_flag("sync", default=False)
     index = get_flag("index", default=True)

--- a/aleph/views/mappings_api.py
+++ b/aleph/views/mappings_api.py
@@ -110,7 +110,7 @@ def create(collection_id):
       - Collection
       - Mapping
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     data = parse_request("MappingCreate")
     entity_id = data.get("table_id")
     query = load_query()
@@ -158,7 +158,7 @@ def view(collection_id, mapping_id):
       - Collection
       - Mapping
     """
-    get_db_collection(collection_id, request.authz.WRITE)
+    get_db_collection(collection_id, ActionEnum.WRITE)
     mapping = obj_or_404(Mapping.by_id(mapping_id))
     return MappingSerializer.jsonify(mapping)
 
@@ -205,7 +205,7 @@ def update(collection_id, mapping_id):
       - Collection
       - Mapping
     """
-    get_db_collection(collection_id, request.authz.WRITE)
+    get_db_collection(collection_id, ActionEnum.WRITE)
     mapping = obj_or_404(Mapping.by_id(mapping_id))
     data = parse_request("MappingCreate")
     entity_id = data.get("table_id")
@@ -249,7 +249,7 @@ def delete(collection_id, mapping_id):
       - Collection
       - Mapping
     """
-    get_db_collection(collection_id, request.authz.WRITE)
+    get_db_collection(collection_id, ActionEnum.WRITE)
     mapping = obj_or_404(Mapping.by_id(mapping_id))
     mapping.delete()
     db.session.commit()
@@ -290,7 +290,7 @@ def trigger(collection_id, mapping_id):
       - Collection
       - Mapping
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     mapping = obj_or_404(Mapping.by_id(mapping_id))
     mapping.disabled = False
     mapping.set_status(Mapping.PENDING)
@@ -333,7 +333,7 @@ def flush(collection_id, mapping_id):
       - Collection
       - Mapping
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     mapping = obj_or_404(Mapping.by_id(mapping_id))
     mapping.disabled = True
     mapping.last_run_status = None

--- a/aleph/views/mappings_api.py
+++ b/aleph/views/mappings_api.py
@@ -4,6 +4,7 @@ from followthemoney import model
 from flask import Blueprint, request
 from werkzeug.exceptions import BadRequest
 
+from aleph.authz import ActionEnum
 from aleph.core import db
 from aleph.model import Mapping
 from aleph.search import QueryParser, DatabaseQueryResult
@@ -113,7 +114,7 @@ def create(collection_id):
     data = parse_request("MappingCreate")
     entity_id = data.get("table_id")
     query = load_query()
-    entity = get_index_entity(entity_id, request.authz.READ)
+    entity = get_index_entity(entity_id, ActionEnum.READ)
     mapping = Mapping.create(
         query, entity.get("id"), collection, request.authz.id
     )  # noqa
@@ -209,7 +210,7 @@ def update(collection_id, mapping_id):
     data = parse_request("MappingCreate")
     entity_id = data.get("table_id")
     query = load_query()
-    entity = get_index_entity(entity_id, request.authz.READ)
+    entity = get_index_entity(entity_id, ActionEnum.READ)
     mapping.update(query=query, table_id=entity.get("id"))
     db.session.commit()
     return MappingSerializer.jsonify(mapping)

--- a/aleph/views/permissions_api.py
+++ b/aleph/views/permissions_api.py
@@ -1,6 +1,7 @@
 from banal import ensure_dict
 from flask import Blueprint, request
 
+from aleph.authz import ActionEnum
 from aleph.model import Role, Permission
 from aleph.logic.roles import check_visible
 from aleph.logic.permissions import update_permission

--- a/aleph/views/permissions_api.py
+++ b/aleph/views/permissions_api.py
@@ -44,7 +44,7 @@ def index(collection_id):
       - Permission
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     roles = Role.all_groups(request.authz).all()
     if request.authz.is_admin:
         roles.extend(Role.all_system())
@@ -116,7 +116,7 @@ def update(collection_id):
       - Permission
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     for permission in parse_request("PermissionUpdateList"):
         role_obj = ensure_dict(permission.get("role"))
         role_id = permission.get("role_id", role_obj.get("id"))

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -113,7 +113,7 @@ class Serializer(object):
 class RoleSerializer(Serializer):
     def _serialize(self, obj):
         obj["links"] = {"self": url_for("roles_api.view", id=obj.get("id"))}
-        obj["writeable"] = request.authz.can_write_role(obj.get("id"))
+        obj["writeable"] = request.authz.can_write_role(int(obj.get("id")))
         if not obj["writeable"]:
             obj.pop("has_password", None)
             obj.pop("is_muted", None)
@@ -135,7 +135,7 @@ class AlertSerializer(Serializer):
     def _serialize(self, obj):
         obj["links"] = {"self": url_for("alerts_api.view", alert_id=obj.get("id"))}
         role_id = obj.pop("role_id", None)
-        obj["writeable"] = request.authz.can_write_role(role_id)
+        obj["writeable"] = request.authz.can_write_role(int(role_id))
         return obj
 
 
@@ -143,7 +143,7 @@ class CollectionSerializer(Serializer):
     def _collect(self, obj):
         self.queue(Role, obj.get("creator_id"))
         for role_id in ensure_list(obj.get("team_id")):
-            if request.authz.can_read_role(role_id):
+            if request.authz.can_read_role(int(role_id)):
                 self.queue(Role, role_id)
 
     def _serialize(self, obj):
@@ -167,7 +167,7 @@ class CollectionSerializer(Serializer):
         obj["creator"] = self.resolve(Role, creator_id, RoleSerializer)
         obj["team"] = []
         for role_id in ensure_list(obj.pop("team_id", [])):
-            if request.authz.can_read_role(role_id):
+            if request.authz.can_read_role(int(role_id)):
                 role = self.resolve(Role, role_id, RoleSerializer)
                 obj["team"].append(role)
         return obj
@@ -180,7 +180,7 @@ class PermissionSerializer(Serializer):
     def _serialize(self, obj):
         obj.pop("collection_id", None)
         role_id = obj.pop("role_id", None)
-        obj["writeable"] = request.authz.can_read_role(role_id)  # wat
+        obj["writeable"] = request.authz.can_read_role(int(role_id))  # wat
         obj["role"] = self.resolve(Role, role_id, RoleSerializer)
         return obj
 

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -114,7 +114,7 @@ class Serializer(object):
 class RoleSerializer(Serializer):
     def _serialize(self, obj):
         obj["links"] = {"self": url_for("roles_api.view", id=obj.get("id"))}
-        obj["writeable"] = request.authz.can_write_role(int(obj.get("id")))
+        obj["writeable"] = request.authz.can_write_role(obj.get("id"))
         if not obj["writeable"]:
             obj.pop("has_password", None)
             obj.pop("is_muted", None)
@@ -136,7 +136,7 @@ class AlertSerializer(Serializer):
     def _serialize(self, obj):
         obj["links"] = {"self": url_for("alerts_api.view", alert_id=obj.get("id"))}
         role_id = obj.pop("role_id", None)
-        obj["writeable"] = request.authz.can_write_role(int(role_id))
+        obj["writeable"] = request.authz.can_write_role(role_id)
         return obj
 
 
@@ -144,7 +144,7 @@ class CollectionSerializer(Serializer):
     def _collect(self, obj):
         self.queue(Role, obj.get("creator_id"))
         for role_id in ensure_list(obj.get("team_id")):
-            if request.authz.can_read_role(int(role_id)):
+            if request.authz.can_read_role(role_id):
                 self.queue(Role, role_id)
 
     def _serialize(self, obj):
@@ -168,7 +168,7 @@ class CollectionSerializer(Serializer):
         obj["creator"] = self.resolve(Role, creator_id, RoleSerializer)
         obj["team"] = []
         for role_id in ensure_list(obj.pop("team_id", [])):
-            if request.authz.can_read_role(int(role_id)):
+            if request.authz.can_read_role(role_id):
                 role = self.resolve(Role, role_id, RoleSerializer)
                 obj["team"].append(role)
         return obj
@@ -181,7 +181,7 @@ class PermissionSerializer(Serializer):
     def _serialize(self, obj):
         obj.pop("collection_id", None)
         role_id = obj.pop("role_id", None)
-        obj["writeable"] = request.authz.can_read_role(int(role_id))  # wat
+        obj["writeable"] = request.authz.can_read_role(role_id)  # wat
         obj["role"] = self.resolve(Role, role_id, RoleSerializer)
         return obj
 

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -7,6 +7,7 @@ from followthemoney import model
 from followthemoney.types import registry
 from followthemoney.helpers import entity_filename
 
+from aleph.authz import ActionEnum
 from aleph.core import url_for
 from aleph.model import Role, Collection, Document, Entity, Events
 from aleph.model import Alert, EntitySet, EntitySetItem
@@ -162,7 +163,7 @@ class CollectionSerializer(Serializer):
             "ui": collection_url(pk),
         }
         obj["shallow"] = obj.get("shallow", True)
-        obj["writeable"] = request.authz.can(pk, request.authz.WRITE)
+        obj["writeable"] = request.authz.can(pk, ActionEnum.WRITE)
         creator_id = obj.pop("creator_id", None)
         obj["creator"] = self.resolve(Role, creator_id, RoleSerializer)
         obj["team"] = []
@@ -272,7 +273,7 @@ class XrefSerializer(Serializer):
             obj["decision"] = None
 
         collection_id = obj.get("collection_id")
-        obj["writeable"] = request.authz.can(collection_id, request.authz.WRITE)
+        obj["writeable"] = request.authz.can(collection_id, ActionEnum.WRITE)
 
         if obj["entity"] and obj["match"]:
             return obj
@@ -292,7 +293,7 @@ class EntitySetSerializer(Serializer):
         collection_id = obj.pop("collection_id", None)
         entity_ids = obj.pop("entities", [])
         obj["shallow"] = False
-        obj["writeable"] = request.authz.can(collection_id, request.authz.WRITE)
+        obj["writeable"] = request.authz.can(collection_id, ActionEnum.WRITE)
         obj["collection"] = self.resolve(
             Collection, collection_id, CollectionSerializer
         )
@@ -316,7 +317,7 @@ class EntitySetItemSerializer(Serializer):
         obj["collection"] = self.resolve(
             Collection, collection_id, CollectionSerializer
         )
-        obj["writeable"] = request.authz.can(collection_id, request.authz.WRITE)
+        obj["writeable"] = request.authz.can(collection_id, ActionEnum.WRITE)
         return obj
 
 
@@ -329,7 +330,7 @@ class EntitySetIndexSerializer(Serializer):
         obj.update(
             {
                 "shallow": True,
-                "writeable": request.authz.can(collection_id, request.authz.WRITE),
+                "writeable": request.authz.can(collection_id, ActionEnum.WRITE),
                 "collection": self.resolve(
                     Collection, collection_id, CollectionSerializer
                 ),

--- a/aleph/views/sessions_api.py
+++ b/aleph/views/sessions_api.py
@@ -104,7 +104,6 @@ def oauth_callback():
     log.info("Logged in: %r", role)
     request.authz = Authz.from_role(role)
     token = request.authz.to_token()
-    token = token.decode("utf-8")
     next_path = get_url_path(request.args.get("state"))
     next_url = ui_url(settings.OAUTH_UI_CALLBACK, next=next_path)
     next_url = "%s#token=%s" % (next_url, token)

--- a/aleph/views/sessions_api.py
+++ b/aleph/views/sessions_api.py
@@ -59,7 +59,7 @@ def password_login():
     update_role(role)
     authz = Authz.from_role(role)
     request.authz = authz
-    return jsonify({"status": "ok", "token": authz.to_token(role=role)})
+    return jsonify({"status": "ok", "token": authz.to_token()})
 
 
 @blueprint.route("/api/2/sessions/oauth")
@@ -103,7 +103,7 @@ def oauth_callback():
     update_role(role)
     log.info("Logged in: %r", role)
     request.authz = Authz.from_role(role)
-    token = request.authz.to_token(role=role)
+    token = request.authz.to_token()
     token = token.decode("utf-8")
     next_path = get_url_path(request.args.get("state"))
     next_url = ui_url(settings.OAUTH_UI_CALLBACK, next=next_path)

--- a/aleph/views/status_api.py
+++ b/aleph/views/status_api.py
@@ -1,6 +1,7 @@
 import logging
 from flask import Blueprint, request
 
+from aleph.authz import ActionEnum
 from aleph.model import Collection
 from aleph.queues import get_active_collection_status
 from aleph.views.serializers import CollectionSerializer
@@ -33,7 +34,7 @@ def status():
     status = get_active_collection_status()
     active_collections = status.pop("datasets", [])
     active_foreign_ids = set(active_collections.keys())
-    collections = request.authz.collections(request.authz.READ)
+    collections = request.authz.collections(ActionEnum.READ)
     serializer = CollectionSerializer(reference=True)
     results = []
     for fid in sorted(active_foreign_ids):

--- a/aleph/views/stream_api.py
+++ b/aleph/views/stream_api.py
@@ -2,6 +2,7 @@ import logging
 from banal import ensure_list
 from flask import Blueprint, request
 
+from aleph.authz import ActionEnum
 from aleph.index.entities import iter_entities, PROXY_INCLUDES
 from aleph.views.util import get_db_collection
 from aleph.views.util import require, stream_ijson
@@ -46,7 +47,7 @@ def entities(collection_id=None):
     includes = ensure_list(request.args.getlist("include"))
     includes = includes or PROXY_INCLUDES
     if collection_id is not None:
-        get_db_collection(collection_id, request.authz.READ)
+        get_db_collection(collection_id, ActionEnum.READ)
     entities = iter_entities(
         authz=request.authz,
         collection_id=collection_id,

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -10,7 +10,7 @@ from werkzeug.exceptions import Forbidden
 from werkzeug.exceptions import BadRequest, NotFound
 from servicelayer.jobs import Job
 
-from aleph.authz import Authz
+from aleph.authz import Authz, ActionEnum
 from aleph.model import Collection, EntitySet
 from aleph.validation import get_validator
 from aleph.index.entities import get_entity as _get_index_entity
@@ -77,33 +77,33 @@ def validate(data, schema):
     raise BadRequest(response=resp)
 
 
-def get_index_entity(entity_id, action=Authz.READ, **kwargs):
+def get_index_entity(entity_id, action: ActionEnum = ActionEnum.READ, **kwargs):
     entity = obj_or_404(_get_index_entity(entity_id, **kwargs))
-    require(request.authz.can(entity["collection_id"], action))
+    require(request.authz.can(entity["collection_id"], action))  # type: ignore
     return entity
 
 
-def get_db_collection(collection_id, action=Authz.READ):
+def get_db_collection(collection_id, action: ActionEnum = ActionEnum.READ):
     collection = obj_or_404(Collection.by_id(collection_id))
-    require(request.authz.can(collection.id, action))
+    require(request.authz.can(collection.id, action))  # type: ignore
     return collection
 
 
-def get_entityset(entityset_id, action=Authz.READ):
+def get_entityset(entityset_id, action: ActionEnum = ActionEnum.READ):
     eset = obj_or_404(EntitySet.by_id(entityset_id))
-    require(request.authz.can(eset.collection_id, action))
+    require(request.authz.can(eset.collection_id, action))  # type: ignore
     return eset
 
 
-def get_nested_collection(data, action=Authz.READ):
+def get_nested_collection(data, action: ActionEnum = ActionEnum.READ):
     collection = ensure_dict(data.get("collection"))
     collection_id = data.get("collection_id", collection.get("id"))
     return get_db_collection(collection_id, action)
 
 
-def get_index_collection(collection_id, action=Authz.READ):
+def get_index_collection(collection_id, action: ActionEnum =ActionEnum.READ):
     collection = obj_or_404(_get_index_collection(collection_id))
-    require(request.authz.can(collection["id"], action))
+    require(request.authz.can(collection["id"], action))  # type: ignore
     return collection
 
 

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -89,7 +89,7 @@ def get_db_collection(collection_id, action: ActionEnum = ActionEnum.READ):
     return collection
 
 
-def get_entityset(entityset_id, action: ActionEnum = ActionEnum.READ):
+def get_entityset(entityset_id, action: ActionEnum = ActionEnum.READ) -> EntitySet:
     eset = obj_or_404(EntitySet.by_id(entityset_id))
     require(request.authz.can(eset.collection_id, action))  # type: ignore
     return eset

--- a/aleph/views/xref_api.py
+++ b/aleph/views/xref_api.py
@@ -4,6 +4,7 @@ from followthemoney import model
 from followthemoney.exc import InvalidData
 from werkzeug.exceptions import BadRequest
 
+from aleph.authz import ActionEnum
 from aleph.search import XrefQuery
 from aleph.index.xref import get_xref
 from aleph.logic.xref import export_matches
@@ -53,7 +54,7 @@ def index(collection_id):
     """
     get_index_collection(collection_id)
     result = XrefQuery.handle(request, collection_id=collection_id)
-    require(request.authz.can(collection_id, request.authz.READ))
+    require(request.authz.can(collection_id, ActionEnum.READ))
     pairs = []
     for xref in result.results:
         pairs.append((xref.get("entity_id"), xref.get("match_id")))
@@ -124,7 +125,7 @@ def export(collection_id):
       - Xref
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.READ)
+    collection = get_db_collection(collection_id, ActionEnum.READ)
     buffer = export_matches(collection, request.authz)
     file_name = "%s - Crossreference.xlsx" % collection.label
     return send_file(

--- a/aleph/views/xref_api.py
+++ b/aleph/views/xref_api.py
@@ -96,7 +96,7 @@ def generate(collection_id):
       - Xref
       - Collection
     """
-    collection = get_db_collection(collection_id, request.authz.WRITE)
+    collection = get_db_collection(collection_id, ActionEnum.WRITE)
     queue_task(collection, OP_XREF)
     return jsonify({"status": "accepted"}, status=202)
 
@@ -179,7 +179,7 @@ def decide(collection_id, xref_id):
     """
     data = parse_request("XrefDecide")
     xref = obj_or_404(get_xref(xref_id, collection_id=collection_id))
-    require(request.authz.can(collection_id, request.authz.WRITE))
+    require(request.authz.can(collection_id, ActionEnum.WRITE))
 
     entity = get_index_entity(xref.get("entity_id"))
     match = get_index_entity(xref.get("match_id"))

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -3,4 +3,5 @@
 psql -c "DROP DATABASE IF EXISTS aleph_test;" $ALEPH_DATABASE_URI
 psql -c "CREATE DATABASE aleph_test;" $ALEPH_DATABASE_URI
 
+mypy --ignore-missing-imports --no-implicit-optional ./aleph
 nosetests --with-coverage --cover-package=aleph --cover-erase

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,6 +39,7 @@ networkx==2.4
 zipstream==1.1.4
 tabulate==0.8.7
 pydantic==1.6.1
+lxml
 
 # Testing dependencies
 factory-boy==2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,7 @@ urllib3==1.25.10
 networkx==2.4
 zipstream==1.1.4
 tabulate==0.8.7
+pydantic==1.6.1
 
 # Testing dependencies
 factory-boy==2.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ Faker==4.1.1
 nose
 coverage
 coveralls
+mypy
 
 # Tracing and logging libraries
 python-json-logger==0.1.11


### PR DESCRIPTION
Hello, this PR:

* Adds type annotations to the authentication logic.
  * This allows for gradually adding more type annotations in the rest of the code.
  * This allows finding typing bugs in any code that interacts with the authentication logic right now.
* Enables mypy in `test` step/script of the Makefile so it gets run in CI/CD.
* Adds a test suite dedicated to the authentication logic.
* Refactors some of the tricky parts of the authentication logic.

My main goal was to just add type annotations to authz.py, but I stumbled upon a few security gaps and ended up refactoring some of the code:

* Never-expiring JWT tokens (ie. no exp field) are allowed by the backend code. I didn't find an obvious way to create such tokens (besides manually with the secret key) but it seemed like there is no use case for this. This PR makes the exp field required on incoming tokens (as they are used like session tokens).
* The backend logic does not specify which algorithm to use when validating an incoming JWT token, so an attacker could craft a JWT token that uses the `none` algorithm (ie. no secret key). At this point I thought I was going to compromise the app, but the JWT library does throw an exception if the algorithm in the token is `none` while a key was supplied by the backend code; neat. Regardless, this PR explicitly specifies the algorithm to be used for JWT tokens (`H256`).
* An aleph JWT token has a field "a" that is a bool that determines whether the "role" associated with the token is an admin. This setting retrieved from the token takes precedence over the is_admin field in the DB, which, I think, is unexpected/surprising. As far as I know, this means that you can craft a token that can turn any non-admin role into an admin. I haven't changed this behavior but I think this is dangerous and should be removed, so that only the is_admin field in the DB determines whether a role is an admin or not.
  * There is the same behavior with the "b" field in the tokens, which takes precedence over is_blocked, but it doesn't seem as dangerous.
* When parsing an Authorization header from an incoming request, the backend has to "guess" what the data is: an API key or a JWT token. That kind of "ambiguity" can sometimes lead to security bugs and I think it would be useful to require a "hint" in the Authorization header, for example `ApiKey <the api key>` VS `JwtToken <the token>`. In the current behavior there is no strict rule. Adding one would be an API-breaking change so I didn't do it.  
  * It also was possible to pass a JWT token via the `api_key` URL/GET parameter; this PR removes this behavior as it seems like it wasn't expected (based on the documentation at https://github.com/alephdata/aleph/blob/main/aleph/validation/spec.py ).

Some additional comments: 

* This adds mypy, lxml, pydantic as dependencies.
  * If we don't pydantic I can rewrite the code to not use it, but pydantic is a very useful library for parsing arbitrary data and could simplify code in other locations.
  * lxml was already needed to run aleph but it was missing from the requirements file.
* One thing I did (but out of scope for this PR) is to rewrite the Makefile into Python invoke tasks (it looks like this: https://gist.github.com/nabla-c0d3/1606993b9ea4a0b97a3b02eaf05f41ba) so I could run them on Windows (where `make` is not available). If it's something you'd like to see in the project I can make a PR for it, but my guess is that keeping the Makefile is fine.