### PR TITLE
Upload: Larger Dropzone

### DIFF
--- a/ui/src/components/Document/DocumentDropzone.jsx
+++ b/ui/src/components/Document/DocumentDropzone.jsx
@@ -46,7 +46,7 @@ class DocumentDropzone extends Component {
           )}
         >
           {({ getRootProps, getInputProps, isDragActive }) => (
-            <div {...getRootProps()}>
+            <div {...getRootProps()} className={'DocumentDropzone'}>
               <input
                 {...getInputProps()}
                 onClick={e => { e.preventDefault(); e.stopPropagation(); }}

--- a/ui/src/components/Document/DocumentDropzone.scss
+++ b/ui/src/components/Document/DocumentDropzone.scss
@@ -2,7 +2,9 @@
 @import "app/mixins.scss";
 
 .DocumentDropzone {
+  flex-grow: 1;
   &__content {
+    min-height: 100%;
     &.active {
       position: relative;
       &:after {

--- a/ui/src/components/Screen/Screen.scss
+++ b/ui/src/components/Screen/Screen.scss
@@ -8,7 +8,7 @@
 
   .main-homepage {
     flex-grow: 1;
-    display:block;
+    display: flex;
     flex-flow: column nowrap;
     // background-color: $aleph-content-background;
     align-items: stretch;


### PR DESCRIPTION
upload: dropzone now covers the whole screen, only excluding navbar and breadcrumb

changes `<main>` css display property from `block` to `flex`!

before:
![Screenshot 2020-09-08 at 12 09 48](https://user-images.githubusercontent.com/1635212/92463551-431fc780-f1cc-11ea-830c-329fed7a9ed0.png)

after:
![Screenshot 2020-09-08 at 12 09 14](https://user-images.githubusercontent.com/1635212/92463580-4915a880-f1cc-11ea-96fd-6a944a5d21e0.png)
