### PR TITLE
Notifications list event filter

### DIFF
--- a/ui/src/components/Notification/NotificationList.jsx
+++ b/ui/src/components/Notification/NotificationList.jsx
@@ -8,6 +8,7 @@ import { ErrorSection } from 'components/common';
 import { queryNotifications } from 'actions';
 import { selectNotificationsResult } from 'selectors';
 import Notification from 'components/Notification/Notification';
+import NotificationListFilter from 'components/Notification/NotificationListFilter';
 
 import './NotificationList.scss';
 
@@ -23,6 +24,7 @@ class NotificationList extends Component {
   constructor(props) {
     super(props);
     this.getMoreResults = this.getMoreResults.bind(this);
+    this.updateQuery = this.updateQuery.bind(this);
   }
 
   componentDidMount() {
@@ -40,6 +42,15 @@ class NotificationList extends Component {
     }
   }
 
+  updateQuery(newQuery) {
+    const { history, location } = this.props;
+
+    history.push({
+      pathname: location.pathname,
+      search: newQuery.toLocation(),
+    });
+  }
+
   fetchIfNeeded() {
     const { result, query } = this.props;
     if (result.shouldLoad) {
@@ -48,7 +59,7 @@ class NotificationList extends Component {
   }
 
   render() {
-    const { result, intl } = this.props;
+    const { query, result, intl } = this.props;
     const skeletonItems = [...Array(15).keys()];
 
     if (result.total === 0) {
@@ -62,6 +73,7 @@ class NotificationList extends Component {
 
     return (
       <>
+        <NotificationListFilter query={query} updateQuery={this.updateQuery} result={result} />
         <ul className="NotificationList">
           {result.results && result.results.map(
             notif => <Notification key={notif.id} notification={notif} />,

--- a/ui/src/components/Notification/NotificationListFilter.jsx
+++ b/ui/src/components/Notification/NotificationListFilter.jsx
@@ -1,0 +1,100 @@
+import _ from 'lodash';
+import React, { Component } from 'react';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { Alignment, Button, Intent, MenuItem } from '@blueprintjs/core';
+
+import { Count, SelectWrapper } from 'components/common';
+
+import 'src/components/common/SortingBar.scss';
+
+const messages = defineMessages({
+  filter_all: {
+    id: 'notifications.type_filter.all',
+    defaultMessage: 'All',
+  },
+});
+
+class NotificationListFilter extends Component {
+  constructor(props) {
+    super(props);
+    this.onSelect = this.onSelect.bind(this);
+  }
+
+  renderOption = (option, { handleClick }) => (
+    <MenuItem
+      key={option.field}
+      onClick={handleClick}
+      text={option.label}
+      label={<Count count={option.count} />}
+    />
+  )
+
+  onSelect(selected) {
+    const { query, updateQuery } = this.props;
+    const newQuery = query.setFilter('event', selected.id)
+    updateQuery(newQuery)
+  }
+
+  render() {
+    const { eventFacetVals, intl } = this.props;
+
+    const defaultOption = {
+      label: intl.formatMessage(messages.filter_all),
+      count: _.sumBy(eventFacetVals, val => val.count),
+    }
+
+    const typeOptions = [defaultOption, ...eventFacetVals];
+    const activeItem = typeOptions.find(item => item.active) || defaultOption;
+
+    return (
+      <div className="SortingBar">
+        <span className="SortingBar__label">
+          <FormattedMessage
+            id="notifications.type_filter"
+            defaultMessage="Showing"
+          />
+        </span>
+        <div className="SortingBar__control">
+          <SelectWrapper
+            itemRenderer={this.renderOption}
+            items={typeOptions}
+            onItemSelect={this.onSelect}
+            activeItem={activeItem}
+            popoverProps={{
+              minimal: true,
+              fill: false,
+              className: 'SortingBar__item__popover',
+            }}
+            inputProps={{
+              fill: false,
+            }}
+            filterable={false}
+            resetOnClose
+            resetOnSelect
+          >
+            <Button
+              text={activeItem?.label}
+              alignText={Alignment.LEFT}
+              minimal
+              intent={Intent.PRIMARY}
+              rightIcon="caret-down"
+            />
+          </SelectWrapper>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const { result } = ownProps;
+  const eventFacetVals = result?.facets?.event?.values || [];
+  return { eventFacetVals };
+};
+
+export default compose(
+  connect(mapStateToProps),
+  injectIntl,
+)(NotificationListFilter);

--- a/ui/src/components/common/ExportLink.jsx
+++ b/ui/src/components/common/ExportLink.jsx
@@ -8,7 +8,6 @@ class ExportLink extends PureComponent {
     const { export_, icon } = this.props;
     const exportSuccess = "successful";
 
-    console.log(export_.export_status);
     const label = (
       <span className="ExportLink">
         <Icon icon={icon} className="left-icon" />

--- a/ui/src/screens/NotificationsScreen/NotificationsScreen.jsx
+++ b/ui/src/screens/NotificationsScreen/NotificationsScreen.jsx
@@ -55,10 +55,12 @@ export class NotificationsScreen extends React.Component {
   }
 }
 
-
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
-  const query = Query.fromLocation('notifications', location, {}, 'notifications').limit(40);
+
+  const query = Query.fromLocation('notifications', location, {'facet': 'event'}, 'notifications')
+    .limit(40);
+
   return {
     query,
     result: selectNotificationsResult(state, query),


### PR DESCRIPTION
Resolves #1286 

@pudo The only remaining issue is that there are two separate event types for the creation of lists and diagrams, but the notification events aren't tagged separately, so both types appear under "New list"

<img width="849" alt="Screen Shot 2020-09-08 at 13 06 48" src="https://user-images.githubusercontent.com/6720200/92469344-f8ef1400-f1d4-11ea-9b68-d50b4de9d59c.png">
