### PR TITLE
Upload: Improve preview screen

### DIFF
--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadView.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadView.jsx
@@ -1,6 +1,7 @@
 import React, { PureComponent } from 'react';
 import { Button, Checkbox, Icon, Intent } from '@blueprintjs/core';
 import { defineMessages, injectIntl } from 'react-intl';
+import { FileSize } from '@alephdata/react-ftm';
 
 import convertPathsToTree from 'util/convertPathsToTree';
 
@@ -11,6 +12,10 @@ const messages = defineMessages({
     id: 'document.upload.save',
     defaultMessage: 'Upload',
   },
+  summary: {
+    id: 'document.upload.summary',
+    defaultMessage: '{numberOfFiles, number} files, {totalSize}'
+  }
 });
 
 export class DocumentUploadView extends PureComponent {
@@ -72,14 +77,20 @@ export class DocumentUploadView extends PureComponent {
 
   render() {
     const { files, intl } = this.props;
+    const { filesToUpload } = this.state;
 
     const fileTree = convertPathsToTree(files);
+    const totalFileSize = files.reduce((totalSize, file) => totalSize + file.size, 0);
 
     return (
       <div className="DocumentUploadView">
         <div className="DocumentUploadView__content">
           {this.renderFolder(fileTree)}
         </div>
+        <p>{intl.formatMessage(messages.summary, {
+          numberOfFiles: filesToUpload.length,
+          totalSize: <FileSize value={totalFileSize} />
+        })}</p>
         <div className="bp3-dialog-footer">
           <div className="bp3-dialog-footer-actions">
             <Button

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadView.scss
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadView.scss
@@ -4,6 +4,8 @@
 .DocumentUploadView {
   &__content {
     margin-bottom: $aleph-grid-size*2;
+    max-height: 60vh;
+    overflow: auto;
   }
   &__folder {
     padding-top: 5px;


### PR DESCRIPTION
- Limit height of file list to max 60% height of viewport. Before the user had to scroll down the complete list in order to submit the form.
- add simple stats: number of selected files, total upload size of all selected files

before
![image](https://user-images.githubusercontent.com/1635212/92611833-7d1ac780-f2b9-11ea-8233-519dac7681f1.png)

after
<img width="515" alt="Screenshot 2020-09-09 at 16 27 08" src="https://user-images.githubusercontent.com/1635212/92611859-860b9900-f2b9-11ea-9cbb-1095f3aa4203.png">