### PR TITLE
[WIP] Use followthemoney-predict for XRef

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND noninteractive
+ARG FTM_PREDICT_MODEL=https://public.data.occrp.org/develop/models/xref/model.xgboost.58c81d5.pkl
 
 # build-essential 
 RUN apt-get -qq -y update \
@@ -36,6 +37,8 @@ ENV ALEPH_ELASTICSEARCH_URI=http://elasticsearch:9200/ \
     REDIS_URL=redis://redis:6379/0 \
     ARCHIVE_TYPE=file \
     ARCHIVE_PATH=/data
+
+ADD ${FTM_PREDICT_MODEL} /model.pkl
 
 # Run the green unicorn
 CMD gunicorn -w 5 -b 0.0.0.0:8000 --log-level info --log-file - aleph.manage:app

--- a/aleph/index/xref.py
+++ b/aleph/index/xref.py
@@ -32,6 +32,7 @@ def configure_xref():
             "match_collection_id": KEYWORD,
             registry.country.group: KEYWORD,
             "schema": KEYWORD,
+            "method": KEYWORD,
             "text": {"type": "text", "analyzer": "latin_index"},
             "created_at": {"type": "date"},
         },
@@ -42,7 +43,9 @@ def configure_xref():
 
 def _index_form(collection, matches):
     now = datetime.utcnow().isoformat()
-    for (score, entity, match_collection_id, match) in matches:
+    for result in matches:
+        entity = result.entity
+        match = result.match
         xref_id = hash_data((entity.id, collection.id, match.id))
         text = set([entity.caption, match.caption])
         text.update(entity.get_type_values(registry.name)[:MAX_NAMES])
@@ -53,12 +56,13 @@ def _index_form(collection, matches):
             "_id": xref_id,
             "_index": xref_index(),
             "_source": {
-                "score": score,
+                "score": result.score,
                 "entity_id": entity.id,
                 "schema": match.schema.name,
                 "collection_id": collection.id,
                 "match_id": match.id,
-                "match_collection_id": match_collection_id,
+                "match_collection_id": result.match_collection_id,
+                "method": result.method,
                 "countries": list(countries),
                 "text": list(text),
                 "created_at": now,

--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -122,6 +122,9 @@ API_RATE_WINDOW = 15  # minutes
 PAGES_PATH = os.path.join(APP_DIR, "pages")
 PAGES_PATH = env.get("ALEPH_PAGES_PATH", PAGES_PATH)
 
+# followthemoney-predict settings
+FOLLOWTHEMONEY_PREDICT_MODEL = "/model.pkl"
+
 ##############################################################################
 # E-mail settings
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 banal==1.0.1
 urlnormalizer==1.2.5
 followthemoney==2.1.9
-followthemoney-predict==0.3.1
+followthemoney-predict==0.5.0
 followthemoney-store[postgresql]==2.2.3
 fingerprints==1.0.1
 servicelayer[google,amazon]==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 banal==1.0.1
 urlnormalizer==1.2.5
 followthemoney==2.1.9
-followthemoney-predict==0.5.0
+followthemoney-predict==0.5.1
 followthemoney-store[postgresql]==2.2.3
 fingerprints==1.0.1
 servicelayer[google,amazon]==1.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 banal==1.0.1
 urlnormalizer==1.2.5
 followthemoney==2.1.9
+followthemoney-predict==0.3.1
 followthemoney-store[postgresql]==2.2.3
 fingerprints==1.0.1
 servicelayer[google,amazon]==1.15.0
@@ -45,5 +46,10 @@ coverage
 coveralls
 
 # Tracing and logging libraries
+<<<<<<< HEAD
 python-json-logger==2.0.0
 google-cloud-logging==1.15.1
+=======
+python-json-logger==0.1.11
+google-cloud-logging==1.15.1
+>>>>>>> 2aa6a73e3... Added model info to xref index and cleaned up xref results passing


### PR DESCRIPTION
This pull request uses `followthemoney-predict` to do xref classification.

Todo:
- [x] Clean up the actual model creation and model selection (ie: who creates a model, when, and how does the correct model get selected by aleph)
- [x] Find final resting place for production model
  - https://public.data.occrp.org/develop/models/xref/
- [x] Add some model information into the XRef index
  - Add model version metadata + inference extra data