### PR TITLE
Upload: Track progress of each request

### DIFF
--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.jsx
@@ -2,22 +2,38 @@ import React, { PureComponent } from 'react';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { ProgressBar } from '@blueprintjs/core';
 
+function computePercentCompleted(uploadTraces, totalUploadSize) {
+  if (totalUploadSize <= 0) { //fallback if we don't know file sizes
+    const done = uploadTraces.filter(trace => trace.status !== "pending").length;
+    return done / uploadTraces.length;
+  }
+
+  return uploadTraces.reduce((result, trace) => {
+    let summand = 0;
+    if (trace.size) { // finished requests for folders are not reflected in the progress bar
+      if (trace.status === "pending" && trace.size) {
+        summand = ((trace.uploaded / trace.total * trace.size) / totalUploadSize) * 0.9; // reserve 10% for the request complete event
+      }
+      else if (trace.status === "done" || trace.status === "error") {
+        summand = trace.size / totalUploadSize;
+      }
+    }
+    return result + summand;
+  }, 0);
+}
+
 
 export class DocumentUploadStatus extends PureComponent {
   render() {
-    const { percentCompleted, uploading } = this.props;
+    const { uploadTraces, totalUploadSize } = this.props;
+    const currUploadingFiles = uploadTraces
+      .filter(trace => trace.status === 'pending')
+      .sort((a, b) => b.uploaded - a.uploaded);
 
     return (
       <div>
-        <p>
-          <FormattedMessage
-            id="document.upload.progress"
-            defaultMessage="Uploading: {file}..."
-            values={{ file: uploading }}
-          />
-        </p>
         <ProgressBar
-          value={percentCompleted}
+          value={computePercentCompleted(uploadTraces, totalUploadSize)}
           animate={false}
           stripes={false}
           className="bp3-intent-success document-upload-progress-bar"
@@ -27,6 +43,13 @@ export class DocumentUploadStatus extends PureComponent {
             id="document.upload.notice"
             defaultMessage="Once the upload is complete, it will take a few moments for the documents to be processed and become searchable."
           />
+        </p>
+        <p>
+          {currUploadingFiles.length > 0 && <FormattedMessage
+            id="document.upload.progress"
+            defaultMessage="Uploading: {file}..."
+            values={{ file: currUploadingFiles[0].name }}
+          />}
         </p>
       </div>
     );


### PR DESCRIPTION
Calculate progress bar value based on uploaded bytes per file versus total size to upload

![image](https://user-images.githubusercontent.com/1635212/93475687-351f2480-f8f9-11ea-8721-445bd359585a.png)

Before this change the progress bar went forward as soon as the request for a file started. Most of the time the progress bar therefore just showed 100% even when a lot of upload requests were still going on.