### PR TITLE
Upload: Error handling

### DIFF
--- a/ui/src/actions/documentActions.js
+++ b/ui/src/actions/documentActions.js
@@ -3,7 +3,7 @@ import asyncActionCreator from './asyncActionCreator';
 
 
 export const ingestDocument = asyncActionCreator(
-  (collectionId, metadata, file, onUploadProgress) => async () => {
+  (collectionId, metadata, file, onUploadProgress, cancelToken) => async () => {
     const formData = new FormData();
     if (file) {
       formData.append('file', file);
@@ -15,6 +15,7 @@ export const ingestDocument = asyncActionCreator(
         'content-type': 'multipart/form-data',
       },
       params: { sync: true },
+      cancelToken
     };
     const response = await endpoint.post(`collections/${collectionId}/ingest`, formData, config);
     return { ...response.data };

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadActionsDone.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadActionsDone.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { FormattedMessage, injectIntl, defineMessages } from "react-intl";
+import { Button, Intent } from "@blueprintjs/core";
+
+const messages = defineMessages({
+  close: {
+    id: 'document.upload.close',
+    defaultMessage: 'Close',
+  },
+  retry: {
+    id: 'document.upload.retry',
+    defaultMessage: 'Retry',
+  }
+});
+
+function DocumentUploadActionsDone({ stats, onRetry, onClose, intl }) {
+  return <section>
+    <p>
+      <FormattedMessage
+        id="document.upload.notice"
+        defaultMessage="The upload is complete. It will take a few moments for the documents to be processed and become searchable."
+      />
+    </p>
+    {stats.errors > 0 && <p>
+      <FormattedMessage
+        id="document.upload.errors"
+        defaultMessage="Some files couldn't be transferred. You can use the Retry button to restart all failed uploads."
+      />
+    </p>}
+    <div className="bp3-dialog-footer-actions">
+      {stats.errors > 0 && <Button
+        type="button"
+        intent={Intent.PRIMARY}
+        icon={"repeat"}
+        text={intl.formatMessage(messages.retry)}
+        onClick={onRetry}
+      />}
+      <Button
+        type="submit"
+        intent={stats.errors <= 0 ? Intent.PRIMARY : Intent.NONE}
+        icon={"tick"}
+        text={intl.formatMessage(messages.close)}
+        onClick={onClose}
+      />
+    </div>
+  </section>
+}
+
+export default injectIntl(DocumentUploadActionsDone)

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadActionsPending.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadActionsPending.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { defineMessages, injectIntl } from "react-intl";
+import { Button, Intent } from "@blueprintjs/core";
+
+const messages = defineMessages({
+  cancel: {
+    id: 'document.upload.cancel',
+    defaultMessage: 'Cancel',
+  }
+});
+
+function DocumentUploadActionsPending({ intl, onClose }) {
+  return <div className="bp3-dialog-footer-actions">
+      <Button
+        type="button"
+        icon={"cross"}
+        intent={Intent.DANGER}
+        text={intl.formatMessage(messages.cancel)}
+        onClick={() => onClose()}
+      />
+    </div>
+}
+
+export default injectIntl(DocumentUploadActionsPending);

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadDialog.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadDialog.jsx
@@ -60,20 +60,20 @@ export class DocumentUploadDialog extends Component {
 
   onClose() {
     const { toggleDialog, isOpen, onUploadSuccess } = this.props;
-    const { uploadDone } = this.state;
+    const { uploadMeta } = this.state;
+
+    if (uploadMeta && uploadMeta.status !== UPLOAD_STATUS.PENDING) {
+      onUploadSuccess();
+    }
+    else if (isOpen) {
+      toggleDialog();
+    }
 
     this.setState({
       files: [],
       uploadTraces: [],
       uploadMeta: null
     });
-
-    if (uploadDone) {
-      onUploadSuccess();
-    }
-    else if (isOpen) {
-      toggleDialog();
-    }
   }
 
   onRetry() {
@@ -222,12 +222,17 @@ export class DocumentUploadDialog extends Component {
 
   render() {
     const { intl, isOpen } = this.props;
+    const { uploadMeta } = this.state;
+    const closeable = uploadMeta?.status !== UPLOAD_STATUS.PENDING;
 
     return (
       <Dialog
         icon="upload"
         className="DocumentUploadDialog"
         isOpen={isOpen}
+        canEscapeKeyClose={closeable}
+        canOutsideClickClose={closeable}
+        isCloseButtonShown={closeable}
         title={intl.formatMessage(messages.title)}
         onClose={this.onClose}
       >

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadDialog.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadDialog.jsx
@@ -101,11 +101,15 @@ export class DocumentUploadDialog extends Component {
   }
 
   onUploadDone() {
-    this.setState(({ uploadMeta, uploadTraces }) => ({
-      uploadMeta: Object.assign({}, uploadMeta, {
-        status: uploadTraces.filter(trace => trace.status === UPLOAD_STATUS.SUCCESS).length > 0 ? UPLOAD_STATUS.SUCCESS : UPLOAD_STATUS.ERROR
-      })
-    }));
+    this.setState(({ uploadMeta, uploadTraces }) => {
+      if (uploadMeta) { // on cancellation uploadMeta could be none, as it takes a while to cancel all requests
+        return {
+          uploadMeta: Object.assign({}, uploadMeta, {
+            status: uploadTraces.filter(trace => trace.status === UPLOAD_STATUS.SUCCESS).length > 0 ? UPLOAD_STATUS.SUCCESS : UPLOAD_STATUS.ERROR
+          })
+        }
+      }
+    });
   }
 
   async traverseFileTree(tree, parent) {

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.jsx
@@ -39,12 +39,16 @@ const messages = defineMessages({
   close: {
     id: 'document.upload.close',
     defaultMessage: 'Close',
+  },
+  retry: {
+    id: 'document.upload.retry',
+    defaultMessage: 'Retry',
   }
 });
 
 export class DocumentUploadStatus extends PureComponent {
   render() {
-    const { uploadTraces, uploadMeta, onClose, intl } = this.props;
+    const { uploadTraces, uploadMeta, onClose, onRetry, intl } = this.props;
     const stats = {
       errors: uploadTraces.filter(trace => trace.status === UPLOAD_STATUS.ERROR).length,
       filesDone: uploadTraces.filter(trace => trace.type === 'file' && trace.status !== UPLOAD_STATUS.PENDING).length
@@ -81,9 +85,16 @@ export class DocumentUploadStatus extends PureComponent {
             />
           </p>
           <div className="bp3-dialog-footer-actions">
+            {stats.errors > 0 && <Button
+              type="button"
+              intent={Intent.PRIMARY}
+              icon={"repeat"}
+              text={intl.formatMessage(messages.retry)}
+              onClick={onRetry}
+            />}
             <Button
               type="submit"
-              intent={Intent.PRIMARY}
+              intent={stats.errors <= 0 ? Intent.PRIMARY : Intent.NONE}
               icon={"tick"}
               text={intl.formatMessage(messages.close)}
               onClick={onClose}

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.jsx
@@ -1,56 +1,95 @@
 import React, { PureComponent } from 'react';
-import { FormattedMessage, injectIntl } from 'react-intl';
-import { ProgressBar } from '@blueprintjs/core';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import { Button, Intent, ProgressBar } from '@blueprintjs/core';
+import DocumentUploadTrace from './DocumentUploadTrace';
 
-function computePercentCompleted(uploadTraces, totalUploadSize) {
-  if (totalUploadSize <= 0) { //fallback if we don't know file sizes
-    const done = uploadTraces.filter(trace => trace.status !== "pending").length;
+import './DocumentUploadStatus.scss';
+
+export const UPLOAD_STATUS = {
+  "PENDING": 1,
+  "ERROR": 2,
+  "SUCCESS": 3
+};
+
+function computePercentCompleted(uploadTraces, uploadMeta) {
+  if (uploadMeta.status !== UPLOAD_STATUS.PENDING) {
+    return 1;
+  }
+
+  if (uploadMeta.totalUploadSize <= 0) { //fallback if we don't know file sizes
+    const done = uploadTraces.filter(trace => trace.status !== UPLOAD_STATUS.PENDING).length;
     return done / uploadTraces.length;
   }
 
   return uploadTraces.reduce((result, trace) => {
     let summand = 0;
     if (trace.size) { // finished requests for folders are not reflected in the progress bar
-      if (trace.status === "pending" && trace.size) {
-        summand = ((trace.uploaded / trace.total * trace.size) / totalUploadSize) * 0.9; // reserve 10% for the request complete event
+      if (trace.status === UPLOAD_STATUS.PENDING && trace.size) {
+        summand = ((trace.uploaded / trace.total * trace.size) / uploadMeta.totalUploadSize) * 0.9; // reserve 10% for the request complete event
       }
-      else if (trace.status === "done" || trace.status === "error") {
-        summand = trace.size / totalUploadSize;
+      else if (trace.status === UPLOAD_STATUS.SUCCESS || trace.status === UPLOAD_STATUS.ERROR) {
+        summand = trace.size / uploadMeta.totalUploadSize;
       }
     }
     return result + summand;
   }, 0);
 }
 
+const messages = defineMessages({
+  close: {
+    id: 'document.upload.close',
+    defaultMessage: 'Close',
+  }
+});
 
 export class DocumentUploadStatus extends PureComponent {
   render() {
-    const { uploadTraces, totalUploadSize } = this.props;
-    const currUploadingFiles = uploadTraces
-      .filter(trace => trace.status === 'pending')
-      .sort((a, b) => b.uploaded - a.uploaded);
+    const { uploadTraces, uploadMeta, onClose, intl } = this.props;
+    const stats = {
+      errors: uploadTraces.filter(trace => trace.status === UPLOAD_STATUS.ERROR).length,
+      filesDone: uploadTraces.filter(trace => trace.type === 'file' && trace.status !== UPLOAD_STATUS.PENDING).length
+    }
 
     return (
       <div>
         <ProgressBar
-          value={computePercentCompleted(uploadTraces, totalUploadSize)}
+          value={computePercentCompleted(uploadTraces, uploadMeta)}
           animate={false}
           stripes={false}
-          className="bp3-intent-success document-upload-progress-bar"
+          intent={stats.errors > 0 ? "warning" : "success"}
+          className="document-upload-progress-bar"
         />
-        <p className="text-muted">
+        <p>
           <FormattedMessage
-            id="document.upload.notice"
-            defaultMessage="Once the upload is complete, it will take a few moments for the documents to be processed and become searchable."
+            id="document.upload.progress"
+            defaultMessage="{done} of {total} files done, {errors} errors."
+            values={{
+              done: stats.filesDone,
+              total: uploadMeta.totalFiles,
+              errors: stats.errors
+            }}
           />
         </p>
-        <p>
-          {currUploadingFiles.length > 0 && <FormattedMessage
-            id="document.upload.progress"
-            defaultMessage="Uploading: {file}..."
-            values={{ file: currUploadingFiles[0].name }}
-          />}
-        </p>
+        <ul className={"bp3-list-unstyled DocumentUploadStatus__list"}>
+          {uploadTraces.map((trace, index) => <DocumentUploadTrace trace={trace} key={index} />)}
+        </ul>
+        {uploadMeta.status !== UPLOAD_STATUS.PENDING && <section>
+          <p>
+            <FormattedMessage
+              id="document.upload.notice"
+              defaultMessage="The upload is complete. It will take a few moments for the documents to be processed and become searchable."
+            />
+          </p>
+          <div className="bp3-dialog-footer-actions">
+            <Button
+              type="submit"
+              intent={Intent.PRIMARY}
+              icon={"tick"}
+              text={intl.formatMessage(messages.close)}
+              onClick={onClose}
+            />
+          </div>
+        </section>}
       </div>
     );
   }

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.jsx
@@ -1,9 +1,11 @@
 import React, { PureComponent } from 'react';
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { Button, Intent, ProgressBar } from '@blueprintjs/core';
+import { FormattedMessage, injectIntl } from 'react-intl';
+import { ProgressBar } from '@blueprintjs/core';
 import DocumentUploadTrace from './DocumentUploadTrace';
 
 import './DocumentUploadStatus.scss';
+import DocumentUploadActionsDone from "./DocumentUploadActionsDone";
+import DocumentUploadActionsPending from "./DocumentUploadActionsPending";
 
 export const UPLOAD_STATUS = {
   "PENDING": 1,
@@ -35,20 +37,9 @@ function computePercentCompleted(uploadTraces, uploadMeta) {
   }, 0);
 }
 
-const messages = defineMessages({
-  close: {
-    id: 'document.upload.close',
-    defaultMessage: 'Close',
-  },
-  retry: {
-    id: 'document.upload.retry',
-    defaultMessage: 'Retry',
-  }
-});
-
 export class DocumentUploadStatus extends PureComponent {
   render() {
-    const { uploadTraces, uploadMeta, onClose, onRetry, intl } = this.props;
+    const { uploadTraces, uploadMeta, onClose, onRetry } = this.props;
     const stats = {
       errors: uploadTraces.filter(trace => trace.status === UPLOAD_STATUS.ERROR).length,
       filesDone: uploadTraces.filter(trace => trace.type === 'file' && trace.status !== UPLOAD_STATUS.PENDING).length
@@ -75,32 +66,11 @@ export class DocumentUploadStatus extends PureComponent {
           />
         </p>
         <ul className={"bp3-list-unstyled DocumentUploadStatus__list"}>
-          {uploadTraces.map((trace, index) => <DocumentUploadTrace trace={trace} key={index} />)}
+          {uploadTraces.map((trace, index) => <DocumentUploadTrace trace={trace} key={index}/>)}
         </ul>
-        {uploadMeta.status !== UPLOAD_STATUS.PENDING && <section>
-          <p>
-            <FormattedMessage
-              id="document.upload.notice"
-              defaultMessage="The upload is complete. It will take a few moments for the documents to be processed and become searchable."
-            />
-          </p>
-          <div className="bp3-dialog-footer-actions">
-            {stats.errors > 0 && <Button
-              type="button"
-              intent={Intent.PRIMARY}
-              icon={"repeat"}
-              text={intl.formatMessage(messages.retry)}
-              onClick={onRetry}
-            />}
-            <Button
-              type="submit"
-              intent={stats.errors <= 0 ? Intent.PRIMARY : Intent.NONE}
-              icon={"tick"}
-              text={intl.formatMessage(messages.close)}
-              onClick={onClose}
-            />
-          </div>
-        </section>}
+
+        {uploadMeta.status === UPLOAD_STATUS.PENDING && <DocumentUploadActionsPending onClose={onClose} />}
+        {uploadMeta.status !== UPLOAD_STATUS.PENDING && <DocumentUploadActionsDone stats={stats} onRetry={onRetry} onClose={onClose} />}
       </div>
     );
   }

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.scss
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.scss
@@ -13,6 +13,9 @@ ul.DocumentUploadStatus__list {
     width: 100%;
 
     &__label {
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
       flex-grow: 1;
     }
 

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.scss
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadStatus.scss
@@ -1,0 +1,24 @@
+@import "~@blueprintjs/core/lib/scss/variables";
+
+ul.DocumentUploadStatus__list {
+  max-height: 20vh;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+  background: $white;
+  border: 1px solid $light-gray1;
+
+  .DocumentUploadTrace {
+    padding: .5rem;
+    display: flex;
+    width: 100%;
+
+    &__label {
+      flex-grow: 1;
+    }
+
+    &__status {
+      flex: 0 0 20px;
+      height: 20px;
+    }
+  }
+}

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadTrace.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadTrace.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { Spinner, Icon } from "@blueprintjs/core";
+import { UPLOAD_STATUS } from "./DocumentUploadStatus";
+
+export default function DocumentUploadTrace(props) {
+  const { trace } = props;
+
+  const renderStatus = () => {
+    if (trace.status === UPLOAD_STATUS.PENDING) {
+      if (trace.uploaded > 0) {
+        return <Spinner intent="primary" size={Spinner.SIZE_SMALL} value={trace.uploaded / trace.total} />
+      } else {
+        return <span />
+      }
+    } else if (trace.status === UPLOAD_STATUS.SUCCESS) {
+      return <Icon intent="success" icon="tick-circle" iconSize={Spinner.SIZE_SMALL} />
+    } else if (trace.status === UPLOAD_STATUS.ERROR) {
+      return <Icon intent="danger" icon="error" iconSize={Spinner.SIZE_SMALL} />
+    }
+  }
+
+  return <li className='DocumentUploadTrace'>
+    <div className='DocumentUploadTrace__label'>{trace.name}</div>
+    <div className='DocumentUploadTrace__status'>
+      {renderStatus()}
+    </div>
+  </li>
+}

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadTrace.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadTrace.jsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { Spinner, Icon } from "@blueprintjs/core";
 import { UPLOAD_STATUS } from "./DocumentUploadStatus";
 
-export default function DocumentUploadTrace(props) {
-  const { trace } = props;
-
+export default function DocumentUploadTrace({ trace }) {
   const renderStatus = () => {
     if (trace.status === UPLOAD_STATUS.PENDING) {
       if (trace.uploaded > 0) {


### PR DESCRIPTION
- don't close dialog on errors
- show user the amount of failed file uploads
- detailed upload status per file as a scrollable list
- retry function: re-upload all files where an error occurred
- while upload is running: add cancel button, prevent dialog from being closed by hitting esc
- cancel post requests when dialog is closed

While uploading:

![image](https://user-images.githubusercontent.com/1635212/93660269-3c574700-fa4d-11ea-816d-49c8ded4c687.png)

When errors occurred:

![image](https://user-images.githubusercontent.com/1635212/93660341-226a3400-fa4e-11ea-9030-4eb81f7f88ea.png)

No errors:

![image](https://user-images.githubusercontent.com/1635212/93660370-7248fb00-fa4e-11ea-8ed6-1efbc059192b.png)
