### PR TITLE
Remove blueprint esnext node modules direct import

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@alephdata/followthemoney": "2.1.9",
     "@alephdata/react-ftm": "1.10.11",
-    "@blueprintjs/core": "3.31.0",
+    "@blueprintjs/core": "3.33.0",
     "@blueprintjs/datetime": "^3.15.1",
     "@blueprintjs/icons": "3.22.0",
     "@blueprintjs/select": "^3.8.0",

--- a/ui/src/components/Screen/Screen.jsx
+++ b/ui/src/components/Screen/Screen.jsx
@@ -35,7 +35,8 @@ class Screen extends React.PureComponent {
   }
 }
 
-
+// See https://github.com/palantir/blueprint/issues/2972#issuecomment-441978641
+//  - HotkeysTarget does not support wrapped es6 components, so wraps Screen component in es5 compatible function
 function ScreenAsAFunction() {}
 ScreenAsAFunction.prototype = Object.create(Screen.prototype);
 

--- a/ui/src/components/Screen/Screen.jsx
+++ b/ui/src/components/Screen/Screen.jsx
@@ -1,49 +1,15 @@
 import React from 'react';
-import { Helmet } from 'react-helmet';
-import c from 'classnames';
-import { Hotkeys, Hotkey } from '@blueprintjs/core';
-// See @alxmiron at https://github.com/palantir/blueprint/issues/3604
-import { HotkeysTarget } from '@blueprintjs/core/lib/esnext/components/hotkeys/hotkeysTarget.js';
-import { compose } from 'redux';
-import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
-import AuthenticationDialog from 'dialogs/AuthenticationDialog/AuthenticationDialog';
-import EntityPreview from 'components/Entity/EntityPreview';
-import Navbar from 'components/Navbar/Navbar';
-import AdvancedSearch from 'components/AdvancedSearch/AdvancedSearch';
-import { selectSession, selectMetadata } from 'selectors';
-
-import './Screen.scss';
+import { Hotkeys, Hotkey, HotkeysTarget } from '@blueprintjs/core';
+import ScreenBase from 'components/Screen/ScreenBase';
 
 
-export class Screen extends React.Component {
+class Screen extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.state = {
-      advancedSearchOpen: false,
-    };
-    this.onToggleAdvancedSearch = this.onToggleAdvancedSearch.bind(this);
-    this.toggleAuthentication = this.toggleAuthentication.bind(this);
-    this.navbarRef = React.createRef();
+    this.focusSearchBox = this.focusSearchBox.bind(this);
   }
 
-  componentDidMount() {
-    window.scrollTo(0, 0);
-  }
-
-  componentDidUpdate(prevProps) {
-    if (this.props.location && (this.props.location.pathname !== prevProps.location.pathname)) {
-      window.scrollTo(0, 0);
-    }
-  }
-
-  onToggleAdvancedSearch() {
-    this.setState(({ advancedSearchOpen }) => ({ advancedSearchOpen: !advancedSearchOpen }));
-  }
-
-  toggleAuthentication = event => event.preventDefault();
-
-  focusSearchBox = () => {
+  focusSearchBox() {
     const searchBox = document.querySelector('#search-box');
     if (searchBox) {
       searchBox.focus();
@@ -64,78 +30,13 @@ export class Screen extends React.Component {
       </Hotkeys>
     );
   }
-
   render() {
-    const {
-      session, metadata, query, requireSession,
-      isHomepage, title, description, className, searchScopes,
-    } = this.props;
-    const { advancedSearchOpen } = this.state;
-    const hasMetadata = metadata && metadata.app && metadata.app.title;
-    const forceAuth = requireSession && !session.loggedIn;
-    const mainClass = isHomepage ? 'main-homepage' : 'main';
-    const titleTemplate = hasMetadata ? `%s - ${metadata.app.title}` : '%s';
-    const defaultTitle = hasMetadata ? metadata.app.title : 'Aleph';
-
-    return (
-      <div className={c('Screen', className)}>
-        <Helmet titleTemplate={titleTemplate} defaultTitle={defaultTitle}>
-          { !!title && (
-            <title>{title}</title>
-          )}
-          { !!description && (
-            <meta name="description" content={description} />
-          )}
-          { !!metadata.app.favicon && (
-            <link rel="shortcut icon" href={metadata.app.favicon} />
-          )}
-        </Helmet>
-        <Navbar
-          navbarRef={this.navbarRef}
-          metadata={metadata}
-          session={session}
-          query={query}
-          isHomepage={isHomepage}
-          searchScopes={searchScopes}
-          onToggleAdvancedSearch={this.onToggleAdvancedSearch}
-        />
-        { (hasMetadata && !!metadata.app.banner) && (
-          <div className="app-banner bp3-callout bp3-intent-warning bp3-icon-warning-sign">
-            {metadata.app.banner}
-          </div>
-        )}
-        {!forceAuth && (
-          <>
-            <main className={mainClass}>
-              {this.props.children}
-            </main>
-            <EntityPreview />
-          </>
-        )}
-        {forceAuth && (
-          <AuthenticationDialog
-            auth={metadata.auth}
-            isOpen
-            toggleDialog={this.toggleAuthentication}
-          />
-        )}
-        <AdvancedSearch
-          isOpen={advancedSearchOpen}
-          onToggle={this.onToggleAdvancedSearch}
-          navbarRef={this.navbarRef}
-        />
-      </div>
-    );
+    return <ScreenBase {...this.props} />;
   }
 }
 
-const mapStateToProps = state => ({
-  metadata: selectMetadata(state),
-  session: selectSession(state),
-});
 
-export default compose(
-  withRouter,
-  connect(mapStateToProps),
-  HotkeysTarget,
-)(Screen);
+function ScreenAsAFunction() {}
+ScreenAsAFunction.prototype = Object.create(Screen.prototype);
+
+export default HotkeysTarget(ScreenAsAFunction);

--- a/ui/src/components/Screen/ScreenBase.jsx
+++ b/ui/src/components/Screen/ScreenBase.jsx
@@ -1,0 +1,114 @@
+import React from 'react';
+import { Helmet } from 'react-helmet';
+import c from 'classnames';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import AuthenticationDialog from 'dialogs/AuthenticationDialog/AuthenticationDialog';
+import EntityPreview from 'components/Entity/EntityPreview';
+import Navbar from 'components/Navbar/Navbar';
+import AdvancedSearch from 'components/AdvancedSearch/AdvancedSearch';
+import { selectSession, selectMetadata } from 'selectors';
+
+import './Screen.scss';
+
+export class ScreenBase extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      advancedSearchOpen: false,
+    };
+    this.onToggleAdvancedSearch = this.onToggleAdvancedSearch.bind(this);
+    this.toggleAuthentication = this.toggleAuthentication.bind(this);
+    this.navbarRef = React.createRef();
+  }
+
+  componentDidMount() {
+    window.scrollTo(0, 0);
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.props.location && (this.props.location.pathname !== prevProps.location.pathname)) {
+      window.scrollTo(0, 0);
+    }
+  }
+
+  onToggleAdvancedSearch() {
+    this.setState(({ advancedSearchOpen }) => ({ advancedSearchOpen: !advancedSearchOpen }));
+  }
+
+  toggleAuthentication = event => event.preventDefault();
+
+  render() {
+    const {
+      session, metadata, query, requireSession,
+      isHomepage, title, description, className, searchScopes,
+    } = this.props;
+    const { advancedSearchOpen } = this.state;
+    const hasMetadata = metadata && metadata.app && metadata.app.title;
+    const forceAuth = requireSession && !session.loggedIn;
+    const mainClass = isHomepage ? 'main-homepage' : 'main';
+    const titleTemplate = hasMetadata ? `%s - ${metadata.app.title}` : '%s';
+    const defaultTitle = hasMetadata ? metadata.app.title : 'Aleph';
+
+    return (
+      <div className={c('Screen', className)}>
+        <Helmet titleTemplate={titleTemplate} defaultTitle={defaultTitle}>
+          { !!title && (
+            <title>{title}</title>
+          )}
+          { !!description && (
+            <meta name="description" content={description} />
+          )}
+          { !!metadata.app.favicon && (
+            <link rel="shortcut icon" href={metadata.app.favicon} />
+          )}
+        </Helmet>
+        <Navbar
+          navbarRef={this.navbarRef}
+          metadata={metadata}
+          session={session}
+          query={query}
+          isHomepage={isHomepage}
+          searchScopes={searchScopes}
+          onToggleAdvancedSearch={this.onToggleAdvancedSearch}
+        />
+        { (hasMetadata && !!metadata.app.banner) && (
+          <div className="app-banner bp3-callout bp3-intent-warning bp3-icon-warning-sign">
+            {metadata.app.banner}
+          </div>
+        )}
+        {!forceAuth && (
+          <>
+            <main className={mainClass}>
+              {this.props.children}
+            </main>
+            <EntityPreview />
+          </>
+        )}
+        {forceAuth && (
+          <AuthenticationDialog
+            auth={metadata.auth}
+            isOpen
+            toggleDialog={this.toggleAuthentication}
+          />
+        )}
+        <AdvancedSearch
+          isOpen={advancedSearchOpen}
+          onToggle={this.onToggleAdvancedSearch}
+          navbarRef={this.navbarRef}
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  metadata: selectMetadata(state),
+  session: selectSession(state),
+});
+
+export default compose(
+  withRouter,
+  connect(mapStateToProps),
+)(ScreenBase);


### PR DESCRIPTION
Wraps Aleph Screen component to allow us to use blueprint's default HotkeysTarget instead of hackily importing from the blueprint esnext build

Solves ui build issue in #1390 

