### PR TITLE
Display derived entities properly in EntityReferencesMode

### DIFF
--- a/ui/src/components/Entity/EntityReferencesMode.jsx
+++ b/ui/src/components/Entity/EntityReferencesMode.jsx
@@ -68,7 +68,7 @@ class EntityReferencesMode extends React.Component {
 
   renderCell(prop, entity) {
     const { schema, isThing } = this.props;
-    let content = <Property.Values prop={prop} values={entity.getProperty(prop)} />;
+    let content = <Property.Values prop={prop} values={entity.getProperty(prop.name)} />;
     if (isThing && schema.caption.indexOf(prop.name) !== -1) {
       content = <Entity.Link entity={entity}>{content}</Entity.Link>;
     }


### PR DESCRIPTION
I am a bit unsure about this fix. For the devired entities mode, it fixes the issue of not showing entities names

but I saw in other places that you are using `entity.getProperty(prop)` instead of `prop.name` as well... :thinking: 