### PR TITLE
Added authz to EntitySet.items() so we don't leak entities

### DIFF
--- a/aleph/model/entityset.py
+++ b/aleph/model/entityset.py
@@ -122,8 +122,11 @@ class EntitySet(db.Model, SoftDeleteModel):
         pq = pq.filter(cls.deleted_at == None)  # noqa
         pq.update({cls.deleted_at: deleted_at}, synchronize_session=False)
 
-    def items(self, deleted=False):
+    def items(self, authz=None, deleted=False):
         q = EntitySetItem.all(deleted=deleted)
+        if authz is not None:
+            ids = authz.collections(authz.READ)
+            q = q.filter(EntitySetItem.collection_id.in_(ids))
         q = q.filter(EntitySetItem.entityset_id == self.id)
         q = q.order_by(EntitySetItem.created_at.asc())
         return q

--- a/aleph/views/entitysets_api.py
+++ b/aleph/views/entitysets_api.py
@@ -278,7 +278,10 @@ def entities_update(entityset_id):
         sync = get_flag("sync", default=True)
         entity_id = upsert_entity(data, collection, authz=request.authz, sync=sync)
     EntitySetItem.save(
-        entityset, entity_id, collection_id=collection.id, added_by_id=request.authz.id,
+        entityset,
+        entity_id,
+        collection_id=collection.id,
+        added_by_id=request.authz.id,
     )
     db.session.commit()
     return entity_view(entity_id)
@@ -312,7 +315,7 @@ def item_index(entityset_id):
       - EntitySetItem
     """
     entityset = get_entityset(entityset_id, request.authz.READ)
-    result = DatabaseQueryResult(request, entityset.items())
+    result = DatabaseQueryResult(request, entityset.items(request.authz))
     return EntitySetItemSerializer.jsonify_result(result)
 
 


### PR DESCRIPTION
Even if a user has read access to an `EntitySet`, they may not have read access to all of the `EntitySetItem`s within that set. This PR uses `authz` to filter out those items so that they don't get leaked to the user.

This leaking will still be an issue until #1428 is resolved.