### PR TITLE
GET /entities/<entity_id>/entitysets Endpoint

### DIFF
--- a/aleph/logic/entitysets.py
+++ b/aleph/logic/entitysets.py
@@ -1,10 +1,25 @@
 import logging
 
-from aleph.model import EntitySet, EntitySetItem, Events
+from aleph.model import EntitySet, EntitySetItem, Events, Judgement
 from aleph.logic.entities import upsert_entity
 from aleph.logic.notifications import publish
 
 log = logging.getLogger(__name__)
+
+
+def get_entitysets_by_entity(
+    entity_id, collection_ids=None, judgements=None, types=None, labels=None
+):
+    if judgements is not None:
+        judgements = list(map(Judgement, judgements))
+    entitysets = EntitySet.by_entity_id(
+        entity_id,
+        collection_ids=collection_ids,
+        judgements=judgements,
+        types=types,
+        labels=labels,
+    )
+    return entitysets
 
 
 def get_entityset(entityset_id):

--- a/aleph/logic/profiles.py
+++ b/aleph/logic/profiles.py
@@ -77,7 +77,7 @@ def decide_xref(xref, judgement, authz):
     entity_profile = EntitySet.by_entity_id(
         entity_id,
         judgements=[Judgement.POSITIVE],
-        collection_id=collection.id,
+        collection_ids=[collection.id],
         types=[EntitySet.PROFILE],
     ).first()
 
@@ -86,7 +86,7 @@ def decide_xref(xref, judgement, authz):
     match_profile = EntitySet.by_entity_id(
         match_id,
         judgements=[Judgement.POSITIVE],
-        collection_id=collection.id,
+        collection_ids=[collection.id],
         types=[EntitySet.PROFILE],
     ).first()
 

--- a/aleph/model/entityset.py
+++ b/aleph/model/entityset.py
@@ -91,24 +91,27 @@ class EntitySet(db.Model, SoftDeleteModel):
 
     @classmethod
     def by_collection_id(cls, collection_id, types=None):
-        """Retuns EntitySets within a given collection_id
-        """
+        """Retuns EntitySets within a given collection_id"""
         q = cls.by_type(types)
         q = q.filter(EntitySet.collection_id == collection_id)
         return q
 
     @classmethod
-    def by_entity_id(cls, entity_id, collection_id=None, judgements=None, types=None):
+    def by_entity_id(
+        cls, entity_id, collection_ids=None, judgements=None, types=None, labels=None
+    ):
         """Retuns EntitySets that include EntitySetItems with the provided entity_id.
 
         NOTE: This only considers EntitySetItems who haven't been deleted
         """
         q = cls.by_type(types)
+        if labels is not None:
+            q = q.filter(EntitySet.label.in_(ensure_list(labels)))
         q = q.join(EntitySetItem)
         q = q.filter(EntitySetItem.deleted_at == None)  # NOQA
         q = q.filter(EntitySetItem.entity_id == entity_id)
-        if collection_id is not None:
-            q = q.filter(EntitySet.collection_id == collection_id)
+        if collection_ids:
+            q = q.filter(EntitySet.collection_id.in_(collection_ids))
         if judgements is not None:
             q = q.filter(EntitySetItem.judgement.in_(ensure_list(judgements)))
         return q

--- a/aleph/views/entities_api.py
+++ b/aleph/views/entities_api.py
@@ -13,9 +13,9 @@ from aleph.search.parser import SearchQueryParser, QueryParser
 from aleph.logic.entities import upsert_entity, delete_entity
 from aleph.logic.entities import entity_references, entity_tags, entity_expand
 from aleph.logic.entities import validate_entity, check_write_entity
-from aleph.logic.entitysets import get_entitysets_by_entity
 from aleph.logic.html import sanitize_html
 from aleph.logic.export import create_export
+from aleph.model.entityset import EntitySet, Judgement
 from aleph.index.util import MAX_PAGE
 from aleph.views.util import get_index_entity, get_db_collection
 from aleph.views.util import jsonify, parse_request, get_flag
@@ -651,8 +651,17 @@ def entity_entitysets(entity_id):
     labels = parser.filters.get("label")
     types = parser.filters.get("type")
 
-    entitysets = get_entitysets_by_entity(
-        entity["id"], collection_ids, judgements=judgements, types=types, labels=labels
+    if judgements is not None:
+        judgements = list(map(Judgement, judgements))
+    if not collection_ids:
+        collection_ids = request.authz.collections(request.authz.READ)
+
+    entitysets = EntitySet.by_entity_id(
+        entity["id"],
+        collection_ids=collection_ids,
+        judgements=judgements,
+        types=types,
+        labels=labels,
     )
 
     result = DatabaseQueryResult(request, entitysets, parser=parser)

--- a/aleph/views/entities_api.py
+++ b/aleph/views/entities_api.py
@@ -8,11 +8,12 @@ from followthemoney import model
 from pantomime.types import ZIP
 
 from aleph.core import db, url_for
-from aleph.search import EntitiesQuery, MatchQuery
+from aleph.search import EntitiesQuery, MatchQuery, DatabaseQueryResult
 from aleph.search.parser import SearchQueryParser, QueryParser
 from aleph.logic.entities import upsert_entity, delete_entity
 from aleph.logic.entities import entity_references, entity_tags, entity_expand
 from aleph.logic.entities import validate_entity, check_write_entity
+from aleph.logic.entitysets import get_entitysets_by_entity
 from aleph.logic.html import sanitize_html
 from aleph.logic.export import create_export
 from aleph.index.util import MAX_PAGE
@@ -20,7 +21,7 @@ from aleph.views.util import get_index_entity, get_db_collection
 from aleph.views.util import jsonify, parse_request, get_flag
 from aleph.views.util import require, get_nested_collection, get_session_id
 from aleph.views.context import enable_cache, tag_request
-from aleph.views.serializers import EntitySerializer
+from aleph.views.serializers import EntitySerializer, EntitySetSerializer
 from aleph.settings import MAX_EXPAND_ENTITIES
 from aleph.queues import queue_task, OP_EXPORT_SEARCH_RESULTS
 
@@ -576,3 +577,83 @@ def expand(entity_id):
             "results": results,
         }
     )
+
+
+@blueprint.route("/api/2/entities/<entity_id>/entitysets", methods=["GET"])
+def entity_entitysets(entity_id):
+    """Returns a list of entitysets which the entity has references in
+    ---
+    get:
+      summary: Shows EntitySets which reference the given entity
+      description: >-
+        Search for all entitysets which reference the given entity. The entity
+        sets can be filtered based on it's collection id, label, type or the
+        judgement of the entity within the set.
+      parameters:
+      - in: path
+        name: entity_id
+        required: true
+        schema:
+          type: string
+      - in: query
+        name: 'filter:type'
+        description: Restrict to a EntitySets of a particular type
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      - in: query
+        name: 'filter:label'
+        description: Restrict to a EntitySets with a particular label
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      - in: query
+        name: 'filter:judgement'
+        description: Restrict to a specific profile judgement
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+      - in: query
+        name: 'filter:collection_id'
+        description: Restrict to entity sets within particular collections
+        schema:
+          items:
+            type: string
+          type: array
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EntitySet'
+          description: OK
+      tags:
+      - Entity
+      - Profiles
+    """
+    entity = get_index_entity(entity_id, request.authz.READ)
+
+    parser = QueryParser(request.args, request.authz)
+    collection_ids = [
+        cid
+        for cid in parser.filters.get("collection_id", [])
+        if request.authz.can(cid, request.authz.READ)
+    ]
+    judgements = parser.filters.get("judgement")
+    labels = parser.filters.get("label")
+    types = parser.filters.get("type")
+
+    entitysets = get_entitysets_by_entity(
+        entity["id"], collection_ids, judgements=judgements, types=types, labels=labels
+    )
+
+    result = DatabaseQueryResult(request, entitysets, parser=parser)
+    return EntitySetSerializer.jsonify_result(result)


### PR DESCRIPTION
This adds a new endpoint attached to entities in order to find all EntitySets which reference the entity. The entitysets can be filtered based on type, collection_id, label or the judgement on the entity within the set.