### PR TITLE
Entity Table Fixes

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@alephdata/followthemoney": "2.1.11",
-    "@alephdata/react-ftm": "2.1.8",
+    "@alephdata/react-ftm": "2.1.8-alpha",
     "@blueprintjs/core": "3.36.0",
     "@blueprintjs/datetime": "^3.15.1",
     "@blueprintjs/icons": "3.23.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@alephdata/followthemoney": "2.1.11",
-    "@alephdata/react-ftm": "2.1.8-alpha",
+    "@alephdata/react-ftm": "2.1.9",
     "@blueprintjs/core": "3.36.0",
     "@blueprintjs/datetime": "^3.15.1",
     "@blueprintjs/icons": "3.23.0",

--- a/ui/src/components/Diagram/DiagramEditor.jsx
+++ b/ui/src/components/Diagram/DiagramEditor.jsx
@@ -63,7 +63,6 @@ class DiagramEditor extends React.Component {
     if (options?.propagate) {
       onStatusChange(UpdateStatus.IN_PROGRESS);
       const { selection, ...layoutData } = layout.toJSON();
-      const entities = entityManager.getEntities();
 
       const updatedDiagram = {
         ...diagram,

--- a/ui/src/components/Diagram/DiagramEditor.jsx
+++ b/ui/src/components/Diagram/DiagramEditor.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import { NetworkDiagram, GraphConfig, GraphLayout, Viewport } from '@alephdata/react-ftm';
 import entityEditorWrapper from 'components/Entity/entityEditorWrapper';
 import { updateEntitySet } from 'actions';
-import updateStates from 'util/updateStates';
+import { UpdateStatus } from 'components/common';
 
 import './DiagramEditor.scss';
 
@@ -61,7 +61,7 @@ class DiagramEditor extends React.Component {
     this.setState({ layout });
 
     if (options?.propagate) {
-      onStatusChange(updateStates.IN_PROGRESS);
+      onStatusChange(UpdateStatus.IN_PROGRESS);
       const { selection, ...layoutData } = layout.toJSON();
       const entities = entityManager.getEntities();
 
@@ -72,10 +72,10 @@ class DiagramEditor extends React.Component {
 
       this.props.updateEntitySet(updatedDiagram.id, updatedDiagram)
         .then(() => {
-          onStatusChange(updateStates.SUCCESS);
+          onStatusChange(UpdateStatus.SUCCESS);
         })
         .catch(() => {
-          onStatusChange(updateStates.ERROR);
+          onStatusChange(UpdateStatus.ERROR);
         });
     }
   }

--- a/ui/src/components/Entity/EntityActionBar.jsx
+++ b/ui/src/components/Entity/EntityActionBar.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
-import { Boundary, Button, ButtonGroup, ControlGroup, OverflowList, Popover } from '@blueprintjs/core';
-
-import { SearchBox } from 'components/common';
+import { Boundary, Button, ButtonGroup, ControlGroup, Divider, OverflowList, Popover } from '@blueprintjs/core';
+import c from 'classnames';
+import { SearchBox, UpdateStatus } from 'components/common';
 
 import './EntityActionBar.scss';
 
@@ -22,20 +22,27 @@ class EntityActionBar extends Component {
   }
 
   render() {
-    const { children, query, onSearchSubmit, searchDisabled, searchPlaceholder, writeable } = this.props;
+    const { children, query, onSearchSubmit, searchDisabled, searchPlaceholder, updateStatus, writeable } = this.props;
+
 
     return (
-      <>
-        <ControlGroup className="EntityActionBar">
-          {writeable && (
-            <OverflowList
-              items={children}
-              collapseFrom={Boundary.END}
-              visibleItemRenderer={(item, i) => <React.Fragment key={i}>{item}</React.Fragment>}
-              overflowRenderer={this.overflowListRenderer}
-              className="bp3-button-group"
-              observeParents
-            />
+      <ControlGroup className={c("EntityActionBar", {"show-status":!!updateStatus})}>
+        {writeable && (
+          <OverflowList
+            items={children}
+            collapseFrom={Boundary.END}
+            visibleItemRenderer={(item, i) => <React.Fragment key={i}>{item}</React.Fragment>}
+            overflowRenderer={this.overflowListRenderer}
+            className="bp3-button-group"
+            observeParents
+          />
+        )}
+        <div className="EntityActionBar__right">
+          {updateStatus && (
+            <>
+              <UpdateStatus status={updateStatus} />
+              <Divider />
+            </>
           )}
           <SearchBox
             onSearch={onSearchSubmit}
@@ -43,8 +50,8 @@ class EntityActionBar extends Component {
             query={query}
             inputProps={{ disabled: searchDisabled }}
           />
-        </ControlGroup>
-      </>
+        </div>
+      </ControlGroup>
     );
   }
 }

--- a/ui/src/components/Entity/EntityActionBar.scss
+++ b/ui/src/components/Entity/EntityActionBar.scss
@@ -2,7 +2,7 @@
 @import "app/mixins.scss";
 
 $search-bar-width: 200px;
-$status-width: 100px;
+$status-width: 120px;
 
 .EntityActionBar {
   margin-bottom: $aleph-grid-size;
@@ -29,7 +29,7 @@ $status-width: 100px;
   .bp3-overflow-list {
     width: calc(100% - #{$search-bar-width});
   }
-  
+
   &.show-status {
     .bp3-overflow-list {
       width: calc(100% - #{$search-bar-width} - #{$status-width});

--- a/ui/src/components/Entity/EntityActionBar.scss
+++ b/ui/src/components/Entity/EntityActionBar.scss
@@ -1,7 +1,8 @@
 @import "app/variables.scss";
 @import "app/mixins.scss";
 
-$search-bar-width: 250px;
+$search-bar-width: 200px;
+$status-width: 100px;
 
 .EntityActionBar {
   margin-bottom: $aleph-grid-size;
@@ -11,7 +12,6 @@ $search-bar-width: 250px;
     @include rtlSupportInvertedProp(margin, right, 1px, null);
 
     .bp3-input-group {
-      min-width: $search-bar-width;
       .bp3-input:not(:first-child) {
         @include rtlSupportInvertedProp(padding, left, $aleph-grid-size*3, null);
       }
@@ -27,7 +27,13 @@ $search-bar-width: 250px;
   }
 
   .bp3-overflow-list {
-    width: calc(100% - #{$search-bar-width + 10px});
+    width: calc(100% - #{$search-bar-width});
+  }
+  
+  &.show-status {
+    .bp3-overflow-list {
+      width: calc(100% - #{$search-bar-width} - #{$status-width});
+    }
   }
 
   &__delete, .bp3-popover-wrapper .bp3-button  {
@@ -43,6 +49,10 @@ $search-bar-width: 250px;
         @include rtlSupportInvertedProp(margin, left, $aleph-grid-size/2, null);
       }
     }
+  }
+
+  &__right {
+    display: flex;
   }
 
   .prevent-flex-grow.bp3-popover-wrapper {

--- a/ui/src/components/Entity/entityEditorWrapper.jsx
+++ b/ui/src/components/Entity/entityEditorWrapper.jsx
@@ -115,9 +115,8 @@ const entityEditorWrapper = (EditorComponent) => {
         }
       }
 
-      async deleteEntity(entity) {
+      async deleteEntity(entityId) {
         const { entitySetId, onStatusChange } = this.props;
-        const entityId = entity.id;
 
         onStatusChange(updateStates.IN_PROGRESS);
 

--- a/ui/src/components/Entity/entityEditorWrapper.jsx
+++ b/ui/src/components/Entity/entityEditorWrapper.jsx
@@ -16,7 +16,7 @@ import {
   queryEntityExpand,
   updateEntity
 } from 'actions';
-import updateStates from 'util/updateStates';
+import { UpdateStatus } from 'components/common';
 
 const entityEditorWrapper = (EditorComponent) => {
   const WrappedComponent = (
@@ -77,16 +77,16 @@ const entityEditorWrapper = (EditorComponent) => {
 
       async createEntity(entity) {
         const { collection, entitySetId, onStatusChange } = this.props;
-        onStatusChange(updateStates.IN_PROGRESS);
+        onStatusChange(UpdateStatus.IN_PROGRESS);
         try {
           if (entitySetId) {
             await this.props.entitySetAddEntity({ entity, entitySetId, sync: true });
           } else {
             await this.props.createEntity({ entity, collection_id: collection.id });
           }
-          onStatusChange(updateStates.SUCCESS);
+          onStatusChange(UpdateStatus.SUCCESS);
         } catch {
-          onStatusChange(updateStates.ERROR);
+          onStatusChange(UpdateStatus.ERROR);
         }
         return null;
       }
@@ -104,21 +104,21 @@ const entityEditorWrapper = (EditorComponent) => {
 
       async updateEntity(entity) {
         const { collection, onStatusChange } = this.props;
-        onStatusChange(updateStates.IN_PROGRESS);
+        onStatusChange(UpdateStatus.IN_PROGRESS);
 
         try {
           entity.collection = collection;
           await this.props.updateEntity(entity);
-          onStatusChange(updateStates.SUCCESS);
+          onStatusChange(UpdateStatus.SUCCESS);
         } catch {
-          onStatusChange(updateStates.ERROR);
+          onStatusChange(UpdateStatus.ERROR);
         }
       }
 
       async deleteEntity(entityId) {
         const { entitySetId, onStatusChange } = this.props;
 
-        onStatusChange(updateStates.IN_PROGRESS);
+        onStatusChange(UpdateStatus.IN_PROGRESS);
 
         try {
           if (entitySetId) {
@@ -126,9 +126,9 @@ const entityEditorWrapper = (EditorComponent) => {
           } else {
             await this.props.deleteEntity(entityId);
           }
-          onStatusChange(updateStates.SUCCESS);
+          onStatusChange(UpdateStatus.SUCCESS);
         } catch {
-          onStatusChange(updateStates.ERROR);
+          onStatusChange(UpdateStatus.ERROR);
         }
       }
 

--- a/ui/src/components/EntityTable/EntityTable.jsx
+++ b/ui/src/components/EntityTable/EntityTable.jsx
@@ -188,7 +188,7 @@ export class EntityTable extends Component {
   }
 
   render() {
-    const { collection, entityManager, query, intl, result, schema, isEntitySet, sort, writeable } = this.props;
+    const { collection, entityManager, query, intl, result, schema, isEntitySet, sort, updateStatus, writeable } = this.props;
     const { selection } = this.state;
     const visitEntity = schema.isThing() ? this.onEntityClick : undefined;
     const showEmptyComponent = result.total === 0 && query.hasQuery();
@@ -200,6 +200,7 @@ export class EntityTable extends Component {
           query={query}
           writeable={writeable}
           onSearchSubmit={this.onSearchSubmit}
+          updateStatus={updateStatus}
           searchPlaceholder={intl.formatMessage(messages.search_placeholder, { schema: schema.plural.toLowerCase() })}
           searchDisabled={result.total === 0 && !query.hasQuery()}
         >

--- a/ui/src/components/EntityTable/EntityTable.scss
+++ b/ui/src/components/EntityTable/EntityTable.scss
@@ -2,7 +2,7 @@
 @import "app/mixins.scss";
 
 .EntityTable {
-  .bp3-button-group {
+  .EntityActionBar {
     margin-bottom: $aleph-content-padding;
   }
 

--- a/ui/src/components/EntityTable/EntityTableViews.jsx
+++ b/ui/src/components/EntityTable/EntityTableViews.jsx
@@ -23,7 +23,12 @@ const messages = defineMessages({
 class EntityTableViews extends React.PureComponent {
   constructor(props) {
     super(props);
+    this.state = {
+      updateStatus: null,
+    };
+
     this.handleTabChange = this.handleTabChange.bind(this);
+    this.onStatusChange = this.onStatusChange.bind(this);
   }
 
   handleTabChange(type) {
@@ -38,13 +43,20 @@ class EntityTableViews extends React.PureComponent {
     });
   }
 
+  onStatusChange(updateStatus) {
+    this.setState({ updateStatus });
+  }
+
   renderTable() {
     const { collection, activeSchema, querySchemaEntities, isEntitySet, writeable } = this.props;
+    const { updateStatus } = this.state;
+
     return <EntityTable
       query={querySchemaEntities(activeSchema)}
       collection={collection}
       schema={activeSchema}
-      onStatusChange={() => { }}
+      onStatusChange={this.onStatusChange}
+      updateStatus={updateStatus}
       writeable={writeable}
       isEntitySet={isEntitySet}
     />;

--- a/ui/src/components/common/Breadcrumbs.jsx
+++ b/ui/src/components/common/Breadcrumbs.jsx
@@ -1,5 +1,5 @@
 import React, { PureComponent, Component } from 'react';
-import { Divider, Icon, Intent, Spinner, Tag } from '@blueprintjs/core';
+import { Icon } from '@blueprintjs/core';
 import c from 'classnames';
 
 import { Category, Collection, Entity, Skeleton, Restricted } from 'components/common';

--- a/ui/src/components/common/Breadcrumbs.jsx
+++ b/ui/src/components/common/Breadcrumbs.jsx
@@ -111,27 +111,8 @@ export default class Breadcrumbs extends Component {
 
   static Text = TextBreadcrumb;
 
-  renderStatus() {
-    const { text, intent } = this.props.status;
-    let icon;
-
-    if (intent === Intent.PRIMARY) {
-      icon = <Spinner size="16" intent={intent} />;
-    } else if (intent === Intent.SUCCESS) {
-      icon = 'tick';
-    } else {
-      icon = 'error';
-    }
-
-    return (
-      <Tag large minimal intent={intent} className="Breadcrumbs__status" icon={icon}>
-        {text}
-      </Tag>
-    );
-  }
-
   render() {
-    const { collection, children, operation, status } = this.props;
+    const { collection, children, operation } = this.props;
 
     const collectionCrumbs = [];
     if (collection) {
@@ -150,8 +131,6 @@ export default class Breadcrumbs extends Component {
             </ul>
           </div>
           <div className="Breadcrumbs__right">
-            {status && this.renderStatus()}
-            {status && operation && <Divider />}
             {operation}
           </div>
         </div>

--- a/ui/src/components/common/UpdateStatus.jsx
+++ b/ui/src/components/common/UpdateStatus.jsx
@@ -1,0 +1,93 @@
+import React, { PureComponent } from 'react';
+import { compose } from 'redux';
+import { defineMessages, injectIntl } from 'react-intl';
+import { Prompt, withRouter } from 'react-router';
+import c from 'classnames';
+import { Intent, Spinner, Tag } from '@blueprintjs/core';
+
+
+const messages = defineMessages({
+  status_success: {
+    id: 'diagram.status_success',
+    defaultMessage: 'Saved',
+  },
+  status_error: {
+    id: 'diagram.status_error',
+    defaultMessage: 'Error saving',
+  },
+  status_in_progress: {
+    id: 'diagram.status_in_progress',
+    defaultMessage: 'Saving...',
+  },
+  error_warning: {
+    id: 'diagram.error_warning',
+    defaultMessage: 'There was an error saving your latest changes, are you sure you want to leave?',
+  },
+  in_progress_warning: {
+    id: 'diagram.in_progress_warning',
+    defaultMessage: 'Changes are still being saved, are you sure you want to leave?',
+  },
+});
+
+class UpdateStatus extends PureComponent {
+  static SUCCESS = 'SUCCESS';
+  static ERROR = 'ERROR';
+  static IN_PROGRESS = 'IN_PROGRESS';
+
+  getStatusValue() {
+    switch (this.props.status) {
+      case 'IN_PROGRESS':
+        return ({
+          text: messages.status_in_progress,
+          intent: Intent.PRIMARY,
+          icon: <Spinner size="16" intent={Intent.PRIMARY} />
+        });
+      case 'ERROR':
+        return ({
+          text: messages.status_error,
+          intent: Intent.DANGER,
+          icon: 'error'
+        });
+      default:
+        return ({
+          text: messages.status_success,
+          intent: Intent.SUCCESS,
+          icon: 'tick'
+        });
+    }
+  }
+
+  render() {
+    const { intl, status } = this.props;
+    const { text, intent, icon } = this.getStatusValue();
+
+    return (
+      <>
+        <Prompt
+          when={status === 'IN_PROGRESS'}
+          message={intl.formatMessage(messages.in_progress_warning)}
+        />
+        <Prompt
+          when={status === 'ERROR'}
+          message={intl.formatMessage(messages.error_warning)}
+        />
+        <Tag large minimal intent={intent} className="UpdateStatus" icon={icon}>
+          {intl.formatMessage(text)}
+        </Tag>
+      </>
+    );
+  }
+}
+
+export default compose(
+  withRouter,
+  injectIntl
+)(UpdateStatus);
+
+// class UpdateStatus {
+//   static Label = connect(mapStateToProps)(CategoryLabel);
+//
+//   static Link = connect(mapStateToProps)(CategoryLink);
+// }
+//
+// export default Category;

--- a/ui/src/components/common/UpdateStatus.jsx
+++ b/ui/src/components/common/UpdateStatus.jsx
@@ -2,29 +2,27 @@ import React, { PureComponent } from 'react';
 import { compose } from 'redux';
 import { defineMessages, injectIntl } from 'react-intl';
 import { Prompt, withRouter } from 'react-router';
-import c from 'classnames';
 import { Intent, Spinner, Tag } from '@blueprintjs/core';
-
 
 const messages = defineMessages({
   status_success: {
-    id: 'diagram.status_success',
+    id: 'entity.status.success',
     defaultMessage: 'Saved',
   },
   status_error: {
-    id: 'diagram.status_error',
+    id: 'entity.status.error',
     defaultMessage: 'Error saving',
   },
   status_in_progress: {
-    id: 'diagram.status_in_progress',
+    id: 'entity.status.in_progress',
     defaultMessage: 'Saving...',
   },
   error_warning: {
-    id: 'diagram.error_warning',
+    id: 'entity.status.error_warning',
     defaultMessage: 'There was an error saving your latest changes, are you sure you want to leave?',
   },
   in_progress_warning: {
-    id: 'diagram.in_progress_warning',
+    id: 'entity.status.in_progress_warning',
     defaultMessage: 'Changes are still being saved, are you sure you want to leave?',
   },
 });
@@ -57,6 +55,11 @@ class UpdateStatus extends PureComponent {
     }
   }
 
+  showPrompt(location) {
+    const { pathname, hash } = window.location;
+    return location.pathname !== pathname || location.hash !== hash
+  }
+
   render() {
     const { intl, status } = this.props;
     const { text, intent, icon } = this.getStatusValue();
@@ -65,11 +68,19 @@ class UpdateStatus extends PureComponent {
       <>
         <Prompt
           when={status === 'IN_PROGRESS'}
-          message={intl.formatMessage(messages.in_progress_warning)}
+          message={location => {
+            if (this.showPrompt(location)) {
+              return intl.formatMessage(messages.in_progress_warning);
+            }
+          }}
         />
         <Prompt
           when={status === 'ERROR'}
-          message={intl.formatMessage(messages.error_warning)}
+          message={location => {
+            if (this.showPrompt(location)) {
+              return intl.formatMessage(messages.error_warning);
+            }
+          }}
         />
         <Tag large minimal intent={intent} className="UpdateStatus" icon={icon}>
           {intl.formatMessage(text)}
@@ -83,11 +94,3 @@ export default compose(
   withRouter,
   injectIntl
 )(UpdateStatus);
-
-// class UpdateStatus {
-//   static Label = connect(mapStateToProps)(CategoryLabel);
-//
-//   static Link = connect(mapStateToProps)(CategoryLink);
-// }
-//
-// export default Category;

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -35,6 +35,7 @@ import ResultCount from './ResultCount';
 import ResultText from './ResultText';
 import SelectWrapper from './SelectWrapper';
 import ExportLink from './ExportLink';
+import UpdateStatus from './UpdateStatus';
 
 
 export {
@@ -75,6 +76,7 @@ export {
   ResultText,
   SelectWrapper,
   ExportLink,
+  UpdateStatus,
 };
 
 export * from './types';

--- a/ui/src/screens/EntitySetIndexScreen/EntitySetIndexScreen.jsx
+++ b/ui/src/screens/EntitySetIndexScreen/EntitySetIndexScreen.jsx
@@ -9,7 +9,6 @@ import { selectEntitySetsResult } from 'selectors';
 import Query from 'app/Query';
 import Screen from 'components/Screen/Screen';
 import Dashboard from 'components/Dashboard/Dashboard';
-import ErrorScreen from 'components/Screen/ErrorScreen';
 import EntitySetCreateMenu from 'components/EntitySet/EntitySetCreateMenu';
 import EntitySetIndex from 'components/EntitySet/EntitySetIndex';
 

--- a/ui/src/screens/EntitySetScreens/DiagramScreen.jsx
+++ b/ui/src/screens/EntitySetScreens/DiagramScreen.jsx
@@ -1,10 +1,9 @@
 import React, { Component } from 'react';
-import { defineMessages, injectIntl } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { Prompt, withRouter } from 'react-router';
+import { withRouter } from 'react-router';
 import queryString from 'query-string';
-import { Divider, Intent } from '@blueprintjs/core';
+import { Divider } from '@blueprintjs/core';
 
 import { fetchEntitySet, queryEntitySetEntities } from 'actions';
 import { selectEntitySet, selectEntitiesResult } from 'selectors';
@@ -96,7 +95,7 @@ export class DiagramScreen extends Component {
   }
 
   render() {
-    const { diagram, entitiesResult, intl } = this.props;
+    const { diagram, entitiesResult } = this.props;
     const { downloadTriggered, filterText, updateStatus } = this.state;
 
     if (diagram.isError) {
@@ -167,6 +166,5 @@ const mapStateToProps = (state, ownProps) => {
 
 export default compose(
   withRouter,
-  injectIntl,
   connect(mapStateToProps, { fetchEntitySet, queryEntitySetEntities }),
 )(DiagramScreen);

--- a/ui/src/screens/EntitySetScreens/DiagramScreen.jsx
+++ b/ui/src/screens/EntitySetScreens/DiagramScreen.jsx
@@ -4,7 +4,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { Prompt, withRouter } from 'react-router';
 import queryString from 'query-string';
-import { Intent } from '@blueprintjs/core';
+import { Divider, Intent } from '@blueprintjs/core';
 
 import { fetchEntitySet, queryEntitySetEntities } from 'actions';
 import { selectEntitySet, selectEntitiesResult } from 'selectors';
@@ -14,31 +14,8 @@ import EntitySetManageMenu from 'components/EntitySet/EntitySetManageMenu';
 import DiagramEditor from 'components/Diagram/DiagramEditor';
 import LoadingScreen from 'components/Screen/LoadingScreen';
 import ErrorScreen from 'components/Screen/ErrorScreen';
-import { Breadcrumbs, Collection, EntitySet } from 'components/common';
-import updateStates from 'util/updateStates';
+import { Breadcrumbs, Collection, EntitySet, UpdateStatus } from 'components/common';
 
-const messages = defineMessages({
-  status_success: {
-    id: 'diagram.status_success',
-    defaultMessage: 'Saved',
-  },
-  status_error: {
-    id: 'diagram.status_error',
-    defaultMessage: 'Error saving',
-  },
-  status_in_progress: {
-    id: 'diagram.status_in_progress',
-    defaultMessage: 'Saving...',
-  },
-  error_warning: {
-    id: 'diagram.error_warning',
-    defaultMessage: 'There was an error saving your latest changes, are you sure you want to leave?',
-  },
-  in_progress_warning: {
-    id: 'diagram.in_progress_warning',
-    defaultMessage: 'Changes are still being saved, are you sure you want to leave?',
-  },
-});
 
 export class DiagramScreen extends Component {
   constructor(props) {
@@ -118,20 +95,6 @@ export class DiagramScreen extends Component {
     }
   }
 
-  formatStatus() {
-    const { intl } = this.props;
-    const { updateStatus } = this.state;
-
-    switch (updateStatus) {
-      case updateStates.IN_PROGRESS:
-        return { text: intl.formatMessage(messages.status_in_progress), intent: Intent.PRIMARY };
-      case updateStates.ERROR:
-        return { text: intl.formatMessage(messages.status_error), intent: Intent.DANGER };
-      default:
-        return { text: intl.formatMessage(messages.status_success), intent: Intent.SUCCESS };
-    }
-  }
-
   render() {
     const { diagram, entitiesResult, intl } = this.props;
     const { downloadTriggered, filterText, updateStatus } = this.state;
@@ -145,11 +108,19 @@ export class DiagramScreen extends Component {
     }
 
     const operation = (
-      <EntitySetManageMenu entitySet={diagram} triggerDownload={this.onDiagramDownload} onSearch={this.onDiagramSearch}/>
+      <>
+        {updateStatus && (
+          <>
+            <UpdateStatus status={updateStatus} />
+            <Divider />
+          </>
+        )}
+        <EntitySetManageMenu entitySet={diagram} triggerDownload={this.onDiagramDownload} onSearch={this.onDiagramSearch}/>
+      </>
     );
 
     const breadcrumbs = (
-      <Breadcrumbs operation={operation} status={this.formatStatus()}>
+      <Breadcrumbs operation={operation}>
         <Breadcrumbs.Collection key="collection" collection={diagram.collection} />
         <Breadcrumbs.Text active>
           <EntitySet.Label entitySet={diagram} icon />
@@ -159,14 +130,6 @@ export class DiagramScreen extends Component {
 
     return (
       <>
-        <Prompt
-          when={updateStatus === updateStates.IN_PROGRESS}
-          message={intl.formatMessage(messages.in_progress_warning)}
-        />
-        <Prompt
-          when={updateStatus === updateStates.ERROR}
-          message={intl.formatMessage(messages.error_warning)}
-        />
         <Screen
           title={diagram.label}
           description={diagram.summary || ''}

--- a/ui/src/screens/NotificationsScreen/NotificationsScreen.jsx
+++ b/ui/src/screens/NotificationsScreen/NotificationsScreen.jsx
@@ -28,7 +28,7 @@ const messages = defineMessages({
 
 export class NotificationsScreen extends React.Component {
   render() {
-    const { query, result, intl, role } = this.props;
+    const { query, intl, role } = this.props;
     const screenProps = {
       title: intl.formatMessage(messages.title),
       requireSession: true,

--- a/ui/src/util/updateStates.js
+++ b/ui/src/util/updateStates.js
@@ -1,5 +1,0 @@
-export default {
-  SUCCESS: 'SUCCESS',
-  ERROR: 'ERROR',
-  IN_PROGRESS: 'IN_PROGRESS',
-};


### PR DESCRIPTION
Fixes #1477 
Fixes #1474 

Re: #1478 
I still wasn't able to reproduce this issue with saving entity props, but I added a status tag to the table editor (the same that's in the diagram editor), so now you will at least be able to see whether an update request has completed/caused an error.

<img width="917" alt="Screen Shot 2020-11-26 at 18 35 37" src="https://user-images.githubusercontent.com/6720200/100381145-9d386800-3018-11eb-8907-3f4174fee3b0.png">

And like with the diagram, there's an alert if you try to navigate away from the screen while the status is in progress or error

<img width="642" alt="Screen Shot 2020-11-26 at 18 38 51" src="https://user-images.githubusercontent.com/6720200/100381138-99a4e100-3018-11eb-8277-a40a69c36cb0.png">

<img width="465" alt="Screen Shot 2020-11-26 at 18 39 41" src="https://user-images.githubusercontent.com/6720200/100381133-97428700-3018-11eb-9059-e9f465c8c3dc.png">

