### PR TITLE
Reflect default PDF rotation

### DIFF
--- a/ui/src/components/Toolbar/PagingButtons.jsx
+++ b/ui/src/components/Toolbar/PagingButtons.jsx
@@ -61,7 +61,7 @@ class PagingButtons extends React.Component {
   }
 
   render() {
-    const { document, numberOfPages, page, rotate, showRotateButtons } = this.props;
+    const { document, numberOfPages, page, showRotateButtons } = this.props;
     const { pageInputVal } = this.state;
 
     if (document.isPending || !document.links) {

--- a/ui/src/components/Toolbar/PagingButtons.jsx
+++ b/ui/src/components/Toolbar/PagingButtons.jsx
@@ -4,6 +4,8 @@ import { FormattedMessage } from 'react-intl';
 import queryString from 'query-string';
 import { ButtonGroup, AnchorButton, Divider, InputGroup } from '@blueprintjs/core';
 
+import normalizeDegreeValue from 'util/normalizeDegreeValue';
+
 import './PagingButtons.scss';
 
 
@@ -34,11 +36,11 @@ class PagingButtons extends React.Component {
     return queryString.stringify(parsedHash);
   }
 
-  getRotateLink(rotation) {
-    const { location } = this.props;
+  getRotateLink(rotateDelta) {
+    const { location, rotate } = this.props;
 
     const parsedHash = queryString.parse(location.hash);
-    parsedHash.rotate = rotation < 0 ? (360 + rotation) % 360 : rotation % 360;
+    parsedHash.rotate = normalizeDegreeValue((rotate || 0) + rotateDelta);
     return queryString.stringify(parsedHash);
   }
 
@@ -59,13 +61,12 @@ class PagingButtons extends React.Component {
   }
 
   render() {
-    const { document, numberOfPages, page, rotate } = this.props;
+    const { document, numberOfPages, page, rotate, showRotateButtons } = this.props;
     const { pageInputVal } = this.state;
 
     if (document.isPending || !document.links) {
       return null;
     }
-    const showRotateButtons = rotate !== undefined;
 
     // Only displays paging buttons on PDF docs
     // Having the logic here makes it easier to use this component.
@@ -97,8 +98,8 @@ class PagingButtons extends React.Component {
           </div>
           {showRotateButtons && (
             <>
-              <AnchorButton minimal href={`#${this.getRotateLink(rotate - 90)}`} icon="image-rotate-left" />
-              <AnchorButton minimal href={`#${this.getRotateLink(rotate + 90)}`} icon="image-rotate-right" />
+              <AnchorButton minimal href={`#${this.getRotateLink(-90)}`} icon="image-rotate-left" />
+              <AnchorButton minimal href={`#${this.getRotateLink(90)}`} icon="image-rotate-right" />
               <Divider />
             </>
           )}

--- a/ui/src/util/normalizeDegreeValue.js
+++ b/ui/src/util/normalizeDegreeValue.js
@@ -1,0 +1,3 @@
+export default function normalizeDegreeValue(value) {
+  return value < 0 ? (360 + value) % 360 : value % 360;
+}

--- a/ui/src/viewers/PdfViewer.jsx
+++ b/ui/src/viewers/PdfViewer.jsx
@@ -64,6 +64,7 @@ export class PdfViewer extends Component {
     window.removeEventListener('resize', throttle(this.onResize, 500));
   }
 
+  onDocumentLoad(pdf) {
     // Handle a resize event (to check document width) after loading
     // Note: onDocumentLoad actualy happens *before* rendering, but the
     // rendering calls happen a bit too often as we don't have sophisticated
@@ -85,7 +86,8 @@ export class PdfViewer extends Component {
   }
 
   setRotation() {
-    const { page, rotate } = this.props;
+    const { rotate } = this.props;
+    // For reference: https://github.com/wojtekmaj/react-pdf/issues/277#issuecomment-424464542
     if (this.pageData) {
       this.setState({
         effectiveRotation: normalizeDegreeValue(this.pageData.rotate + (rotate || 0))
@@ -131,6 +133,7 @@ export class PdfViewer extends Component {
     const { effectiveRotation, width } = this.state;
     const { Document, Page } = this.state.components;
     const loading = <Skeleton.Text type="div" length={4000} />;
+
     return (
       <>
         {numPages !== null && numPages > 0 && (

--- a/ui/src/viewers/PdfViewer.jsx
+++ b/ui/src/viewers/PdfViewer.jsx
@@ -9,6 +9,7 @@ import { PagingButtons } from 'components/Toolbar';
 import { SectionLoading, Skeleton } from 'components/common';
 import { queryEntities } from 'actions';
 import { selectEntitiesResult } from 'selectors';
+import normalizeDegreeValue from 'util/normalizeDegreeValue';
 import PdfViewerSearch from 'viewers/PdfViewerSearch';
 import PdfViewerPage from 'viewers/PdfViewerPage';
 
@@ -26,6 +27,7 @@ export class PdfViewer extends Component {
       },
     };
     this.onDocumentLoad = this.onDocumentLoad.bind(this);
+    this.onPageLoad = this.onPageLoad.bind(this);
     this.onResize = this.onResize.bind(this);
   }
 
@@ -48,6 +50,9 @@ export class PdfViewer extends Component {
         this.onResize();
       }, 350);
     }
+    if (prevProps.rotate !== this.props.rotate) {
+      this.setRotation();
+    }
     if (!countQuery.sameAs(prevProps.countQuery)) {
       this.onResize();
       this.fetchPage();
@@ -59,7 +64,6 @@ export class PdfViewer extends Component {
     window.removeEventListener('resize', throttle(this.onResize, 500));
   }
 
-  onDocumentLoad() {
     // Handle a resize event (to check document width) after loading
     // Note: onDocumentLoad actualy happens *before* rendering, but the
     // rendering calls happen a bit too often as we don't have sophisticated
@@ -73,6 +77,20 @@ export class PdfViewer extends Component {
       // it by a 1 or 2 pixels.
       this.onResize();
     }, 350);
+  }
+
+  onPageLoad(page) {
+    this.pageData = page;
+    this.setRotation();
+  }
+
+  setRotation() {
+    const { page, rotate } = this.props;
+    if (this.pageData) {
+      this.setState({
+        effectiveRotation: normalizeDegreeValue(this.pageData.rotate + (rotate || 0))
+      });
+    }
   }
 
   onResize() {
@@ -110,7 +128,7 @@ export class PdfViewer extends Component {
     const {
       document, page, rotate, numPages, pdfUrl,
     } = this.props;
-    const { width } = this.state;
+    const { effectiveRotation, width } = this.state;
     const { Document, Page } = this.state.components;
     const loading = <Skeleton.Text type="div" length={4000} />;
     return (
@@ -121,6 +139,7 @@ export class PdfViewer extends Component {
             rotate={rotate}
             document={document}
             numberOfPages={numPages}
+            showRotateButtons
           />
         )}
         <div key={pdfUrl}>
@@ -139,8 +158,9 @@ export class PdfViewer extends Component {
                 pageNumber={page}
                 className="page"
                 width={width}
-                rotate={rotate}
+                rotate={effectiveRotation}
                 loading={loading}
+                onLoadSuccess={this.onPageLoad}
               />
             )}
           </Document>
@@ -191,7 +211,7 @@ const mapStateToProps = (state, ownProps) => {
   const { document, location } = ownProps;
   const hashQuery = queryString.parse(location.hash);
   const page = parseInt(hashQuery.page, 10) || 1;
-  const rotate = parseInt(hashQuery.rotate, 10) || 0;
+  const rotate = hashQuery.rotate && parseInt(hashQuery.rotate, 10);
 
   const baseQuery = Query.fromLocation('entities', location, {}, 'document')
     .setFilter('properties.document', document.id)

--- a/ui/src/viewers/PdfViewerPage.jsx
+++ b/ui/src/viewers/PdfViewerPage.jsx
@@ -33,7 +33,7 @@ class PdfViewerPage extends Component {
     }
     return (
       <>
-        <PagingButtons document={document} numberOfPages={numPages} page={page} />
+        <PagingButtons document={document} numberOfPages={numPages} page={page} showRotateButtons={false} />
         {entity && (
           <TextViewer document={entity} dir={dir} noStyle />
         )}


### PR DESCRIPTION
Fixes #1511 

Captures underlying rotate orientation value from loaded pdf page, then applies UI rotation to this value

See:
https://github.com/wojtekmaj/react-pdf/issues/277#issuecomment-424464542