### PR TITLE
Replace "Personal dataset" with "Investigation" in UI

### DIFF
--- a/aleph/model/collection.py
+++ b/aleph/model/collection.py
@@ -41,7 +41,7 @@ class Collection(db.Model, IdModel, SoftDeleteModel):
         "customs": lazy_gettext("Customs declarations"),
         "census": lazy_gettext("Population census"),
         "transport": lazy_gettext("Air and maritime registers"),
-        "casefile": lazy_gettext("Personal datasets"),
+        "casefile": lazy_gettext("Investigations"),
         "other": lazy_gettext("Other material"),
     }
     CASEFILE = "casefile"

--- a/aleph/pages/home.en.md
+++ b/aleph/pages/home.en.md
@@ -40,7 +40,7 @@ samples: ["Vladimir Putin", "TeliaSonera"]
     <div className="HomeScreen__feature-block">
       <div className="HomeScreen__feature-block__content">
         <img src="/static/home_networks.svg" />
-        <p><b>Sketch out the defining connections</b> of your project in a personal dataset to keep track of your story as it develops.</p>
+        <p><b>Sketch out the defining connections</b> of your project in an investigation to keep track of your story as it develops.</p>
       </div>
     </div>
     <div className="HomeScreen__feature-block">

--- a/site/aleph.occrp.org/pages/about.en.md
+++ b/site/aleph.occrp.org/pages/about.en.md
@@ -5,7 +5,7 @@ menu: true
 icon: help
 ---
 
-OCCRP Aleph is an investigative data platform that helps reporters to **follow the money**. We provide access to a vast archive of public records, open databases, and leaked material. You can search the data, upload your own files to a personal dataset, or sketch a diagram to summarize your investigative findings.
+OCCRP Aleph is an investigative data platform that helps reporters to **follow the money**. We provide access to a vast archive of public records, open databases, and leaked material. You can search the data, upload your own files to an investigation, or sketch a diagram to summarize your investigative findings.
 
 ### What data is in Aleph?
 
@@ -17,7 +17,7 @@ On a technical note: Aleph is not just a document search engine. Aleph also impo
 
 ### Applying for journalist access
 
-Much of the Aleph archive is protected from public access due to concerns about data protection and civil rights. OCCRP may grant access to journalists with a track record of sound editorial judgement. 
+Much of the Aleph archive is protected from public access due to concerns about data protection and civil rights. OCCRP may grant access to journalists with a track record of sound editorial judgement.
 
 Please [fill out this form](https://forms.gle/Dm9eLbecFNKnAtRGA) if you would like to receive access to protected material on Aleph (“Friends of OCCRP” access). Journalists who are part of cross-border investigative projects with OCCRP are granted access implicitly.
 

--- a/site/aleph.occrp.org/pages/faq.en.md
+++ b/site/aleph.occrp.org/pages/faq.en.md
@@ -7,13 +7,13 @@ short: FAQ
 
 Aleph is not a whistleblowing platform. Please check out OCCRP’s [becoming a whistleblower](https://www.occrp.org/en/become-a-whistleblower/) page if you have documents that you want to share with our reporters.
 
-### How up-to-date is the data? 
+### How up-to-date is the data?
 
 This varies from dataset to dataset. While some sources are static, we run more than 200 scrapers to update official datasets on a weekly or monthly basis. Datasets that are updated automatically will show the update frequency in the dataset description.
 
 ### Can I add my own data to OCCRP Aleph?
 
-As a journalist with ‘Friends of OCCRP’ access, you’re invited to use Aleph to upload documents, or to make a dataset with your persons of interest. Aleph helps you to systematize your own research, share it with colleagues and cross-reference lists of people with our archive. You can also use Aleph as an OCR tool for scanned documents. 
+As a journalist with ‘Friends of OCCRP’ access, you’re invited to use Aleph to upload documents, or to create an investigation with your persons of interest. Aleph helps you to systematize your own research, share it with colleagues and cross-reference lists of people with our archive. You can also use Aleph as an OCR tool for scanned documents. 
 
 The data you upload will be visible to some members of OCCRP’s data team, but no other editorial staff. In some cases, the data team may offer to introduce you to journalists who are developing related stories.
 
@@ -27,7 +27,7 @@ Please file a request with [OCCRP ID](https://id.occrp.org) to suggest a dataset
 
 ### Can I use the Aleph software for my own project?
 
-Yes! Much of the software we’re building at OCCRP is open source, and we invest a lot of time to make sure other organizations can benefit from this technology as well. 
+Yes! Much of the software we’re building at OCCRP is open source, and we invest a lot of time to make sure other organizations can benefit from this technology as well.
 
 Please visit the [Aleph software documentation](https://docs.alephdata.org/developers/installation) for information on how to install and operate the software.
 

--- a/site/aleph.occrp.org/pages/home.en.md
+++ b/site/aleph.occrp.org/pages/home.en.md
@@ -66,7 +66,7 @@ samples:
     <div className="HomeScreen__feature-block">
       <div className="HomeScreen__feature-block__content">
         <img src="/static/home_networks.svg" />
-        <p><b>Sketch out the defining connections</b> of your project in a personal dataset to keep track of your story as it develops.</p>
+        <p><b>Sketch out the defining connections</b> of your project in an investigation to keep track of your story as it develops.</p>
       </div>
     </div>
     <div className="HomeScreen__feature-block">

--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -77,6 +77,7 @@ class Router extends Component {
           <Redirect from="/cases" to="/investigations" />
           <Redirect from="/collections/:collectionId/documents" to="/datasets/:collectionId" />
           <Route path="/datasets/:collectionId" exact component={CollectionScreen} />
+          <Route path="/investigations/:collectionId" exact component={CollectionScreen} />
           <Redirect from="/collections/:collectionId" to="/datasets/:collectionId" />
           <Redirect from="/collections/:collectionId/xref/:otherId" to="/datasets/:collectionId\?filter\:match_collection_id=:otherId#mode=xref" />
           <Redirect from="/datasets/:collectionId/xref/:otherId" to="/datasets/:collectionId\?filter\:match_collection_id=:otherId#mode=xref" />

--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -73,7 +73,8 @@ class Router extends Component {
           <Redirect from="/documents/:documentId" to="/entities/:documentId" />
           <Route path="/datasets" exact component={CollectionIndexScreen} />
           <Redirect from="/sources" to="/datasets" />
-          <Route path="/cases" exact component={CasesIndexScreen} />
+          <Route path="/investigations" exact component={CasesIndexScreen} />
+          <Redirect from="/cases" to="/investigations" />
           <Redirect from="/collections/:collectionId/documents" to="/datasets/:collectionId" />
           <Route path="/datasets/:collectionId" exact component={CollectionScreen} />
           <Redirect from="/collections/:collectionId" to="/datasets/:collectionId" />

--- a/ui/src/components/AuthButtons/AuthButtons.jsx
+++ b/ui/src/components/AuthButtons/AuthButtons.jsx
@@ -18,10 +18,6 @@ const messages = defineMessages({
     id: 'nav.view_notifications',
     defaultMessage: 'Notifications',
   },
-  casefiles: {
-    id: 'nav.casefiles',
-    defaultMessage: 'Investigations',
-  },
   diagrams: {
     id: 'nav.diagrams',
     defaultMessage: 'Network diagrams',
@@ -101,12 +97,6 @@ export class AuthButtons extends Component {
                   </div>
                 </Link>
                 <MenuDivider />
-                <Link to="/cases" className="bp3-menu-item">
-                  <Icon icon="briefcase" />
-                  <div className="bp3-text-overflow-ellipsis bp3-fill">
-                    {intl.formatMessage(messages.casefiles)}
-                  </div>
-                </Link>
                 <Link to="/diagrams" className="bp3-menu-item">
                   <Icon icon="graph" />
                   <div className="bp3-text-overflow-ellipsis bp3-fill">

--- a/ui/src/components/AuthButtons/AuthButtons.jsx
+++ b/ui/src/components/AuthButtons/AuthButtons.jsx
@@ -20,7 +20,7 @@ const messages = defineMessages({
   },
   casefiles: {
     id: 'nav.casefiles',
-    defaultMessage: 'Personal datasets',
+    defaultMessage: 'Investigations',
   },
   diagrams: {
     id: 'nav.diagrams',

--- a/ui/src/components/Collection/CollectionManageMenu.jsx
+++ b/ui/src/components/Collection/CollectionManageMenu.jsx
@@ -23,6 +23,10 @@ const messages = defineMessages({
     id: 'collection.info.delete',
     defaultMessage: 'Delete dataset',
   },
+  delete_casefile: {
+    id: 'collection.info.delete_casefile',
+    defaultMessage: 'Delete investigation',
+  },
   reingest: {
     id: 'collection.info.reingest',
     defaultMessage: 'Re-ingest documents',
@@ -62,7 +66,7 @@ class CollectionManageMenu extends PureComponent {
         <DialogToggleButton
           ButtonComponent={MenuItem}
           buttonProps={{
-            text: intl.formatMessage(messages.delete),
+            text: intl.formatMessage(messages[collection.casefile ? 'delete_casefile' : 'delete']),
             icon: "trash",
             shouldDismissPopover: false
           }}

--- a/ui/src/components/Collection/CollectionReindexAlert.jsx
+++ b/ui/src/components/Collection/CollectionReindexAlert.jsx
@@ -5,6 +5,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { triggerCollectionReindex } from 'actions';
 import { showSuccessToast } from 'app/toast';
+import { Collection } from 'components/common';
 
 
 const messages = defineMessages({
@@ -46,7 +47,7 @@ class CollectionReindexAlert extends Component {
   }
 
   render() {
-    const { intl, isOpen } = this.props;
+    const { collection, intl, isOpen } = this.props;
     return (
       <Alert
         cancelButtonText={intl.formatMessage(messages.cancel)}
@@ -62,7 +63,8 @@ class CollectionReindexAlert extends Component {
         <p>
           <FormattedMessage
             id="collection.analyze.alert.text"
-            defaultMessage="You're about to re-index the entities in this dataset. This can be helpful if there are inconsistencies in how the data is presented."
+            defaultMessage="You're about to re-index the entities in {collectionLabel}. This can be helpful if there are inconsistencies in how the data is presented."
+            values={{ collectionLabel: <Collection.Label collection={collection} icon={false} /> }}
           />
         </p>
         <Checkbox

--- a/ui/src/components/Collection/CollectionReingestAlert.jsx
+++ b/ui/src/components/Collection/CollectionReingestAlert.jsx
@@ -5,6 +5,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { triggerCollectionReingest } from 'actions';
 import { showSuccessToast } from 'app/toast';
+import { Collection } from 'components/common';
 
 
 const messages = defineMessages({
@@ -46,7 +47,7 @@ class CollectionReingestAlert extends Component {
   }
 
   render() {
-    const { intl, isOpen } = this.props;
+    const { collection, intl, isOpen } = this.props;
     return (
       <Alert
         cancelButtonText={intl.formatMessage(messages.cancel)}
@@ -62,7 +63,8 @@ class CollectionReingestAlert extends Component {
         <p>
           <FormattedMessage
             id="collection.reingest.text"
-            defaultMessage="You're about to re-process all documents in this dataset. This might take some time."
+            defaultMessage="You're about to re-process all documents in {collectionLabel}. This might take some time."
+            values={{ collectionLabel: <Collection.Label collection={collection} icon={false} /> }}
           />
         </p>
         <Checkbox

--- a/ui/src/components/Dashboard/Dashboard.jsx
+++ b/ui/src/components/Dashboard/Dashboard.jsx
@@ -132,8 +132,8 @@ class Dashboard extends React.Component {
                 icon="briefcase"
                 text={intl.formatMessage(messages.cases)}
                 label={<ResultCount result={casesCountResult} />}
-                onClick={() => this.navigate('/cases')}
-                active={current === '/cases'}
+                onClick={() => this.navigate('/investigations')}
+                active={current === '/investigations'}
               />
               <MenuItem
                 icon="graph"

--- a/ui/src/components/Dashboard/Dashboard.jsx
+++ b/ui/src/components/Dashboard/Dashboard.jsx
@@ -28,7 +28,7 @@ const messages = defineMessages({
   },
   cases: {
     id: 'dashboard.cases',
-    defaultMessage: 'Personal datasets',
+    defaultMessage: 'Investigations',
   },
   diagrams: {
     id: 'dashboard.diagrams',

--- a/ui/src/components/Entity/EntityInfoMode.jsx
+++ b/ui/src/components/Entity/EntityInfoMode.jsx
@@ -10,16 +10,25 @@ import './EntityInfoMode.scss';
 
 function EntityInfoMode(props) {
   const { entity } = props;
+  const isCasefile = entity.collection?.casefile;
   return (
     <EntityProperties entity={entity}>
       {entity.collection && (
         <li>
           <span className="key">
             <span>
-              <FormattedMessage
-                id="infoMode.collection"
-                defaultMessage="Dataset"
-              />
+              {isCasefile && (
+                <FormattedMessage
+                  id="infoMode.collection_casefile"
+                  defaultMessage="Investigation"
+                />
+              )}
+              {!isCasefile && (
+                <FormattedMessage
+                  id="infoMode.collection"
+                  defaultMessage="Dataset"
+                />
+              )}
             </span>
           </span>
           <Card elevation={0} className="value collection-info">

--- a/ui/src/components/Entity/EntityMappingMode.jsx
+++ b/ui/src/components/Entity/EntityMappingMode.jsx
@@ -105,7 +105,7 @@ export class EntityMappingMode extends Component {
           <p className="text-page-subtitle">
             <FormattedMessage
               id="mapping.info"
-              defaultMessage="Follow the steps below to map items in this dataset to structured Follow the Money entites. For more information, please refer to the {link}"
+              defaultMessage="Follow the steps below to map items in this investigation to structured Follow the Money entites. For more information, please refer to the {link}"
               values={{
                 link: (
                   <a

--- a/ui/src/components/MappingEditor/MappingEditor.jsx
+++ b/ui/src/components/MappingEditor/MappingEditor.jsx
@@ -211,7 +211,7 @@ export class MappingEditor extends Component {
                   <p className="MappingEditor__section__description">
                     <FormattedMessage
                       id="mapping.section4.description"
-                      defaultMessage="Generated entities will be added to {collection} by default. If you would like to additionally add them to a list or diagram within the dataset, please click below and select from the available options."
+                      defaultMessage="Generated entities will be added to {collection} by default. If you would like to additionally add them to a list or diagram within the investigation, please click below and select from the available options."
                       values={{ collection: <Collection.Label collection={document.collection} icon={false} /> }}
                     />
                   </p>

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -47,7 +47,7 @@ export class Navbar extends React.Component {
 
   render() {
     const {
-      metadata, pages, searchScopes, navbarRef, query, isHomepage,
+      metadata, pages, searchScopes, navbarRef, query, isHomepage, session,
     } = this.props;
     const { mobileSearchOpen } = this.state;
 
@@ -109,11 +109,13 @@ export class Navbar extends React.Component {
                     <FormattedMessage id="nav.collections" defaultMessage="Datasets" />
                   </Button>
                 </Link>
-                <Link to="/investigations">
-                  <Button icon="briefcase" className="Navbar_collections-button bp3-minimal">
-                    <FormattedMessage id="nav.cases" defaultMessage="Investigations" />
-                  </Button>
-                </Link>
+                {session.loggedIn && (
+                  <Link to="/investigations">
+                    <Button icon="briefcase" className="Navbar_collections-button bp3-minimal">
+                      <FormattedMessage id="nav.cases" defaultMessage="Investigations" />
+                    </Button>
+                  </Link>
+                )}
                 {menuPages.map(page => (
                   <Link to={getPageLink(page)} key={page.name}>
                     <Button icon={page.icon} className="Navbar_collections-button bp3-minimal">

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -105,20 +105,20 @@ export class Navbar extends React.Component {
             {!mobileSearchOpen && (
               <>
                 <Link to="/datasets">
-                  <Button icon="database" className="Navbar_collections-button bp3-minimal">
+                  <Button icon="database" className="Navbar__collections-button bp3-minimal">
                     <FormattedMessage id="nav.collections" defaultMessage="Datasets" />
                   </Button>
                 </Link>
                 {session.loggedIn && (
                   <Link to="/investigations">
-                    <Button icon="briefcase" className="Navbar_collections-button bp3-minimal">
+                    <Button icon="briefcase" className="Navbar__collections-button mobile-hide bp3-minimal">
                       <FormattedMessage id="nav.cases" defaultMessage="Investigations" />
                     </Button>
                   </Link>
                 )}
                 {menuPages.map(page => (
                   <Link to={getPageLink(page)} key={page.name}>
-                    <Button icon={page.icon} className="Navbar_collections-button bp3-minimal">
+                    <Button icon={page.icon} className="Navbar__collections-button mobile-hide bp3-minimal">
                       {page.short}
                     </Button>
                   </Link>

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -109,7 +109,7 @@ export class Navbar extends React.Component {
                     <FormattedMessage id="nav.collections" defaultMessage="Datasets" />
                   </Button>
                 </Link>
-                <Link to="/cases">
+                <Link to="/investigations">
                   <Button icon="briefcase" className="Navbar_collections-button bp3-minimal">
                     <FormattedMessage id="nav.cases" defaultMessage="Investigations" />
                   </Button>

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -109,6 +109,11 @@ export class Navbar extends React.Component {
                     <FormattedMessage id="nav.collections" defaultMessage="Datasets" />
                   </Button>
                 </Link>
+                <Link to="/cases">
+                  <Button icon="briefcase" className="Navbar_collections-button bp3-minimal">
+                    <FormattedMessage id="nav.cases" defaultMessage="Investigations" />
+                  </Button>
+                </Link>
                 {menuPages.map(page => (
                   <Link to={getPageLink(page)} key={page.name}>
                     <Button icon={page.icon} className="Navbar_collections-button bp3-minimal">

--- a/ui/src/components/Navbar/Navbar.scss
+++ b/ui/src/components/Navbar/Navbar.scss
@@ -104,7 +104,7 @@
     }
   }
 
-  &__collections-button {
+  &__collections-button.mobile-hide {
     @media screen and (max-width: $aleph-screen-sm-max-width) {
       display: none !important;
     }

--- a/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
+++ b/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
@@ -5,6 +5,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { deleteCollection } from 'actions';
+import { Collection } from 'components/common';
 
 
 const messages = defineMessages({
@@ -33,7 +34,7 @@ class CollectionDeleteDialog extends Component {
   }
 
   render() {
-    const { intl } = this.props;
+    const { collection, intl } = this.props;
     return (
       <Alert
         isOpen={this.props.isOpen}
@@ -46,7 +47,8 @@ class CollectionDeleteDialog extends Component {
       >
         <FormattedMessage
           id="collection.delete.question"
-          defaultMessage="Are you sure you want to delete this dataset and all contained items?"
+          defaultMessage="Are you sure you want to delete {collectionLabel} and all contained items?"
+          values={{ collectionLabel: <Collection.Label collection={collection} icon={false} /> }}
         />
       </Alert>
     );

--- a/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
+++ b/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
@@ -28,7 +28,7 @@ class CollectionDeleteDialog extends Component {
 
   async onDelete() {
     const { collection, history } = this.props;
-    const path = collection.casefile ? '/cases' : '/datasets';
+    const path = collection.casefile ? '/investigations' : '/datasets';
     await this.props.deleteCollection(collection);
     history.push({ pathname: path });
   }

--- a/ui/src/dialogs/CollectionEditDialog/CollectionEditDialog.jsx
+++ b/ui/src/dialogs/CollectionEditDialog/CollectionEditDialog.jsx
@@ -45,11 +45,11 @@ const messages = defineMessages({
   },
   check_restricted: {
     id: 'collection.edit.info.restricted',
-    defaultMessage: 'This collection is restricted and viewers should be warned.',
+    defaultMessage: 'This dataset is restricted and viewers should be warned.',
   },
   title: {
     id: 'collection.edit.title',
-    defaultMessage: 'Dataset settings',
+    defaultMessage: 'Settings',
   },
   delete_button: {
     id: 'collection.edit.info.delete',

--- a/ui/src/dialogs/CollectionXrefDialog/CollectionXrefDialog.jsx
+++ b/ui/src/dialogs/CollectionXrefDialog/CollectionXrefDialog.jsx
@@ -6,6 +6,7 @@ import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 
 import { triggerCollectionXref } from 'actions';
 import { showSuccessToast, showWarningToast } from 'app/toast';
+import { Collection } from 'components/common';
 
 
 const messages = defineMessages({
@@ -57,7 +58,7 @@ class CollectionXrefDialog extends Component {
   }
 
   render() {
-    const { intl } = this.props;
+    const { collection, intl } = this.props;
     return (
       <Dialog
         icon="comparison"
@@ -69,7 +70,8 @@ class CollectionXrefDialog extends Component {
         <div className="bp3-dialog-body">
           <FormattedMessage
             id="collection.xref.text"
-            defaultMessage="You will now cross-reference this dataset against all other sources. Start this process once and then wait for it to complete."
+            defaultMessage="You will now cross-reference {collectionLabel} against all other sources. Start this process once and then wait for it to complete."
+            values={{ collectionLabel: <Collection.Label collection={collection} icon={false} /> }}
           />
         </div>
         <div className="bp3-dialog-footer">

--- a/ui/src/dialogs/CreateCaseDialog/CreateCaseDialog.jsx
+++ b/ui/src/dialogs/CreateCaseDialog/CreateCaseDialog.jsx
@@ -16,7 +16,7 @@ import getCollectionLink from 'util/getCollectionLink';
 const messages = defineMessages({
   label_placeholder: {
     id: 'case.label_placeholder',
-    defaultMessage: 'Untitled dataset',
+    defaultMessage: 'Untitled investigation',
   },
   language_placeholder: {
     id: 'case.language_placeholder',
@@ -24,7 +24,7 @@ const messages = defineMessages({
   },
   summary_placeholder: {
     id: 'case.summary',
-    defaultMessage: 'A brief description of the dataset',
+    defaultMessage: 'A brief description of the investigation',
   },
   save: {
     id: 'case.save',

--- a/ui/src/dialogs/CreateCaseDialog/CreateCaseDialog.jsx
+++ b/ui/src/dialogs/CreateCaseDialog/CreateCaseDialog.jsx
@@ -36,7 +36,7 @@ const messages = defineMessages({
   },
   title: {
     id: 'case.title',
-    defaultMessage: 'Create a personal dataset',
+    defaultMessage: 'Create an investigation',
   },
 });
 

--- a/ui/src/dialogs/EntitySetCreateDialog/EntitySetCreateDialog.jsx
+++ b/ui/src/dialogs/EntitySetCreateDialog/EntitySetCreateDialog.jsx
@@ -20,7 +20,7 @@ const messages = defineMessages({
   },
   collection_select_placeholder: {
     id: 'entityset.create.collection.existing',
-    defaultMessage: 'Select a dataset',
+    defaultMessage: 'Select an investigation',
   },
   list_title: {
     id: 'list.create.title',
@@ -256,7 +256,7 @@ class EntitySetCreateDialog extends Component {
                 <div className="bp3-label">
                   <FormattedMessage
                     id="entityset.create.collection"
-                    defaultMessage="Dataset"
+                    defaultMessage="Investigation"
                   />
                   <Collection.Select
                     collection={collection}
@@ -270,7 +270,7 @@ class EntitySetCreateDialog extends Component {
                     <FormattedMessage
                       id='entityset.create.collection.new'
                       defaultMessage={
-                        `Don't see the dataset you're looking for? {link}`
+                        `Don't see the investigation you're looking for? {link}`
                       }
                       values={{
                          link: (

--- a/ui/src/dialogs/EntitySetCreateDialog/EntitySetCreateDialog.jsx
+++ b/ui/src/dialogs/EntitySetCreateDialog/EntitySetCreateDialog.jsx
@@ -279,7 +279,7 @@ class EntitySetCreateDialog extends Component {
                             <FormattedMessage
                               id='entityset.create.collection.new_link'
                               defaultMessage={
-                                `Create a new personal dataset`
+                                `Create a new investigation`
                               }
                             />
                           </a>

--- a/ui/src/screens/CasesIndexScreen/CasesIndexScreen.jsx
+++ b/ui/src/screens/CasesIndexScreen/CasesIndexScreen.jsx
@@ -15,23 +15,23 @@ import CaseCreateButton from 'components/Toolbar/CaseCreateButton';
 const messages = defineMessages({
   title: {
     id: 'cases.title',
-    defaultMessage: 'Personal datasets',
+    defaultMessage: 'Investigations',
   },
   empty: {
     id: 'cases.empty',
-    defaultMessage: 'You do not have any personal datasets yet.',
+    defaultMessage: 'You do not have any investigations yet.',
   },
   create: {
     id: 'cases.create',
-    defaultMessage: 'New personal dataset',
+    defaultMessage: 'New investigation',
   },
   placeholder: {
     id: 'cases.placeholder',
-    defaultMessage: 'Search personal datasets...',
+    defaultMessage: 'Search investigations...',
   },
   no_results: {
     id: 'cases.no_results',
-    defaultMessage: 'No personal datasets were found matching this query.',
+    defaultMessage: 'No investigations were found matching this query.',
   },
 });
 
@@ -63,7 +63,7 @@ export class CasesIndexScreen extends Component {
             <p className="Dashboard__subheading">
               <FormattedMessage
                 id="case.description"
-                defaultMessage="Personal datasets let you upload and share documents and data which belong to a particular story. You can upload PDFs, email archives or spreadsheets, and they will be made easy to search and browse."
+                defaultMessage="Investigations let you upload and share documents and data which belong to a particular story. You can upload PDFs, email archives or spreadsheets, and they will be made easy to search and browse."
               />
             </p>
             <div className="Dashboard__actions">

--- a/ui/src/screens/CollectionIndexScreen/CollectionIndexScreen.jsx
+++ b/ui/src/screens/CollectionIndexScreen/CollectionIndexScreen.jsx
@@ -4,7 +4,6 @@ import {
 } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { ButtonGroup } from '@blueprintjs/core';
 
 import Query from 'app/Query';
 import { queryCollections } from 'actions';
@@ -15,7 +14,6 @@ import {
 import SearchFacets from 'components/Facet/SearchFacets';
 import Screen from 'components/Screen/Screen';
 import CollectionIndex from 'components/CollectionIndex/CollectionIndex';
-import CaseCreateButton from 'components/Toolbar/CaseCreateButton';
 
 import './CollectionIndexScreen.scss';
 
@@ -32,10 +30,6 @@ const messages = defineMessages({
   empty: {
     id: 'collection.index.empty',
     defaultMessage: 'No datasets were found.',
-  },
-  create: {
-    id: 'collection.index.create',
-    defaultMessage: 'New dataset',
   },
   no_results: {
     id: 'collection.index.no_results',
@@ -67,16 +61,8 @@ export class CollectionIndexScreen extends Component {
 
   render() {
     const { result, query, intl } = this.props;
-    const operation = (
-      <ButtonGroup>
-        <CaseCreateButton
-          icon="database"
-          text={intl.formatMessage(messages.create)}
-        />
-      </ButtonGroup>
-    );
     const breadcrumbs = (
-      <Breadcrumbs operation={operation}>
+      <Breadcrumbs>
         <Breadcrumbs.Text icon="database">
           <FormattedMessage
             id="collection.index.breadcrumb"

--- a/ui/src/screens/CollectionIndexScreen/CollectionIndexScreen.jsx
+++ b/ui/src/screens/CollectionIndexScreen/CollectionIndexScreen.jsx
@@ -122,7 +122,10 @@ export class CollectionIndexScreen extends Component {
 }
 const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
-  let query = Query.fromLocation('collections', location, {}, 'collections')
+  const context = {
+    'exclude:category': 'casefile'
+  };
+  let query = Query.fromLocation('collections', location, context, 'collections')
     .defaultFacet('countries')
     .defaultFacet('category')
     .limit(40);

--- a/ui/src/screens/CollectionScreen/CollectionScreen.jsx
+++ b/ui/src/screens/CollectionScreen/CollectionScreen.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import queryString from 'query-string';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router';
+import { Redirect, withRouter } from 'react-router';
 
 import Screen from 'components/Screen/Screen';
 import CollectionManageMenu from 'components/Collection/CollectionManageMenu';
@@ -52,12 +52,22 @@ export class CollectionScreen extends Component {
 
   render() {
     const {
-      collection, collectionId, activeMode,
+      collection, collectionId, activeMode, location,
     } = this.props;
     const { extraBreadcrumbs } = this.props;
 
     if (collection.isError) {
       return <ErrorScreen error={collection.error} />;
+    }
+
+    if (!collection.isPending) {
+      const isCasefile = collection.casefile;
+      const pathPrefix = location.pathname.split('/')[1];
+      if (isCasefile && pathPrefix === 'datasets') {
+        return <Redirect to={`/investigations/${collectionId}`} />;
+      } else if (!isCasefile && pathPrefix === 'investigations') {
+        return <Redirect to={`/datasets/${collectionId}`} />;
+      }
     }
 
     const searchScope = {

--- a/ui/src/screens/EntitySetIndexScreen/EntitySetIndexScreen.jsx
+++ b/ui/src/screens/EntitySetIndexScreen/EntitySetIndexScreen.jsx
@@ -24,7 +24,7 @@ const messages = defineMessages({
   },
   diagram_description: {
     id: 'diagrams.description',
-    defaultMessage: 'Network diagrams let you visualize complex relationships within a dataset.',
+    defaultMessage: 'Network diagrams let you visualize complex relationships within an investigation.',
   },
   list_description: {
     id: 'lists.description',

--- a/ui/src/screens/GroupScreen/GroupScreen.jsx
+++ b/ui/src/screens/GroupScreen/GroupScreen.jsx
@@ -21,11 +21,11 @@ import './GroupScreen.scss';
 const messages = defineMessages({
   empty: {
     id: 'sources.index.empty',
-    defaultMessage: 'This group is not linked to any datasets.',
+    defaultMessage: 'This group is not linked to any datasets or investigations.',
   },
   placeholder: {
     id: 'sources.index.placeholder',
-    defaultMessage: 'Search datasets belonging to {group}...',
+    defaultMessage: 'Search datasets and investigations belonging to {group}...',
   },
 });
 
@@ -59,7 +59,7 @@ export class GroupScreen extends Component {
             <p className="Dashboard__subheading">
               <FormattedMessage
                 id="group.page.description"
-                defaultMessage="The list below shows all datasets that belong to this group."
+                defaultMessage="The list below shows all datasets and investigations that belong to this group."
               />
             </p>
           </div>

--- a/ui/src/screens/NotificationsScreen/NotificationsScreen.jsx
+++ b/ui/src/screens/NotificationsScreen/NotificationsScreen.jsx
@@ -48,7 +48,7 @@ export class NotificationsScreen extends React.Component {
             <p className="Dashboard__subheading">
               <FormattedMessage
                 id="notification.description"
-                defaultMessage="View the latest updates to datasets, groups and tracking alerts you follow."
+                defaultMessage="View the latest updates to datasets, investigations, groups and tracking alerts you follow."
               />
             </p>
           </div>

--- a/ui/src/util/getCategoryLink.js
+++ b/ui/src/util/getCategoryLink.js
@@ -1,4 +1,7 @@
 
 export default function getCategoryLink(category) {
+  if (category === 'casefile') {
+    return '/investigations'
+  }
   return `/datasets?collectionsfilter%3Acategory=${category}`;
 }

--- a/ui/src/util/getCollectionLink.js
+++ b/ui/src/util/getCollectionLink.js
@@ -1,3 +1,10 @@
 export default function getCollectionLink(collection) {
-  return (collection && collection.id) ? `/datasets/${collection.id}` : null;
+  if (collection && collection.id) {
+    if (collection.casefile) {
+      return `/investigations/${collection.id}`;
+    } else {
+      return `/datasets/${collection.id}`;
+    }
+  }
+  return null;
 }


### PR DESCRIPTION
- replaced mentions of "personal dataset" with "investigation"
- new routes (with redirects) for /investigations and /investigation/:id