### PR TITLE
Added `sample-entities` aleph command

### DIFF
--- a/aleph/index/entities.py
+++ b/aleph/index/entities.py
@@ -1,5 +1,6 @@
 import logging
 import fingerprints
+import warnings
 from pprint import pprint, pformat  # noqa
 from banal import ensure_list, first
 from followthemoney import model
@@ -64,6 +65,7 @@ def iter_entities(
     excludes=None,
     filters=None,
     sort=None,
+    randomize=False,
     random_seed=None,
 ):
     """Scan all entities matching the given criteria."""
@@ -72,7 +74,12 @@ def iter_entities(
     }
     q = _entities_query(filters, authz, collection_id, schemata)
     preserve_order = False
-    if sort == "random":
+    if randomize:
+        if sort is not None:
+            warnings.warn(
+                "iter_entities: randomize and sort are mutually exclusive. ignoring sort order.",
+                RuntimeWarning,
+            )
         seed_q = {"field": "_seq_no"}
         if random_seed:
             seed_q["seed"] = random_seed

--- a/aleph/manage.py
+++ b/aleph/manage.py
@@ -279,7 +279,7 @@ def sample_entities(secret, properties, schematas, seed, sample_pct, limit, outf
     iter_proxies_kwargs = {
         "authz": authz,
         "schemata": schematas or None,
-        "sort": "random",
+        "randomize": True,
         "random_seed": seed,
     }
     n_entities = 0

--- a/aleph/model/collection.py
+++ b/aleph/model/collection.py
@@ -218,6 +218,13 @@ class Collection(db.Model, IdModel, SoftDeleteModel):
         return cls._apply_authz(q, authz)
 
     @classmethod
+    def all_by_secret(cls, secret, authz=None):
+        q = super(Collection, cls).all()
+        if secret is not None:
+            q = q.filter(Collection.restricted == secret)
+        return cls._apply_authz(q, authz)
+
+    @classmethod
     def create(cls, data, authz, created_at=None):
         foreign_id = data.get("foreign_id") or make_textid()
         collection = cls.by_foreign_id(foreign_id, deleted=True)


### PR DESCRIPTION
This command is meant to serve any modeling needs by providing random
samples of data from aleph. The data can be filtered by whether it comes
from a secret collection or not and we can subsample and fix the random
seed. There is also filtering on entity schema in addition to which
properties must exist in the entity.

```
$ aleph sample-entities --help
Usage: aleph sample-entities [OPTIONS] [OUTFILE]
  Sample random entities
Options:
  --secret BOOLEAN     Whether to sample from secret collections (None means
                       sample from both)
  -p, --property TEXT  Entities must have at least one of the listed
                       properties
  -s, --schemata TEXT  Filter schematas
  --seed INTEGER       Set the random seed
  --sample-pct FLOAT   Random sampling percent (value from 0-1)
  --limit INTEGER      Number of entities to return
  --help               Show this message and exit.
```