### PR TITLE
Infinite Scroll Debugging

### DIFF
--- a/ui/src/components/EntitySearch/EntitySearchResults.scss
+++ b/ui/src/components/EntitySearch/EntitySearchResults.scss
@@ -30,10 +30,6 @@
     background: $aleph-text-highlight-color;
     font-style: normal;
   }
-
-  .bp3-skeleton {
-    height: 42px;
-  }
 }
 
 //medium and small screen

--- a/ui/src/components/EntitySet/EntitySetIndex.jsx
+++ b/ui/src/components/EntitySet/EntitySetIndex.jsx
@@ -2,9 +2,8 @@ import React, { Component } from 'react';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
-import { Waypoint } from 'react-waypoint';
 import { Button, Intent } from '@blueprintjs/core';
-import { ErrorSection } from 'components/common';
+import { ErrorSection, QueryInfiniteLoad } from 'components/common';
 import { queryEntitySets } from 'actions';
 import EntitySetIndexItem from 'components/EntitySet/EntitySetIndexItem';
 
@@ -22,11 +21,6 @@ const messages = defineMessages({
 });
 
 class EntitySetIndex extends Component {
-  constructor(props) {
-    super(props);
-    this.getMoreResults = this.getMoreResults.bind(this);
-  }
-
   componentDidMount() {
     this.fetchIfNeeded();
   }
@@ -42,15 +36,8 @@ class EntitySetIndex extends Component {
     }
   }
 
-  getMoreResults() {
-    const { query, result } = this.props;
-    if (result && !result.isPending && result.next && !result.isError) {
-      this.props.queryEntitySets({ query, next: result.next });
-    }
-  }
-
   render() {
-    const { intl, loadMoreOnScroll, onSelect, result, showCollection, type } = this.props;
+    const { intl, loadMoreOnScroll, onSelect, query, result, showCollection, type } = this.props;
 
     const isPending = result.isPending && !result.total;
     const skeletonItems = [...Array(8).keys()];
@@ -87,10 +74,10 @@ class EntitySetIndex extends Component {
           ))}
         </ul>
         {loadMoreOnScroll && (
-          <Waypoint
-            onEnter={this.getMoreResults}
-            bottomOffset="0"
-            scrollableAncestor={window}
+          <QueryInfiniteLoad
+            query={query}
+            result={result}
+            fetch={this.props.queryEntitySets}
           />
         )}
         {showLoadMoreButton && (

--- a/ui/src/components/EntityTable/EntityTable.jsx
+++ b/ui/src/components/EntityTable/EntityTable.jsx
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import { Divider } from '@blueprintjs/core';
-import { Waypoint } from 'react-waypoint';
 import _ from 'lodash';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -10,7 +9,7 @@ import queryString from 'query-string';
 import { EdgeCreateDialog, TableEditor } from '@alephdata/react-ftm';
 
 import entityEditorWrapper from 'components/Entity/entityEditorWrapper';
-import { Count, ErrorSection } from 'components/common';
+import { Count, ErrorSection, QueryInfiniteLoad } from 'components/common';
 import { DialogToggleButton } from 'components/Toolbar';
 import EntitySetSelector from 'components/EntitySet/EntitySetSelector';
 import DocumentSelectDialog from 'dialogs/DocumentSelectDialog/DocumentSelectDialog';
@@ -62,7 +61,6 @@ export class EntityTable extends Component {
       selection: [],
     };
     this.updateQuery = this.updateQuery.bind(this);
-    this.getMoreResults = this.getMoreResults.bind(this);
     this.updateSelection = this.updateSelection.bind(this);
     this.onSortColumn = this.onSortColumn.bind(this);
     this.onSearchSubmit = this.onSearchSubmit.bind(this);
@@ -78,13 +76,6 @@ export class EntityTable extends Component {
 
   componentDidUpdate() {
     this.fetchIfNeeded();
-  }
-
-  getMoreResults() {
-    const { query, result } = this.props;
-    if (result.next && !result.isPending && !result.isError) {
-      this.props.queryEntities({ query, next: result.next });
-    }
   }
 
   fetchIfNeeded() {
@@ -283,10 +274,10 @@ export class EntityTable extends Component {
                 isPending={result.total === undefined}
                 visitEntity={visitEntity}
               />
-              <Waypoint
-                onEnter={this.getMoreResults}
-                bottomOffset="0"
-                scrollableAncestor={window}
+              <QueryInfiniteLoad
+                query={query}
+                result={result}
+                fetch={this.props.queryEntities}
               />
             </>
           )}

--- a/ui/src/components/EntityTable/EntityTable.jsx
+++ b/ui/src/components/EntityTable/EntityTable.jsx
@@ -285,7 +285,7 @@ export class EntityTable extends Component {
               />
               <Waypoint
                 onEnter={this.getMoreResults}
-                bottomOffset="-600px"
+                bottomOffset="0"
                 scrollableAncestor={window}
               />
             </>

--- a/ui/src/components/common/QueryInfiniteLoad.jsx
+++ b/ui/src/components/common/QueryInfiniteLoad.jsx
@@ -18,9 +18,7 @@ class QueryInfiniteLoad extends Component {
 
   getMoreResults() {
     const { query, result } = this.props;
-    if (result && result.next && !result.isPending && !result.isError) {
-      this.props.fetch({ query, result, next: result.next });
-    }
+    this.props.fetch({ query, result, next: result.next });
   }
 
   fetchIfNeeded() {
@@ -31,13 +29,20 @@ class QueryInfiniteLoad extends Component {
   }
 
   render() {
-    return (
-      <Waypoint
-        onEnter={this.getMoreResults}
-        bottomOffset="-300px"
-        scrollableAncestor={window}
-      />
-    );
+    const { result } = this.props;
+    const canLoadMore = result && result.next && !result.isPending && !result.isError;
+
+    if (canLoadMore) {
+      return (
+        <Waypoint
+          onEnter={this.getMoreResults}
+          bottomOffset="-100px"
+          scrollableAncestor={window}
+        />
+      );
+    }
+
+    return null;
   }
 }
 

--- a/ui/src/components/common/ResultText.jsx
+++ b/ui/src/components/common/ResultText.jsx
@@ -5,11 +5,11 @@ import { FormattedNumber, FormattedMessage } from 'react-intl';
 class ResultText extends PureComponent {
   renderText() {
     const { result } = this.props;
-    if (!result || result.isPending) {
-      return <FormattedMessage id="result.searching" defaultMessage="Searching..." />;
-    }
-    if (result.isError) {
+    if (result?.isError) {
       return <FormattedMessage id="result.error" defaultMessage="Error" />;
+    }
+    if (!result || result.total == undefined) {
+      return <FormattedMessage id="result.searching" defaultMessage="Searching..." />;
     }
     if (result.total_type === 'gte') {
       return (


### PR DESCRIPTION
I modified the QueryInfiniteLoad component to only render the waypoint when loading more results is actually possible.  
This handles cases where:
- a user's viewport is larger than the first page of results, so the waypoint was never be triggered
- a user scrolls to the next waypoint while the previous page is still pending -> now the request for the next page will be sent when the previous page request is finished