### PR TITLE
UI: PDF Viewer fixes

### DIFF
--- a/ui/src/components/Document/DocumentViewMode.jsx
+++ b/ui/src/components/Document/DocumentViewMode.jsx
@@ -1,4 +1,4 @@
-import React, { lazy } from 'react';
+import React, { lazy, Suspense } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -15,6 +15,7 @@ import FolderViewer from 'viewers/FolderViewer';
 import EmailViewer from 'viewers/EmailViewer';
 import VideoViewer from 'viewers/VideoViewer';
 import EntityActionBar from 'components/Entity/EntityActionBar';
+import { SectionLoading } from 'components/common';
 import { selectEntityDirectionality } from 'selectors';
 
 import './DocumentViewMode.scss';
@@ -123,12 +124,14 @@ export class DocumentViewMode extends React.Component {
     }
     if (document.schema.isA('Pages')) {
       return (
-        <PdfViewer
-          document={document}
-          queryText={queryText}
-          activeMode={activeMode}
-          dir={dir}
-        />
+        <Suspense fallback={<SectionLoading />}>
+          <PdfViewer
+            document={document}
+            queryText={queryText}
+            activeMode={activeMode}
+            dir={dir}
+          />
+        </Suspense>
       );
     }
     if (document.schema.isA('Folder')) {

--- a/ui/src/viewers/PdfViewer.jsx
+++ b/ui/src/viewers/PdfViewer.jsx
@@ -123,8 +123,12 @@ export class PdfViewer extends Component {
   }
 
   fetchComponents() {
-    import(/* webpackChunkName:'pdf-lib' */'react-pdf/dist/esm/entry.webpack')
-      .then((components) => this.setState({ components }));
+    import(/* webpackChunkName:'pdf-lib' */'react-pdf')
+      .then(({ Document, Page, pdfjs }) => {
+        // see https://github.com/wojtekmaj/react-pdf#create-react-app
+        pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
+        this.setState({ components: { Document, Page }});
+      });
   }
 
   renderPdf() {

--- a/ui/src/viewers/PdfViewer.jsx
+++ b/ui/src/viewers/PdfViewer.jsx
@@ -12,6 +12,8 @@ import { selectEntitiesResult } from 'selectors';
 import normalizeDegreeValue from 'util/normalizeDegreeValue';
 import PdfViewerSearch from 'viewers/PdfViewerSearch';
 import PdfViewerPage from 'viewers/PdfViewerPage';
+// eslint-disable-next-line
+import PdfjsWorker from 'file-loader!pdfjs-dist/build/pdf.worker.min.js';
 
 import './PdfViewer.scss';
 
@@ -126,7 +128,7 @@ export class PdfViewer extends Component {
     import(/* webpackChunkName:'pdf-lib' */'react-pdf')
       .then(({ Document, Page, pdfjs }) => {
         // see https://github.com/wojtekmaj/react-pdf#create-react-app
-        pdfjs.GlobalWorkerOptions.workerSrc = `//cdnjs.cloudflare.com/ajax/libs/pdf.js/${pdfjs.version}/pdf.worker.js`;
+        pdfjs.GlobalWorkerOptions.workerSrc = PdfjsWorker;
         this.setState({ components: { Document, Page }});
       });
   }


### PR DESCRIPTION
Fixes #1570 
I spent probably way too long trying to figure out a way to do this without the CDN, but it really seems that's the only way to ensure the pdf worker is loaded correctly - and is the officially recommended approach when using an un-ejected create-react-app. But PDFs are now loading so much more smoothly and it seems quickly as well.

This PR also fixes an issue where the entire app would flash into a brief loading state when the PDFViewer was lazy loaded for the first time.