### PR TITLE
UI: Avoid re-rendering top nav

### DIFF
--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -5,8 +5,9 @@ import { Spinner } from '@blueprintjs/core';
 
 import { fetchMetadata } from 'actions';
 import { selectSession, selectMetadata } from 'selectors';
-import NotFoundScreen from 'screens/NotFoundScreen/NotFoundScreen';
+import Navbar from 'components/Navbar/Navbar';
 
+import NotFoundScreen from 'screens/NotFoundScreen/NotFoundScreen';
 import OAuthScreen from 'screens/OAuthScreen/OAuthScreen';
 import LogoutScreen from 'screens/LogoutScreen/LogoutScreen';
 import ActivateScreen from 'screens/ActivateScreen/ActivateScreen';
@@ -62,42 +63,45 @@ class Router extends Component {
     }
 
     return (
-      <Suspense fallback={Loading}>
-        <Switch>
-          <Route path="/oauth" exact component={OAuthScreen} />
-          <Route path="/logout" exact component={LogoutScreen} />
-          <Route path="/pages/:page" exact component={PagesScreen} />
-          <Route path="/activate/:code" exact component={ActivateScreen} />
-          <Route path="/entities/:entityId" exact component={EntityScreen} />
-          <Redirect from="/text/:documentId" to="/entities/:documentId" />
-          <Redirect from="/tabular/:documentId/:sheet" to="/entities/:documentId" />
-          <Redirect from="/documents/:documentId" to="/entities/:documentId" />
-          <Route path="/datasets" exact component={DatasetIndexScreen} />
-          <Redirect from="/sources" to="/datasets" />
-          <Route path="/investigations" exact component={InvestigationIndexScreen} />
-          <Redirect from="/cases" to="/investigations" />
-          <Redirect from="/collections/:collectionId/documents" to="/datasets/:collectionId" />
-          <Route path="/datasets/:collectionId" exact component={CollectionScreen} />
-          <Route path="/investigations/:collectionId" exact component={InvestigationScreen} />
-          <Redirect from="/collections/:collectionId" to="/datasets/:collectionId" />
-          <Redirect from="/collections/:collectionId/xref/:otherId" to="/datasets/:collectionId\?filter\:match_collection_id=:otherId#mode=xref" />
-          <Redirect from="/datasets/:collectionId/xref/:otherId" to="/datasets/:collectionId\?filter\:match_collection_id=:otherId#mode=xref" />
-          <Route path="/profiles/:profileId" exact component={ProfileScreen} />
-          <Route path="/diagrams/:entitySetId" exact component={DiagramScreen} />
-          <Route path="/diagrams" exact component={EntitySetIndexScreen} />
-          <Route path="/lists/:entitySetId" exact component={ListScreen} />
-          <Route path="/lists" exact component={EntitySetIndexScreen} />
-          <Route path="/search" exact component={SearchScreen} />
-          <Route path="/notifications" exact component={NotificationsScreen} />
-          <Route path="/alerts" exact component={AlertsScreen} />
-          <Route path="/exports" exact component={ExportsScreen} />
-          <Route path="/settings" exact component={SettingsScreen} />
-          <Route path="/status" exact component={SystemStatusScreen} />
-          <Route path="/groups/:groupId" exact component={GroupScreen} />
-          <Route path="/" exact component={HomeScreen} />
-          <Route component={NotFoundScreen} />
-        </Switch>
-      </Suspense>
+      <>
+        <Navbar />
+        <Suspense fallback={Loading}>
+          <Switch>
+            <Route path="/oauth" exact component={OAuthScreen} />
+            <Route path="/logout" exact component={LogoutScreen} />
+            <Route path="/pages/:page" exact component={PagesScreen} />
+            <Route path="/activate/:code" exact component={ActivateScreen} />
+            <Route path="/entities/:entityId" exact component={EntityScreen} />
+            <Redirect from="/text/:documentId" to="/entities/:documentId" />
+            <Redirect from="/tabular/:documentId/:sheet" to="/entities/:documentId" />
+            <Redirect from="/documents/:documentId" to="/entities/:documentId" />
+            <Route path="/datasets" exact component={DatasetIndexScreen} />
+            <Redirect from="/sources" to="/datasets" />
+            <Route path="/investigations" exact component={InvestigationIndexScreen} />
+            <Redirect from="/cases" to="/investigations" />
+            <Redirect from="/collections/:collectionId/documents" to="/datasets/:collectionId" />
+            <Route path="/datasets/:collectionId" exact component={CollectionScreen} />
+            <Route path="/investigations/:collectionId" exact component={InvestigationScreen} />
+            <Redirect from="/collections/:collectionId" to="/datasets/:collectionId" />
+            <Redirect from="/collections/:collectionId/xref/:otherId" to="/datasets/:collectionId\?filter\:match_collection_id=:otherId#mode=xref" />
+            <Redirect from="/datasets/:collectionId/xref/:otherId" to="/datasets/:collectionId\?filter\:match_collection_id=:otherId#mode=xref" />
+            <Route path="/profiles/:profileId" exact component={ProfileScreen} />
+            <Route path="/diagrams/:entitySetId" exact component={DiagramScreen} />
+            <Route path="/diagrams" exact component={EntitySetIndexScreen} />
+            <Route path="/lists/:entitySetId" exact component={ListScreen} />
+            <Route path="/lists" exact component={EntitySetIndexScreen} />
+            <Route path="/search" exact component={SearchScreen} />
+            <Route path="/notifications" exact component={NotificationsScreen} />
+            <Route path="/alerts" exact component={AlertsScreen} />
+            <Route path="/exports" exact component={ExportsScreen} />
+            <Route path="/settings" exact component={SettingsScreen} />
+            <Route path="/status" exact component={SystemStatusScreen} />
+            <Route path="/groups/:groupId" exact component={GroupScreen} />
+            <Route path="/" exact component={HomeScreen} />
+            <Route component={NotFoundScreen} />
+          </Switch>
+        </Suspense>
+      </>
     );
   }
 }

--- a/ui/src/components/AdvancedSearch/AdvancedSearch.jsx
+++ b/ui/src/components/AdvancedSearch/AdvancedSearch.jsx
@@ -217,12 +217,12 @@ class AdvancedSearch extends React.Component {
   }
 
   render() {
-    const { navbarRef } = this.props;
+    const { isOpen, navbarRef } = this.props;
 
     return (
       <div className="AdvancedSearch" ref={this.ref}>
         <Drawer
-          isOpen={this.props.isOpen}
+          isOpen={isOpen}
           position={Position.TOP}
           canOutsideClickClose
           icon="settings"

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -8,8 +8,9 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import c from 'classnames';
 
+import Query from 'app/Query';
 import AuthButtons from 'components/AuthButtons/AuthButtons';
-import { selectSession, selectPages } from 'selectors';
+import { selectMetadata, selectSession, selectPages } from 'selectors';
 import SearchAlert from 'components/SearchAlert/SearchAlert';
 import { SearchBox } from 'components/common';
 import getPageLink from 'util/getPageLink';
@@ -139,10 +140,17 @@ export class Navbar extends React.Component {
   }
 }
 const mapStateToProps = (state, ownProps) => {
-  const { query } = ownProps;
+  const { location } = ownProps;
+  // We normally only want Things, not Intervals (relations between things).
+  const context = {
+    highlight: true,
+    'filter:schemata': 'Thing',
+  };
 
   return ({
-    query,
+    query: Query.fromLocation('entities', location, context, ''),
+    isHomepage: location.pathname === '/',
+    metadata: selectMetadata(state),
     session: selectSession(state),
     pages: selectPages(state),
   });

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -72,8 +72,8 @@ export class Navbar extends React.Component {
 
     return (
       <>
-        <div ref={this.navbarRef}>
-          <Bp3Navbar id="Navbar" className="Navbar bp3-dark" >
+        <div className="Navbar" ref={this.navbarRef}>
+          <Bp3Navbar id="Navbar" className="bp3-dark" >
             <Bp3Navbar.Group align={Alignment.LEFT} className={c('Navbar__left-group', { hide: mobileSearchOpen })}>
               <Link to="/" className="Navbar__home-link">
                 {!!metadata.app.logo && <img src={metadata.app.logo} alt={metadata.app.title} />}

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -9,6 +9,7 @@ import { withRouter } from 'react-router';
 import c from 'classnames';
 
 import Query from 'app/Query';
+import AdvancedSearch from 'components/AdvancedSearch/AdvancedSearch';
 import AuthButtons from 'components/AuthButtons/AuthButtons';
 import { selectMetadata, selectSession, selectPages } from 'selectors';
 import SearchAlert from 'components/SearchAlert/SearchAlert';
@@ -29,14 +30,22 @@ export class Navbar extends React.Component {
     super(props);
     this.state = {
       mobileSearchOpen: false,
+      advancedSearchOpen: false,
     };
+
     this.onToggleMobileSearch = this.onToggleMobileSearch.bind(this);
+    this.onToggleAdvancedSearch = this.onToggleAdvancedSearch.bind(this);
     this.onSearchSubmit = this.onSearchSubmit.bind(this);
+    this.navbarRef = React.createRef();
   }
 
   onToggleMobileSearch(event) {
     event.preventDefault();
     this.setState(({ mobileSearchOpen }) => ({ mobileSearchOpen: !mobileSearchOpen }));
+  }
+
+  onToggleAdvancedSearch() {
+    this.setState(({ advancedSearchOpen }) => ({ advancedSearchOpen: !advancedSearchOpen }));
   }
 
   onSearchSubmit(queryText) {
@@ -55,87 +64,96 @@ export class Navbar extends React.Component {
 
   render() {
     const { metadata, pages, session, query, result, isHomepage, intl } = this.props;
-    const { mobileSearchOpen } = this.state;
+    const { advancedSearchOpen, mobileSearchOpen } = this.state;
 
     const queryText = query?.getString('q');
     const alertQuery = result?.query_text || queryText;
     const menuPages = pages.filter((page) => page.menu);
 
     return (
-      <Bp3Navbar id="Navbar" className="Navbar bp3-dark">
-        <Bp3Navbar.Group align={Alignment.LEFT} className={c('Navbar__left-group', { hide: mobileSearchOpen })}>
-          <Link to="/" className="Navbar__home-link">
-            {!!metadata.app.logo && <img src={metadata.app.logo} alt={metadata.app.title} />}
-            {!!metadata.app.title && <span className="Navbar__home-link__text">{metadata.app.title}</span>}
-          </Link>
-        </Bp3Navbar.Group>
-        <Bp3Navbar.Group align={Alignment.CENTER} className={c('Navbar__middle-group', { 'mobile-force-open': mobileSearchOpen })}>
-          {!isHomepage && (
-            <div className="Navbar__search-container">
-              <div className="Navbar__search-container__content">
-                <div className="Navbar__search-container__searchbar">
-                  <SearchBox
-                    onSearch={this.onSearchSubmit}
-                    query={query}
-                    inputProps={{
-                      rightElement: <SearchAlert alertQuery={alertQuery} />
-                    }}
-                    placeholder={intl.formatMessage(messages.placeholder)}
-                  />
-                </div>
-                <Button
-                  className="Navbar__search-container__search-tips bp3-fixed"
-                  icon="settings"
-                  minimal
-                  onClick={this.props.onToggleAdvancedSearch}
-                />
-              </div>
-            </div>
-          )}
-        </Bp3Navbar.Group>
-        <Bp3Navbar.Group align={Alignment.RIGHT} className="Navbar__right-group" id="navbarSupportedContent">
-          {!isHomepage && (
-            <>
-              <div className="Navbar__mobile-search-toggle">
-                {!mobileSearchOpen && (
-                  <Button icon="search" className="bp3-minimal" onClick={this.onToggleMobileSearch} />
-                )}
-                {mobileSearchOpen && (
-                  <Button icon="cross" className="bp3-minimal" onClick={this.onToggleMobileSearch} />
-                )}
-              </div>
-              {!mobileSearchOpen && <Bp3Navbar.Divider className="Navbar__mobile-search-divider" />}
-            </>
-          )}
-          {!mobileSearchOpen && (
-            <>
-              <Link to="/datasets">
-                <Button icon="database" className="Navbar_collections-button bp3-minimal">
-                  <FormattedMessage id="nav.collections" defaultMessage="Datasets" />
-                </Button>
+      <>
+        <div ref={this.navbarRef}>
+          <Bp3Navbar id="Navbar" className="Navbar bp3-dark" >
+            <Bp3Navbar.Group align={Alignment.LEFT} className={c('Navbar__left-group', { hide: mobileSearchOpen })}>
+              <Link to="/" className="Navbar__home-link">
+                {!!metadata.app.logo && <img src={metadata.app.logo} alt={metadata.app.title} />}
+                {!!metadata.app.title && <span className="Navbar__home-link__text">{metadata.app.title}</span>}
               </Link>
-              {session.loggedIn && (
-                <Link to="/investigations">
-                  <Button icon="briefcase" className="Navbar__collections-button mobile-hide bp3-minimal">
-                    <FormattedMessage id="nav.cases" defaultMessage="Investigations" />
-                  </Button>
-                </Link>
+            </Bp3Navbar.Group>
+            <Bp3Navbar.Group align={Alignment.CENTER} className={c('Navbar__middle-group', { 'mobile-force-open': mobileSearchOpen })}>
+              {!isHomepage && (
+                <div className="Navbar__search-container">
+                  <div className="Navbar__search-container__content">
+                    <div className="Navbar__search-container__searchbar">
+                      <SearchBox
+                        onSearch={this.onSearchSubmit}
+                        query={query}
+                        inputProps={{
+                          rightElement: <SearchAlert alertQuery={alertQuery} />
+                        }}
+                        placeholder={intl.formatMessage(messages.placeholder)}
+                      />
+                    </div>
+                    <Button
+                      className="Navbar__search-container__search-tips bp3-fixed"
+                      icon="settings"
+                      minimal
+                      onClick={this.onToggleAdvancedSearch}
+                    />
+                  </div>
+                </div>
               )}
-              {menuPages.map(page => (
-                <Link to={getPageLink(page)} key={page.name}>
-                  <Button icon={page.icon} className="Navbar__collections-button mobile-hide bp3-minimal">
-                    {page.short}
-                  </Button>
-                </Link>
-              ))}
-            </>
-          )}
-          <Bp3Navbar.Divider className={c({ 'mobile-hidden': mobileSearchOpen })} />
-          <div className={c({ 'mobile-hidden': mobileSearchOpen })}>
-            <AuthButtons className={c({ hide: mobileSearchOpen })} />
-          </div>
-        </Bp3Navbar.Group>
-      </Bp3Navbar>
+            </Bp3Navbar.Group>
+            <Bp3Navbar.Group align={Alignment.RIGHT} className="Navbar__right-group" id="navbarSupportedContent">
+              {!isHomepage && (
+                <>
+                  <div className="Navbar__mobile-search-toggle">
+                    {!mobileSearchOpen && (
+                      <Button icon="search" className="bp3-minimal" onClick={this.onToggleMobileSearch} />
+                    )}
+                    {mobileSearchOpen && (
+                      <Button icon="cross" className="bp3-minimal" onClick={this.onToggleMobileSearch} />
+                    )}
+                  </div>
+                  {!mobileSearchOpen && <Bp3Navbar.Divider className="Navbar__mobile-search-divider" />}
+                </>
+              )}
+              {!mobileSearchOpen && (
+                <>
+                  <Link to="/datasets">
+                    <Button icon="database" className="Navbar_collections-button bp3-minimal">
+                      <FormattedMessage id="nav.collections" defaultMessage="Datasets" />
+                    </Button>
+                  </Link>
+                  {session.loggedIn && (
+                    <Link to="/investigations">
+                      <Button icon="briefcase" className="Navbar__collections-button mobile-hide bp3-minimal">
+                        <FormattedMessage id="nav.cases" defaultMessage="Investigations" />
+                      </Button>
+                    </Link>
+                  )}
+                  {menuPages.map(page => (
+                    <Link to={getPageLink(page)} key={page.name}>
+                      <Button icon={page.icon} className="Navbar__collections-button mobile-hide bp3-minimal">
+                        {page.short}
+                      </Button>
+                    </Link>
+                  ))}
+                </>
+              )}
+              <Bp3Navbar.Divider className={c({ 'mobile-hidden': mobileSearchOpen })} />
+              <div className={c({ 'mobile-hidden': mobileSearchOpen })}>
+                <AuthButtons className={c({ hide: mobileSearchOpen })} />
+              </div>
+            </Bp3Navbar.Group>
+          </Bp3Navbar>
+        </div>
+        <AdvancedSearch
+          isOpen={advancedSearchOpen}
+          onToggle={this.onToggleAdvancedSearch}
+          navbarRef={this.navbarRef}
+        />
+      </>
     );
   }
 }

--- a/ui/src/components/Navbar/Navbar.scss
+++ b/ui/src/components/Navbar/Navbar.scss
@@ -4,7 +4,7 @@
 $navbar-horizontal-padding: $aleph-grid-size*.8;
 
 .Navbar {
-  &.bp3-navbar {
+  .bp3-navbar {
     display: flex;
     padding: 0 $aleph-content-padding;
     justify-content: space-between;

--- a/ui/src/components/Screen/Screen.jsx
+++ b/ui/src/components/Screen/Screen.jsx
@@ -35,7 +35,6 @@ export class Screen extends React.Component {
     } = this.props;
     const hasMetadata = metadata && metadata.app && metadata.app.title;
     const forceAuth = requireSession && !session.loggedIn;
-    const mainClass = isHomepage ? 'main-homepage' : 'main';
     const titleTemplate = hasMetadata ? `%s - ${metadata.app.title}` : '%s';
     const defaultTitle = hasMetadata ? metadata.app.title : 'Aleph';
 
@@ -59,7 +58,7 @@ export class Screen extends React.Component {
         )}
         {!forceAuth && (
           <>
-            <main className={mainClass}>
+            <main>
               {this.props.children}
             </main>
             <EntityPreview />

--- a/ui/src/components/Screen/Screen.jsx
+++ b/ui/src/components/Screen/Screen.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import AuthenticationDialog from 'dialogs/AuthenticationDialog/AuthenticationDialog';
 import EntityPreview from 'components/Entity/EntityPreview';
-import AdvancedSearch from 'components/AdvancedSearch/AdvancedSearch';
 import { selectSession, selectMetadata } from 'selectors';
 
 import './Screen.scss';
@@ -14,12 +13,7 @@ import './Screen.scss';
 export class Screen extends React.Component {
   constructor(props) {
     super(props);
-    this.state = {
-      advancedSearchOpen: false,
-    };
-    this.onToggleAdvancedSearch = this.onToggleAdvancedSearch.bind(this);
     this.toggleAuthentication = this.toggleAuthentication.bind(this);
-    this.navbarRef = React.createRef();
   }
 
   componentDidMount() {
@@ -32,10 +26,6 @@ export class Screen extends React.Component {
     }
   }
 
-  onToggleAdvancedSearch() {
-    this.setState(({ advancedSearchOpen }) => ({ advancedSearchOpen: !advancedSearchOpen }));
-  }
-
   toggleAuthentication = event => event.preventDefault();
 
   render() {
@@ -43,7 +33,6 @@ export class Screen extends React.Component {
       session, metadata, requireSession,
       isHomepage, title, description, className,
     } = this.props;
-    const { advancedSearchOpen } = this.state;
     const hasMetadata = metadata && metadata.app && metadata.app.title;
     const forceAuth = requireSession && !session.loggedIn;
     const mainClass = isHomepage ? 'main-homepage' : 'main';
@@ -83,11 +72,6 @@ export class Screen extends React.Component {
             toggleDialog={this.toggleAuthentication}
           />
         )}
-        <AdvancedSearch
-          isOpen={advancedSearchOpen}
-          onToggle={this.onToggleAdvancedSearch}
-          navbarRef={this.navbarRef}
-        />
       </div>
     );
   }

--- a/ui/src/components/Screen/Screen.jsx
+++ b/ui/src/components/Screen/Screen.jsx
@@ -6,7 +6,6 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import AuthenticationDialog from 'dialogs/AuthenticationDialog/AuthenticationDialog';
 import EntityPreview from 'components/Entity/EntityPreview';
-import Navbar from 'components/Navbar/Navbar';
 import AdvancedSearch from 'components/AdvancedSearch/AdvancedSearch';
 import { selectSession, selectMetadata } from 'selectors';
 
@@ -41,7 +40,7 @@ export class Screen extends React.Component {
 
   render() {
     const {
-      session, metadata, query, result, requireSession,
+      session, metadata, requireSession,
       isHomepage, title, description, className,
     } = this.props;
     const { advancedSearchOpen } = this.state;
@@ -64,15 +63,6 @@ export class Screen extends React.Component {
             <link rel="shortcut icon" href={metadata.app.favicon} />
           )}
         </Helmet>
-        <Navbar
-          navbarRef={this.navbarRef}
-          metadata={metadata}
-          session={session}
-          query={query}
-          result={result}
-          isHomepage={isHomepage}
-          onToggleAdvancedSearch={this.onToggleAdvancedSearch}
-        />
         { (hasMetadata && !!metadata.app.banner) && (
           <div className="app-banner bp3-callout bp3-intent-warning bp3-icon-warning-sign">
             {metadata.app.banner}

--- a/ui/src/components/Screen/Screen.scss
+++ b/ui/src/components/Screen/Screen.scss
@@ -6,20 +6,10 @@
   flex-flow: column nowrap;
   background: $aleph-page-background;
 
-  .main-homepage {
+  main {
     flex-grow: 1;
     display: flex;
     flex-flow: column nowrap;
-    // background-color: $aleph-content-background;
     align-items: stretch;
-  }
-
-  .main {
-    @extend .main-homepage;
-    // padding-bottom: ($aleph-grid-size * 2 - 1);
-  }
-
-  .screen-children {
-    width: 100%;
   }
 }

--- a/ui/src/components/common/DualPane.scss
+++ b/ui/src/components/common/DualPane.scss
@@ -4,6 +4,10 @@
 
 .DualPane {
   padding: $aleph-content-padding;
+  flex-grow: 1;
+  display: flex;
+  flex-flow: column nowrap;
+  
   @media screen and (max-width: $aleph-screen-sm-max-width) {
     padding: $aleph-mobile-content-padding;
   }

--- a/ui/src/screens/SearchScreen/SearchScreen.jsx
+++ b/ui/src/screens/SearchScreen/SearchScreen.jsx
@@ -38,11 +38,7 @@ export class SearchScreen extends React.Component {
     const title = intl.formatMessage(messages.title, { title: titleStatus });
 
     return (
-      <Screen
-        query={query}
-        result={result}
-        title={title}
-      >
+      <Screen title={title} >
         <FacetedEntitySearch
           query={query}
           result={result}


### PR DESCRIPTION
Avoid re-rendering navbar on every route change by factoring navbar component outside of router switch

I hope I didn't miss anything, but this ended up being a quite straightforward change.  And the whole in-app navigation loading feels a lot smoother / doesn't flash and re load the app logo every route change