### PR TITLE
UI: Date histogram filter bounds

### DIFF
--- a/ui/src/components/Facet/DateFacet.jsx
+++ b/ui/src/components/Facet/DateFacet.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react';
 import { compose } from 'redux';
+import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { Card, Icon, Spinner } from '@blueprintjs/core';
+import queryString from 'query-string';
+import { Button, Card, Icon, Intent, Spinner } from '@blueprintjs/core';
 import { Histogram } from '@alephdata/react-ftm';
-import { formatDateQParam } from 'components/Facet/util';
+import { DEFAULT_START_INTERVAL, filterDateIntervals, formatDateQParam, timestampToYear } from 'components/Facet/util';
 
 import './DateFacet.scss';
 
@@ -21,6 +23,7 @@ export class DateFilter extends Component {
   constructor(props) {
     super(props);
     this.onSelect = this.onSelect.bind(this);
+    this.toggleShowHidden = this.toggleShowHidden.bind(this);
   }
 
   onSelect(selected) {
@@ -39,26 +42,60 @@ export class DateFilter extends Component {
     updateQuery(newQuery)
   }
 
-  getLabel(timestamp) {
-    return new Date(timestamp).getFullYear();
+  toggleShowHidden() {
+    const { query, history, location } = this.props;
+
+    const parsedHash = queryString.parse(location.hash);
+    parsedHash['show_all_dates'] = true;
+
+    history.push({
+      pathname: location.pathname,
+      search: query.toLocation(),
+      hash: queryString.stringify(parsedHash),
+    });
+  }
+
+  renderShowHiddenToggle() {
+    return (
+      <div className="DateFacet__secondary text-muted">
+        <FormattedMessage
+          id="search.screen.dates.show-hidden"
+          defaultMessage="* Showing only date filter options from {start} to the present. { button } to view dates outside this range."
+          values={{
+            start: DEFAULT_START_INTERVAL,
+            button: (
+              <Button minimal small intent={Intent.PRIMARY} onClick={this.toggleShowHidden}>
+                <FormattedMessage
+                  id="search.screen.dates.show-hidden"
+                  defaultMessage="Click here"
+                />
+              </Button>
+            ),
+          }}
+        />
+      </div>
+    );
   }
 
   render() {
-    const { intervals, intl, isOpen } = this.props;
-    if (!isOpen || (intervals && intervals.length <= 1)) return null;
+    const { filteredIntervals, intervals, intl, isOpen, displayShowHiddenToggle } = this.props;
+    if (!isOpen || (filteredIntervals && filteredIntervals.length <= 1)) return null;
     let content;
 
     if (intervals) {
       const dataPropName = intl.formatMessage(messages.results);
       content = (
-        <Histogram
-          data={intervals.map(({label, count, ...rest}) => ({ label: this.getLabel(label), [dataPropName]: count, ...rest }))}
-          dataPropName={dataPropName}
-          onSelect={this.onSelect}
-          containerProps={{
-            height: DATE_FACET_HEIGHT,
-          }}
-        />
+        <>
+          <Histogram
+            data={filteredIntervals.map(({label, count, ...rest}) => ({ label: timestampToYear(label), [dataPropName]: count, ...rest }))}
+            dataPropName={dataPropName}
+            onSelect={this.onSelect}
+            containerProps={{
+              height: DATE_FACET_HEIGHT,
+            }}
+          />
+          {displayShowHiddenToggle && this.renderShowHiddenToggle()}
+        </>
       )
     } else {
       content = (
@@ -74,6 +111,7 @@ export class DateFilter extends Component {
           <Icon icon="calendar" className="left-icon" />
           <span className="DateFacet__label__text">
             <FormattedMessage id="search.screen.dates_title" defaultMessage="Dates" />
+            {displayShowHiddenToggle && "*"}
           </span>
         </div>
         {content}
@@ -82,7 +120,22 @@ export class DateFilter extends Component {
   }
 }
 
+const mapStateToProps = (state, ownProps) => {
+  const { location, intervals, query } = ownProps;
+  const hashQuery = queryString.parse(location.hash);
+
+  if (intervals && !hashQuery.show_all_dates) {
+    const { filteredIntervals, hasOutOfRange } = filterDateIntervals({ query, intervals })
+    return {
+      filteredIntervals,
+      displayShowHiddenToggle: hasOutOfRange
+    };
+  }
+  return { filteredIntervals: intervals };
+};
+
 export default compose(
   withRouter,
+  connect(mapStateToProps),
   injectIntl,
 )(DateFilter);

--- a/ui/src/components/Facet/DateFacet.jsx
+++ b/ui/src/components/Facet/DateFacet.jsx
@@ -124,14 +124,14 @@ const mapStateToProps = (state, ownProps) => {
   const { location, intervals, query } = ownProps;
   const hashQuery = queryString.parse(location.hash);
 
-  if (intervals && !hashQuery.show_all_dates) {
-    const { filteredIntervals, hasOutOfRange } = filterDateIntervals({ query, intervals })
+  if (intervals) {
+    const { filteredIntervals, hasOutOfRange } = filterDateIntervals({ query, intervals, useDefaultBounds: !hashQuery.show_all_dates })
     return {
       filteredIntervals,
       displayShowHiddenToggle: hasOutOfRange
     };
   }
-  return { filteredIntervals: intervals };
+  return {};
 };
 
 export default compose(

--- a/ui/src/components/Facet/DateFacet.scss
+++ b/ui/src/components/Facet/DateFacet.scss
@@ -1,4 +1,5 @@
 @import "app/variables.scss";
+@import "app/mixins.scss";
 
 .DateFacet {
   &.bp3-card {
@@ -21,5 +22,22 @@
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
+  }
+
+  &__secondary {
+    margin-bottom: $aleph-grid-size/2;
+    @include rtl(text-align, right, left);
+
+    &, .bp3-button-text {
+      font-size: 12px;
+    }
+
+    .bp3-button-text:hover {
+      text-decoration: underline;
+    }
+
+    .bp3-button {
+      display: contents;
+    }
   }
 }

--- a/ui/src/components/Facet/util.js
+++ b/ui/src/components/Facet/util.js
@@ -13,35 +13,35 @@ const timestampToYear = timestamp => {
   return new Date(timestamp).getFullYear();
 }
 
-const filterDateIntervals = ({ query, intervals }) => {
+const filterDateIntervals = ({ query, intervals, useDefaultBounds }) => {
   const defaultEndInterval = new Date().getFullYear();
   const hasGtFilter = query.hasFilter('gte:dates');
   const hasLtFilter = query.hasFilter('lte:dates');
 
   const gt = hasGtFilter
     ? cleanDateQParam(query.getFilter('gte:dates')[0])
-    : DEFAULT_START_INTERVAL;
+    : (useDefaultBounds && DEFAULT_START_INTERVAL);
 
   const lt = hasLtFilter
     ? cleanDateQParam(query.getFilter('lte:dates')[0])
-    : defaultEndInterval;
+    : (useDefaultBounds && defaultEndInterval);
 
   let gtOutOfRange, ltOutOfRange = false;
 
   const filteredIntervals = intervals.filter(({ id }) => {
     const year = timestampToYear(id);
-    if (year < gt) {
+    if (gt && year < gt) {
       gtOutOfRange = true;
       return false;
     }
-    if (year > lt) {
+    if (lt && year > lt) {
       ltOutOfRange = true;
       return false;
     }
     return true;
   })
 
-  const hasOutOfRange = (!hasGtFilter && gtOutOfRange) || (!hasLtFilter && ltOutOfRange)
+  const hasOutOfRange = useDefaultBounds && ((!hasGtFilter && gtOutOfRange) || (!hasLtFilter && ltOutOfRange));
   return { filteredIntervals, hasOutOfRange };
 }
 

--- a/ui/src/components/Facet/util.js
+++ b/ui/src/components/Facet/util.js
@@ -1,9 +1,54 @@
-const eSSuffix = '||/y';
+const DEFAULT_START_INTERVAL = 1900;
+const ES_SUFFIX = '||/y';
 
-export const formatDateQParam = (datetime) => {
+const formatDateQParam = (datetime) => {
   return `${new Date(datetime).getFullYear()}||/y`
 };
 
-export const cleanDateQParam = (value) => {
-  return value.replace(eSSuffix, '');
+const cleanDateQParam = (value) => {
+  return value.replace(ES_SUFFIX, '');
 };
+
+const timestampToYear = timestamp => {
+  return new Date(timestamp).getFullYear();
+}
+
+const filterDateIntervals = ({ query, intervals }) => {
+  const defaultEndInterval = new Date().getFullYear();
+  const hasGtFilter = query.hasFilter('gte:dates');
+  const hasLtFilter = query.hasFilter('lte:dates');
+
+  const gt = hasGtFilter
+    ? cleanDateQParam(query.getFilter('gte:dates')[0])
+    : DEFAULT_START_INTERVAL;
+
+  const lt = hasLtFilter
+    ? cleanDateQParam(query.getFilter('lte:dates')[0])
+    : defaultEndInterval;
+
+  let gtOutOfRange, ltOutOfRange = false;
+
+  const filteredIntervals = intervals.filter(({ id }) => {
+    const year = timestampToYear(id);
+    if (year < gt) {
+      gtOutOfRange = true;
+      return false;
+    }
+    if (year > lt) {
+      ltOutOfRange = true;
+      return false;
+    }
+    return true;
+  })
+
+  const hasOutOfRange = (!hasGtFilter && gtOutOfRange) || (!hasLtFilter && ltOutOfRange)
+  return { filteredIntervals, hasOutOfRange };
+}
+
+export {
+  cleanDateQParam,
+  DEFAULT_START_INTERVAL,
+  formatDateQParam,
+  timestampToYear,
+  filterDateIntervals
+}


### PR DESCRIPTION
Solves two issues currently with the date histogram filter (Both issues could, and maybe should? be solved on the request side of things instead, but this is a front-end solution just in case)

Issues:
1. Selecting a date range in the histogram currently sends a request which returns entities which might have additional date-type property values that lie outside the desired range, which is quite confusing and makes it feel like the histogram filter is not working.

Solution: in the Date Facet component, don't display intervals that fall outside the query range, if a range is specified.

2. The range of dates for entities I have access to in prod is currently the years 1000 - 9654, so the default histogram is pretty nonsensical.

Solution: in the Date Facet component, there are now default fallback bounds if no query range is specified. (I arbitrarily set it to 1900 - the current year). And there is a toggle to show all dates outside these bounds.

Happy to talk about better ways of achieving this too...