### PR TITLE
UI: Safari Intl polyfill

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -11,6 +11,9 @@
     "@blueprintjs/select": "3.15.0",
     "@blueprintjs/table": "3.8.20",
     "@formatjs/cli": "^3.0.1",
+    "@formatjs/intl-locale": "^2.4.14",
+    "@formatjs/intl-pluralrules": "^4.0.6",
+    "@formatjs/intl-relativetimeformat": "^8.0.4",
     "@formatjs/intl-utils": "^3.8.4",
     "@types/jest": "^26.0.0",
     "@types/node": "^14.0.1",
@@ -19,7 +22,6 @@
     "axios": "^0.21.0",
     "classnames": "^2.2.6",
     "http-proxy-middleware": "^1.0.3",
-    "intl-pluralrules": "^1.1.1",
     "js-file-download": "^0.4.9",
     "jwt-decode": "^3.0.0",
     "lodash": "^4.17.11",
@@ -80,4 +82,4 @@
   "devDependencies": {
     "file-selector": "^0.2.2"
   }
-}
+}}

--- a/ui/package.json
+++ b/ui/package.json
@@ -82,4 +82,4 @@
   "devDependencies": {
     "file-selector": "^0.2.2"
   }
-}}
+}

--- a/ui/src/app/Translator.jsx
+++ b/ui/src/app/Translator.jsx
@@ -6,7 +6,6 @@ import { Spinner } from '@blueprintjs/core';
 
 import { selectLocale } from 'selectors';
 import translations from 'content/translations.json';
-import { selectLocale } from 'selectors';
 
 
 class Translator extends React.Component {
@@ -50,8 +49,8 @@ class Translator extends React.Component {
       return <div className="spinner"><Spinner className="bp3-large" /></div>
     }
 
-    //  override arabic locale to marocan version 
-    // We want all dates and numbers in latin instead of default ar eastern digits 
+    //  override arabic locale to marocan version
+    // We want all dates and numbers in latin instead of default ar eastern digits
     const modifiedLocale = locale === "ar" ? "ar-ma" : locale;
 
     return (

--- a/ui/src/app/Translator.jsx
+++ b/ui/src/app/Translator.jsx
@@ -2,21 +2,21 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { IntlProvider } from 'react-intl';
 import { shouldPolyfill } from '@formatjs/intl-relativetimeformat/should-polyfill'
-import { Spinner } from '@blueprintjs/core';
 
 import { selectLocale } from 'selectors';
+import { SectionLoading } from 'components/common';
 import translations from 'content/translations.json';
 
 
 class Translator extends React.Component {
   constructor(props) {
     super(props);
-    this.requiresPollyfill = shouldPolyfill();
-    this.state = { isPending: this.requiresPollyfill };
+    this.requiresPolyfill = shouldPolyfill();
+    this.state = { isPending: this.requiresPolyfill };
   }
 
   componentDidMount() {
-    if (this.requiresPollyfill) {
+    if (this.requiresPolyfill) {
       this.fetchPolyfill();
     }
   }
@@ -46,7 +46,7 @@ class Translator extends React.Component {
     const { isPending } = this.state;
 
     if (isPending) {
-      return <div className="spinner"><Spinner className="bp3-large" /></div>
+      return <SectionLoading className="bp3-large" />
     }
 
     //  override arabic locale to marocan version

--- a/ui/src/app/Translator.jsx
+++ b/ui/src/app/Translator.jsx
@@ -1,23 +1,54 @@
 import React from 'react';
 import { connect } from 'react-redux';
-
 import { IntlProvider } from 'react-intl';
-// import en from 'react-intl/locale-data/en';
-// import de from 'react-intl/locale-data/de';
-// import bs from 'react-intl/locale-data/bs';
-// import ru from 'react-intl/locale-data/ru';
-// import es from 'react-intl/locale-data/es';
-// import ar from 'react-intl/locale-data/ar';
+import { shouldPolyfill } from '@formatjs/intl-relativetimeformat/should-polyfill'
+import { Spinner } from '@blueprintjs/core';
 
 import { selectLocale } from 'selectors';
 import translations from 'content/translations.json';
+import { selectLocale } from 'selectors';
 
-// add locale data to react-intl
-// addLocaleData([...en, ...de, ...bs, ...es, ...ru, ...ar]);
 
-class Translator extends React.PureComponent {
+class Translator extends React.Component {
+  constructor(props) {
+    super(props);
+    this.requiresPollyfill = shouldPolyfill();
+    this.state = { isPending: this.requiresPollyfill };
+  }
+
+  componentDidMount() {
+    if (this.requiresPollyfill) {
+      this.fetchPolyfill();
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    if (this.requiresPolyfill && prevProps.locale !== this.props.locale) {
+      this.fetchLocale()
+    }
+  }
+
+  fetchPolyfill = async () => {
+    await import('@formatjs/intl-locale/polyfill')
+    await import('@formatjs/intl-pluralrules/polyfill');
+    await import('@formatjs/intl-relativetimeformat/polyfill');
+    this.fetchLocale();
+  }
+
+  fetchLocale = async () => {
+    const { locale } = this.props;
+    await import(`@formatjs/intl-pluralrules/locale-data/${locale}`)
+    await import(`@formatjs/intl-relativetimeformat/locale-data/${locale}`)
+    this.setState({ isPending: false });
+  }
+
   render() {
     const { children, locale } = this.props;
+    const { isPending } = this.state;
+
+    if (isPending) {
+      return <div className="spinner"><Spinner className="bp3-large" /></div>
+    }
 
     //  override arabic locale to marocan version 
     // We want all dates and numbers in latin instead of default ar eastern digits 

--- a/ui/src/app/blueprint-overrides.scss
+++ b/ui/src/app/blueprint-overrides.scss
@@ -129,6 +129,9 @@ table {
     &:not(:first-child) {
       @include rtlSupportInvertedProp(padding, left, 30px, 10px);
     }
+
+    // to handle Safari input placeholder line-height weirdness
+    line-height: normal !important;
   }
   > .bp3-button {
       &:last-child {

--- a/ui/src/app/layouts.scss
+++ b/ui/src/app/layouts.scss
@@ -27,7 +27,7 @@
   .pane-layout-side {
     flex: none;
     width: $aleph-sidebar-width;
-    min-height: 100%;
+    height: 100%;
     overflow: visible;
 
     @media screen and (max-width: $aleph-screen-md-max-width) and (min-width: $aleph-screen-sm-max-width) {

--- a/ui/src/components/Entity/EntityActionBar.scss
+++ b/ui/src/components/Entity/EntityActionBar.scss
@@ -72,4 +72,9 @@ $status-width: 120px;
   .Count {
     @include rtlSupportInvertedProp(margin, left, $aleph-grid-size/2, null);
   }
+
+  .bp3-button {
+    margin-top: 0;
+    margin-bottom: 0;
+  }
 }

--- a/ui/src/components/Entity/EntityActionBar.scss
+++ b/ui/src/components/Entity/EntityActionBar.scss
@@ -58,6 +58,7 @@ $status-width: 120px;
 
   &__right {
     display: flex;
+    margin: 0 !important;
   }
 
   .prevent-flex-grow.bp3-popover-wrapper {

--- a/ui/src/components/Investigation/InvestigationOverview.jsx
+++ b/ui/src/components/Investigation/InvestigationOverview.jsx
@@ -46,22 +46,22 @@ class InvestigationOverview extends React.Component {
           <div className="InvestigationOverview__section__content">
             <div className="InvestigationOverview__guides">
               <AnchorButton minimal intent={Intent.PRIMARY} alignText="left" icon="people" target="_blank" href={`${guidesURLPrefix}creating-a-personal-dataset#managing-access-to-your-personal-dataset`}>
-                <FormattedMessage id="investigation.overview.guides" defaultMessage="Managing access" />
+                <FormattedMessage id="investigation.overview.guides.access" defaultMessage="Managing access" />
               </AnchorButton>
               <AnchorButton minimal intent={Intent.PRIMARY} alignText="left" icon="upload" target="_blank" href={`${guidesURLPrefix}cross-referencing`}>
-                <FormattedMessage id="investigation.overview.guides" defaultMessage="Uploading documents" />
+                <FormattedMessage id="investigation.overview.guides.documents" defaultMessage="Uploading documents" />
               </AnchorButton>
               <AnchorButton minimal intent={Intent.PRIMARY} alignText="left" icon="graph" target="_blank" href={`${guidesURLPrefix}uploading-documents`}>
-                <FormattedMessage id="investigation.overview.guides" defaultMessage="Drawing network diagrams" />
+                <FormattedMessage id="investigation.overview.guides.diagrams" defaultMessage="Drawing network diagrams" />
               </AnchorButton>
               <AnchorButton minimal intent={Intent.PRIMARY} alignText="left" icon="new-object" target="_blank" href={`${guidesURLPrefix}using-the-table-editor`}>
-                <FormattedMessage id="investigation.overview.guides" defaultMessage="Creating & editing entities" />
+                <FormattedMessage id="investigation.overview.guides.entities" defaultMessage="Creating & editing entities" />
               </AnchorButton>
               <AnchorButton minimal intent={Intent.PRIMARY} alignText="left" icon="table" target="_blank" href={`${guidesURLPrefix}generating-multiple-entities-from-a-list`}>
-                <FormattedMessage id="investigation.overview.guides" defaultMessage="Generating entities from a spreadsheet" />
+                <FormattedMessage id="investigation.overview.guides.mappings" defaultMessage="Generating entities from a spreadsheet" />
               </AnchorButton>
               <AnchorButton minimal intent={Intent.PRIMARY} alignText="left" icon="comparison" target="_blank" href={`${guidesURLPrefix}cross-referencing`}>
-                <FormattedMessage id="investigation.overview.guides" defaultMessage="Cross-referencing your data" />
+                <FormattedMessage id="investigation.overview.guides.xref" defaultMessage="Cross-referencing your data" />
               </AnchorButton>
             </div>
           </div>

--- a/ui/src/components/Screen/Screen.scss
+++ b/ui/src/components/Screen/Screen.scss
@@ -11,5 +11,6 @@
     display: flex;
     flex-flow: column nowrap;
     align-items: stretch;
+    height: 100%;
   }
 }

--- a/ui/src/components/common/SectionLoading.jsx
+++ b/ui/src/components/common/SectionLoading.jsx
@@ -3,10 +3,10 @@ import { Spinner } from '@blueprintjs/core';
 
 import './SectionLoading.scss';
 
-const SectionLoading = () => (
+const SectionLoading = (props = {}) => (
   <div className="SectionLoading">
     <div className="spinner">
-      <Spinner />
+      <Spinner {...props}/>
     </div>
   </div>
 );

--- a/ui/src/components/common/SectionLoading.scss
+++ b/ui/src/components/common/SectionLoading.scss
@@ -1,5 +1,5 @@
 .SectionLoading {
-    min-height: 5em;
+    min-height: 15em;
     max-height: 80vh;
     height: 100%;
     width: 100%;

--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import App from 'app/App';
-import 'intl-pluralrules';
 
 ReactDOM.render(
   React.createElement(App),


### PR DESCRIPTION
It looks like the Intl polyfills are outside the scope of what can be finagled by messing with the targeted browserslist in create-react-app, so this branch includes a polyfill for both Intl.PluralRules and Intl.FormattedRelativeTime that is loaded dynamically depending on a user’s browser support (mainly relevant for Safari < 14).

(If we want to avoid some of this polyfill grossness we could instead do a fallback to replace the “a week ago” in notifications/exports with the simple date timestamp if a browser can’t support it…)

+ fixes for some other small Safari css weirdness


