### PR TITLE
Get rid of sample-entities command. Provide option to filter by secret and casefile flags when listing collections.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # build-essential 
 RUN apt-get -qq -y update \
     && apt-get -qq -y install locales \
-    ca-certificates postgresql-client curl \
+    ca-certificates postgresql-client curl jq\
     python3-pip python3-icu python3-psycopg2 \
     python3-lxml python3-crypto \
     && apt-get -qq -y autoremove \


### PR DESCRIPTION
Doing the sampling inside ES led to hanging queries. So we do the sampling outside ES.

The other alternative is to do the sampling inside ftm-store database but we have to additionally implement property based filters in SQL in that case. 