### PR TITLE
Entity decision hotkeys

### DIFF
--- a/ui/src/components/Collection/CollectionXrefMode.jsx
+++ b/ui/src/components/Collection/CollectionXrefMode.jsx
@@ -39,7 +39,7 @@ export class CollectionXrefMode extends React.Component {
   updateQuery(newQuery) {
     const { history, location } = this.props;
     const parsedHash = queryString.parse(location.hash);
-    parsedHash.selectedIndex = undefined;
+    parsedHash.selectedId = undefined;
 
     history.push({
       pathname: location.pathname,

--- a/ui/src/components/Collection/CollectionXrefMode.jsx
+++ b/ui/src/components/Collection/CollectionXrefMode.jsx
@@ -4,6 +4,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { Button, Intent } from '@blueprintjs/core';
+import queryString from 'query-string';
 
 import SearchActionBar from 'components/common/SearchActionBar';
 import SearchFacets from 'components/Facet/SearchFacets';
@@ -37,10 +38,13 @@ export class CollectionXrefMode extends React.Component {
 
   updateQuery(newQuery) {
     const { history, location } = this.props;
+    const parsedHash = queryString.parse(location.hash);
+    parsedHash.selectedIndex = undefined;
+
     history.push({
       pathname: location.pathname,
       search: newQuery.toLocation(),
-      hash: location.hash,
+      hash: queryString.stringify(parsedHash),
     });
   }
 

--- a/ui/src/components/Entity/EntityHeading.jsx
+++ b/ui/src/components/Entity/EntityHeading.jsx
@@ -43,6 +43,7 @@ class EntityHeading extends React.PureComponent {
                   <FormattedRelativeTime
                     value={value}
                     unit={unit}
+                    // eslint-disable-next-line
                     style="long"
                     numeric="auto"
                   />

--- a/ui/src/components/Entity/EntitySimilarMode.jsx
+++ b/ui/src/components/Entity/EntitySimilarMode.jsx
@@ -7,7 +7,7 @@ import { Callout } from '@blueprintjs/core';
 import { querySimilar } from 'actions';
 import { selectSimilarResult } from 'selectors';
 import {
-  ErrorSection, QueryInfiniteLoad, JudgementButtons, Score, Collection, Skeleton,
+  ErrorSection, QueryInfiniteLoad, JudgementButtons, Score, Collection, Skeleton, EntityDecisionHotkeys, EntityDecisionRow,
 } from 'components/common';
 import EntityCompare from 'components/Entity/EntityCompare';
 import { entitySimilarQuery } from 'queries';
@@ -119,7 +119,7 @@ class EntitySimilarMode extends Component {
 
   renderRow(similar) {
     return (
-      <tr key={similar.entity.id}>
+      <EntityDecisionRow key={similar.entity.id} objId={similar.entity.id}>
         <td className="numeric narrow">
           <JudgementButtons obj={similar} onChange={this.onDecide} />
         </td>
@@ -132,7 +132,7 @@ class EntitySimilarMode extends Component {
         <td className="collection">
           <Collection.Link collection={similar.entity.collection} icon />
         </td>
-      </tr>
+      </EntityDecisionRow>
     );
   }
 
@@ -150,13 +150,15 @@ class EntitySimilarMode extends Component {
     return (
       <div className="EntitySimilarMode">
         {this.renderSummary()}
-        <table className="data-table">
-          {this.renderHeader()}
-          <tbody>
-            {result.results?.map(res => this.renderRow(res))}
-            {result.isPending && skeletonItems.map(idx => this.renderSkeleton(idx))}
-          </tbody>
-        </table>
+        <EntityDecisionHotkeys result={result} onDecide={this.onDecide}>
+          <table className="data-table">
+            {this.renderHeader()}
+            <tbody>
+              {result.results?.map(res => this.renderRow(res))}
+              {result.isPending && skeletonItems.map(idx => this.renderSkeleton(idx))}
+            </tbody>
+          </table>
+        </EntityDecisionHotkeys>
         <QueryInfiniteLoad
           query={query}
           result={result}

--- a/ui/src/components/Entity/EntitySimilarMode.jsx
+++ b/ui/src/components/Entity/EntitySimilarMode.jsx
@@ -3,6 +3,7 @@ import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { Callout } from '@blueprintjs/core';
+import queryString from 'query-string';
 
 import { querySimilar } from 'actions';
 import { selectSimilarResult } from 'selectors';
@@ -117,9 +118,10 @@ class EntitySimilarMode extends Component {
     );
   }
 
-  renderRow(similar) {
+  renderRow(similar, index) {
+    const { selectedIndex } = this.props;
     return (
-      <EntityDecisionRow key={similar.entity.id} objId={similar.entity.id}>
+      <EntityDecisionRow key={similar.entity.id} selected={index === selectedIndex}>
         <td className="numeric narrow">
           <JudgementButtons obj={similar} onChange={this.onDecide} />
         </td>
@@ -154,7 +156,7 @@ class EntitySimilarMode extends Component {
           <table className="data-table">
             {this.renderHeader()}
             <tbody>
-              {result.results?.map(res => this.renderRow(res))}
+              {result.results?.map((res, i) => this.renderRow(res, i))}
               {result.isPending && skeletonItems.map(idx => this.renderSkeleton(idx))}
             </tbody>
           </table>
@@ -173,7 +175,10 @@ const mapStateToProps = (state, ownProps) => {
   const { entity, location } = ownProps;
   const query = entitySimilarQuery(location, entity.id);
   const result = selectSimilarResult(state, query);
-  return { query, result };
+
+  const parsedHash = queryString.parse(location.hash);
+
+  return { query, result, selectedIndex: +parsedHash.selectedIndex };
 };
 
 EntitySimilarMode = connect(mapStateToProps, { querySimilar, pairwiseJudgement })(EntitySimilarMode);

--- a/ui/src/components/Profile/ProfileItemsMode.jsx
+++ b/ui/src/components/Profile/ProfileItemsMode.jsx
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { Callout, Intent } from '@blueprintjs/core';
 import c from 'classnames';
+import queryString from 'query-string';
 
 import { selectEntitySetItemsResult } from 'selectors';
 import {
@@ -44,9 +45,11 @@ class ProfileItemsMode extends Component {
     }
   }
 
-  renderRow(item) {
+  renderRow(item, index) {
+    const { selectedIndex } = this.props;
+
     return (
-      <EntityDecisionRow objId={item.id || item.entity.id}>
+      <EntityDecisionRow key={item.id || item.entity.id} selected={index === selectedIndex}>
         <td className="numeric narrow">
           <JudgementButtons obj={item} onChange={this.onDecide} />
         </td>
@@ -112,7 +115,7 @@ class ProfileItemsMode extends Component {
               </tr>
             </thead>
             <tbody>
-              {result.results?.map(res => this.renderRow(res))}
+              {result.results?.map((res, i) => this.renderRow(res, i))}
               {!result.total && result.isPending && skeletonItems.map(idx => this.renderSkeleton(idx))}
             </tbody>
           </table>
@@ -125,9 +128,12 @@ class ProfileItemsMode extends Component {
 const mapStateToProps = (state, ownProps) => {
   const { profile, location } = ownProps;
   const query = entitySetItemsQuery(location, profile.id);
+  const parsedHash = queryString.parse(location.hash);
+
   return {
     query,
-    result: selectEntitySetItemsResult(state, query)
+    result: selectEntitySetItemsResult(state, query),
+    selectedIndex: +parsedHash.selectedIndex
   };
 };
 

--- a/ui/src/components/Profile/ProfileItemsMode.jsx
+++ b/ui/src/components/Profile/ProfileItemsMode.jsx
@@ -7,7 +7,7 @@ import c from 'classnames';
 
 import { selectEntitySetItemsResult } from 'selectors';
 import {
-  JudgementButtons, Collection,
+  JudgementButtons, Collection, EntityDecisionHotkeys, EntityDecisionRow,
 } from 'components/common';
 import EntityCompare from 'components/Entity/EntityCompare';
 import { entitySetItemsQuery } from 'queries';
@@ -46,7 +46,7 @@ class ProfileItemsMode extends Component {
 
   renderRow(item) {
     return (
-      <tr key={item.id || item.entity.id}>
+      <EntityDecisionRow objId={item.id || item.entity.id}>
         <td className="numeric narrow">
           <JudgementButtons obj={item} onChange={this.onDecide} />
         </td>
@@ -56,7 +56,7 @@ class ProfileItemsMode extends Component {
         <td className="collection">
           <Collection.Link collection={item.collection} icon />
         </td>
-      </tr>
+      </EntityDecisionRow>
     );
   }
 
@@ -88,33 +88,35 @@ class ProfileItemsMode extends Component {
             defaultMessage="Make decisions below to determine which source entities should be added or excluded from this profile."
           />
         </Callout>
-        <table className={c("data-table", { 'pending': result.isPending })}>
-          <thead>
-            <tr>
-              <th className="numeric narrow" />
-              <th>
-                <span className="value">
-                  <FormattedMessage
-                    id="profile.items.entity"
-                    defaultMessage="Combined entities"
-                  />
-                </span>
-              </th>
-              <th className="collection">
-                <span className="value">
-                  <FormattedMessage
-                    id="xref.match_collection"
-                    defaultMessage="Dataset"
-                  />
-                </span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {result.results?.map(res => this.renderRow(res))}
-            {!result.total && result.isPending && skeletonItems.map(idx => this.renderSkeleton(idx))}
-          </tbody>
-        </table>
+        <EntityDecisionHotkeys result={result} onDecide={this.onDecide}>
+          <table className={c("data-table", { 'pending': result.isPending })}>
+            <thead>
+              <tr>
+                <th className="numeric narrow" />
+                <th>
+                  <span className="value">
+                    <FormattedMessage
+                      id="profile.items.entity"
+                      defaultMessage="Combined entities"
+                    />
+                  </span>
+                </th>
+                <th className="collection">
+                  <span className="value">
+                    <FormattedMessage
+                      id="xref.match_collection"
+                      defaultMessage="Dataset"
+                    />
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.results?.map(res => this.renderRow(res))}
+              {!result.total && result.isPending && skeletonItems.map(idx => this.renderSkeleton(idx))}
+            </tbody>
+          </table>
+        </EntityDecisionHotkeys>
       </div >
     );
   }

--- a/ui/src/components/Profile/ProfileSimilarMode.jsx
+++ b/ui/src/components/Profile/ProfileSimilarMode.jsx
@@ -7,7 +7,7 @@ import c from 'classnames';
 
 import { selectSimilarResult } from 'selectors';
 import {
-  QueryInfiniteLoad, JudgementButtons, Score, Collection,
+  QueryInfiniteLoad, JudgementButtons, Score, Collection, EntityDecisionHotkeys, EntityDecisionRow,
 } from 'components/common';
 import EntityCompare from 'components/Entity/EntityCompare';
 import { profileSimilarQuery } from 'queries';
@@ -43,7 +43,7 @@ class ProfileItemsMode extends Component {
 
   renderRow(item) {
     return (
-      <tr key={item.id || item.entity.id}>
+      <EntityDecisionRow objId={item.id || item.entity.id}>
         <td className="numeric narrow">
           <JudgementButtons obj={item} onChange={this.onDecide} />
         </td>
@@ -56,7 +56,7 @@ class ProfileItemsMode extends Component {
         <td className="collection">
           <Collection.Link collection={item.entity.collection} icon />
         </td>
-      </tr>
+      </EntityDecisionRow>
     );
   }
 
@@ -74,40 +74,42 @@ class ProfileItemsMode extends Component {
     }
     return (
       <div className="ProfileSimilarMode">
-        <table className={c("data-table", { 'pending': result.isPending })}>
-          <thead>
-            <tr>
-              <th className="numeric narrow" />
-              <th>
-                <span className="value">
-                  <FormattedMessage
-                    id="entity.similar.entity"
-                    defaultMessage="Similar entity"
-                  />
-                </span>
-              </th>
-              <th className="numeric narrow">
-                <span className="value">
-                  <FormattedMessage
-                    id="xref.score"
-                    defaultMessage="Score"
-                  />
-                </span>
-              </th>
-              <th className="collection">
-                <span className="value">
-                  <FormattedMessage
-                    id="xref.match_collection"
-                    defaultMessage="Dataset"
-                  />
-                </span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {result.results?.map(res => this.renderRow(res))}
-          </tbody>
-        </table>
+        <EntityDecisionHotkeys result={result} onDecide={this.onDecide}>
+          <table className={c("data-table", { 'pending': result.isPending })}>
+            <thead>
+              <tr>
+                <th className="numeric narrow" />
+                <th>
+                  <span className="value">
+                    <FormattedMessage
+                      id="entity.similar.entity"
+                      defaultMessage="Similar entity"
+                    />
+                  </span>
+                </th>
+                <th className="numeric narrow">
+                  <span className="value">
+                    <FormattedMessage
+                      id="xref.score"
+                      defaultMessage="Score"
+                    />
+                  </span>
+                </th>
+                <th className="collection">
+                  <span className="value">
+                    <FormattedMessage
+                      id="xref.match_collection"
+                      defaultMessage="Dataset"
+                    />
+                  </span>
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {result.results?.map(res => this.renderRow(res))}
+            </tbody>
+          </table>
+        </EntityDecisionHotkeys>
         <QueryInfiniteLoad
           query={query}
           result={result}

--- a/ui/src/components/Profile/ProfileSimilarMode.jsx
+++ b/ui/src/components/Profile/ProfileSimilarMode.jsx
@@ -4,6 +4,7 @@ import { withRouter } from 'react-router';
 import { connect } from 'react-redux';
 import { Callout } from '@blueprintjs/core';
 import c from 'classnames';
+import queryString from 'query-string';
 
 import { selectSimilarResult } from 'selectors';
 import {
@@ -41,9 +42,10 @@ class ProfileItemsMode extends Component {
     }
   }
 
-  renderRow(item) {
+  renderRow(item, index) {
+    const { selectedIndex } = this.props;
     return (
-      <EntityDecisionRow objId={item.id || item.entity.id}>
+      <EntityDecisionRow key={item.id || item.entity.id} selected={index === selectedIndex}>
         <td className="numeric narrow">
           <JudgementButtons obj={item} onChange={this.onDecide} />
         </td>
@@ -106,7 +108,7 @@ class ProfileItemsMode extends Component {
               </tr>
             </thead>
             <tbody>
-              {result.results?.map(res => this.renderRow(res))}
+              {result.results?.map((res, i) => this.renderRow(res, i))}
             </tbody>
           </table>
         </EntityDecisionHotkeys>
@@ -123,9 +125,12 @@ class ProfileItemsMode extends Component {
 const mapStateToProps = (state, ownProps) => {
   const { profile, location } = ownProps;
   const query = profileSimilarQuery(location, profile.id);
+  const parsedHash = queryString.parse(location.hash);
+
   return {
     query,
     result: selectSimilarResult(state, query),
+    selectedIndex: +parsedHash.selectedIndex
   };
 };
 

--- a/ui/src/components/XrefTable/XrefTable.jsx
+++ b/ui/src/components/XrefTable/XrefTable.jsx
@@ -115,7 +115,7 @@ class XrefTable extends Component {
 
 
 const mapStateToProps = (state, ownProps) => {
-  const { profile, location } = ownProps;
+  const { location } = ownProps;
   const parsedHash = queryString.parse(location.hash);
 
   return {

--- a/ui/src/components/XrefTable/XrefTable.jsx
+++ b/ui/src/components/XrefTable/XrefTable.jsx
@@ -75,7 +75,7 @@ class XrefTable extends Component {
   )
 
   render() {
-    const { intl, result } = this.props;
+    const { intl, result, selectedIndex } = this.props;
     const skeletonItems = [...Array(25).keys()];
 
     if (result.isError) {
@@ -100,6 +100,7 @@ class XrefTable extends Component {
                 key={xref.id}
                 xref={xref}
                 onDecide={this.onDecide}
+                selected={i === selectedIndex}
               />
             ))}
             {result.isPending && skeletonItems.map(item => (
@@ -112,8 +113,18 @@ class XrefTable extends Component {
   }
 }
 
+
+const mapStateToProps = (state, ownProps) => {
+  const { profile, location } = ownProps;
+  const parsedHash = queryString.parse(location.hash);
+
+  return {
+    selectedIndex: +parsedHash.selectedIndex
+  };
+};
+
 export default compose(
   withRouter,
-  connect(null, { pairwiseJudgement }),
+  connect(mapStateToProps, { pairwiseJudgement }),
   injectIntl,
 )(XrefTable);

--- a/ui/src/components/XrefTable/XrefTableRow.jsx
+++ b/ui/src/components/XrefTable/XrefTableRow.jsx
@@ -29,7 +29,7 @@ class XrefTableRow extends Component {
   }
 
   render() {
-    const { isPending, onDecide, xref } = this.props;
+    const { isPending, onDecide, selected, xref } = this.props;
 
     if (isPending) {
       return this.renderSkeleton();
@@ -39,7 +39,7 @@ class XrefTableRow extends Component {
       return null;
     }
     return (
-      <EntityDecisionRow className="XrefTableRow" objId={xref.id}>
+      <EntityDecisionRow className="XrefTableRow" selected={selected}>
         <td className="numeric narrow">
           <JudgementButtons obj={xref} onChange={onDecide} />
         </td>

--- a/ui/src/components/XrefTable/XrefTableRow.jsx
+++ b/ui/src/components/XrefTable/XrefTableRow.jsx
@@ -1,28 +1,13 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
+import c from 'classnames';
 
 import {
-  Collection, Skeleton, JudgementButtons, Score,
+  Collection, EntityDecisionRow, Skeleton, JudgementButtons, Score,
 } from 'components/common';
-import EntityCompare from 'components/Entity/EntityCompare';
-import { showWarningToast } from 'app/toast';
-import { pairwiseJudgement } from 'actions';
 
+import EntityCompare from 'components/Entity/EntityCompare';
 
 class XrefTableRow extends Component {
-  constructor(props) {
-    super(props);
-    this.onDecide = this.onDecide.bind(this);
-  }
-
-  async onDecide(xref) {
-    try {
-      await this.props.pairwiseJudgement(xref);
-    } catch (e) {
-      showWarningToast(e.message);
-    }
-  }
-
   renderSkeleton() {
     return (
       <tr>
@@ -44,7 +29,7 @@ class XrefTableRow extends Component {
   }
 
   render() {
-    const { isPending, xref } = this.props;
+    const { isPending, onDecide, selected, xref } = this.props;
 
     if (isPending) {
       return this.renderSkeleton();
@@ -54,9 +39,9 @@ class XrefTableRow extends Component {
       return null;
     }
     return (
-      <tr className="XrefTableRow">
+      <EntityDecisionRow className="XrefTableRow" selected={selected} objId={xref.id}>
         <td className="numeric narrow">
-          <JudgementButtons obj={xref} onChange={this.onDecide} />
+          <JudgementButtons obj={xref} onChange={onDecide} />
         </td>
         <td className="entity bordered">
           <EntityCompare entity={xref.entity} other={xref.match} showEmpty={true} />
@@ -70,10 +55,9 @@ class XrefTableRow extends Component {
         <td className="collection">
           <Collection.Link collection={xref.match?.collection} icon />
         </td>
-      </tr >
+      </EntityDecisionRow>
     );
   }
 }
 
-XrefTableRow = connect(null, { pairwiseJudgement })(XrefTableRow);
 export default XrefTableRow;

--- a/ui/src/components/XrefTable/XrefTableRow.jsx
+++ b/ui/src/components/XrefTable/XrefTableRow.jsx
@@ -29,7 +29,7 @@ class XrefTableRow extends Component {
   }
 
   render() {
-    const { isPending, onDecide, selected, xref } = this.props;
+    const { isPending, onDecide, xref } = this.props;
 
     if (isPending) {
       return this.renderSkeleton();
@@ -39,7 +39,7 @@ class XrefTableRow extends Component {
       return null;
     }
     return (
-      <EntityDecisionRow className="XrefTableRow" selected={selected} objId={xref.id}>
+      <EntityDecisionRow className="XrefTableRow" objId={xref.id}>
         <td className="numeric narrow">
           <JudgementButtons obj={xref} onChange={onDecide} />
         </td>

--- a/ui/src/components/XrefTable/XrefTableRow.jsx
+++ b/ui/src/components/XrefTable/XrefTableRow.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import c from 'classnames';
 
 import {
   Collection, EntityDecisionRow, Skeleton, JudgementButtons, Score,

--- a/ui/src/components/common/EntityDecisionHotkeys.jsx
+++ b/ui/src/components/common/EntityDecisionHotkeys.jsx
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 import queryString from 'query-string';
 import { withRouter } from 'react-router';
 
-import { ErrorSection, HotKeysContainer } from 'components/common';
+import { HotKeysContainer } from 'components/common';
 
 
 class EntityDecisionHotkeys extends Component {

--- a/ui/src/components/common/EntityDecisionHotkeys.jsx
+++ b/ui/src/components/common/EntityDecisionHotkeys.jsx
@@ -1,0 +1,111 @@
+import React, { Component } from 'react';
+import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import queryString from 'query-string';
+import { withRouter } from 'react-router';
+
+import { ErrorSection, HotKeysContainer } from 'components/common';
+import { showWarningToast } from 'app/toast';
+
+
+class EntityDecisionHotkeys extends Component {
+  constructor(props) {
+    super(props);
+    this.onDecideSelected = this.onDecideSelected.bind(this);
+    this.selectNext = this.selectNext.bind(this);
+    this.selectPrevious = this.selectPrevious.bind(this);
+  }
+
+  getCurrentSelectedIndex() {
+    const { result, selectedId } = this.props;
+
+    return result.results?.findIndex(
+      item => item.id === selectedId,
+    );
+  }
+
+  onDecideSelected(judgement) {
+    const { history, location, onDecide, result, selectedIndex } = this.props;
+
+    const selectedXrefResult = result.results?.[this.getCurrentSelectedIndex()];
+    if (selectedXrefResult) {
+      selectedXrefResult.judgement = selectedXrefResult.judgement === judgement ? 'no_judgement' : judgement
+      onDecide(selectedXrefResult);
+      this.selectNext();
+    }
+  }
+
+  updateQuery(nextSelected) {
+    const { history, location } = this.props;
+    if (!nextSelected) { return; }
+
+    const parsedHash = queryString.parse(location.hash);
+    parsedHash.selectedId = nextSelected.id;
+
+    history.replace({
+      pathname: location.pathname,
+      search: location.search,
+      hash: queryString.stringify(parsedHash),
+    });
+  }
+
+  selectNext() {
+    const { history, location, result } = this.props;
+    const selectedIndex = this.getCurrentSelectedIndex();
+    const hasNext = result.results && result.results.length > (selectedIndex + 1)
+    if (hasNext) {
+      this.updateQuery(result.results[selectedIndex + 1]);
+    }
+  }
+
+  selectPrevious() {
+    const { history, location, result } = this.props;
+    const selectedIndex = this.getCurrentSelectedIndex();
+    const hasPrevious = result.results?.length && selectedIndex > 0;
+    if (hasPrevious) {
+      this.updateQuery(result.results[selectedIndex - 1]);
+    }
+  }
+
+  render() {
+    const { children, } = this.props;
+
+    return (
+      <HotKeysContainer
+        hotKeys={[
+          {
+            combo: 'y', global: true, label: 'Decide same', onKeyDown: () => this.onDecideSelected('positive'),
+          },
+          {
+            combo: 'h', global: true, label: 'Decide not enough information', onKeyDown: () => this.onDecideSelected('unsure'),
+          },
+          {
+            combo: 'n', global: true, label: 'Decide different', onKeyDown: () => this.onDecideSelected('negative'),
+          },
+          {
+            combo: 'up', global: true, label: 'Select previous cross reference result', onKeyDown: this.selectPrevious,
+          },
+          {
+            combo: 'down', global: true, label: 'Select next cross reference result', onKeyDown: this.selectNext,
+          },
+        ]}
+      >
+        {children}
+      </HotKeysContainer>
+    );
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const { location } = ownProps;
+  const parsedHash = queryString.parse(location.hash);
+
+  return { selectedId: parsedHash.selectedId };
+}
+
+export default compose(
+  withRouter,
+  connect(mapStateToProps),
+  injectIntl,
+)(EntityDecisionHotkeys);

--- a/ui/src/components/common/EntityDecisionHotkeys.jsx
+++ b/ui/src/components/common/EntityDecisionHotkeys.jsx
@@ -21,7 +21,7 @@ class EntityDecisionHotkeys extends Component {
     const { result, selectedId } = this.props;
 
     return result.results?.findIndex(
-      item => item.id === selectedId,
+      item => (item.id || item.entityId) === selectedId,
     );
   }
 
@@ -32,6 +32,7 @@ class EntityDecisionHotkeys extends Component {
     if (selectedXrefResult) {
       selectedXrefResult.judgement = selectedXrefResult.judgement === judgement ? 'no_judgement' : judgement
       onDecide(selectedXrefResult);
+      console.log('selecting next');
       this.selectNext();
     }
   }
@@ -41,7 +42,9 @@ class EntityDecisionHotkeys extends Component {
     if (!nextSelected) { return; }
 
     const parsedHash = queryString.parse(location.hash);
-    parsedHash.selectedId = nextSelected.id;
+    parsedHash.selectedId = nextSelected.id || nextSelected.entityId;
+
+    console.log('updating query', nextSelected)
 
     history.replace({
       pathname: location.pathname,
@@ -54,6 +57,7 @@ class EntityDecisionHotkeys extends Component {
     const { history, location, result } = this.props;
     const selectedIndex = this.getCurrentSelectedIndex();
     const hasNext = result.results && result.results.length > (selectedIndex + 1)
+    console.log('hasNext', selectedIndex, hasNext)
     if (hasNext) {
       this.updateQuery(result.results[selectedIndex + 1]);
     }

--- a/ui/src/components/common/EntityDecisionHotkeys.jsx
+++ b/ui/src/components/common/EntityDecisionHotkeys.jsx
@@ -17,34 +17,31 @@ class EntityDecisionHotkeys extends Component {
     this.selectPrevious = this.selectPrevious.bind(this);
   }
 
-  getCurrentSelectedIndex() {
-    const { result, selectedId } = this.props;
+  componentDidUpdate(prevProps) {
+    const { result, selectedIndex } = this.props;
+    const newLength = result.results?.length;
 
-    return result.results?.findIndex(
-      item => (item.id || item.entityId) === selectedId,
-    );
+    if (prevProps.result.results?.length !== newLength && selectedIndex >= newLength) {
+      this.updateQuery(newLength - 1);
+    }
   }
 
   onDecideSelected(judgement) {
     const { history, location, onDecide, result, selectedIndex } = this.props;
 
-    const selectedXrefResult = result.results?.[this.getCurrentSelectedIndex()];
+    const selectedXrefResult = result.results?.[selectedIndex === -1 ? 0 : selectedIndex];
     if (selectedXrefResult) {
       selectedXrefResult.judgement = selectedXrefResult.judgement === judgement ? 'no_judgement' : judgement
       onDecide(selectedXrefResult);
-      console.log('selecting next');
       this.selectNext();
     }
   }
 
   updateQuery(nextSelected) {
     const { history, location } = this.props;
-    if (!nextSelected) { return; }
 
     const parsedHash = queryString.parse(location.hash);
-    parsedHash.selectedId = nextSelected.id || nextSelected.entityId;
-
-    console.log('updating query', nextSelected)
+    parsedHash.selectedIndex = nextSelected;
 
     history.replace({
       pathname: location.pathname,
@@ -54,26 +51,26 @@ class EntityDecisionHotkeys extends Component {
   }
 
   selectNext() {
-    const { history, location, result } = this.props;
-    const selectedIndex = this.getCurrentSelectedIndex();
+    const { history, location, result, selectedIndex } = this.props;
     const hasNext = result.results && result.results.length > (selectedIndex + 1)
-    console.log('hasNext', selectedIndex, hasNext)
+
     if (hasNext) {
-      this.updateQuery(result.results[selectedIndex + 1]);
+      this.updateQuery(selectedIndex + 1);
     }
   }
 
   selectPrevious() {
-    const { history, location, result } = this.props;
-    const selectedIndex = this.getCurrentSelectedIndex();
+    const { history, location, result, selectedIndex } = this.props;
     const hasPrevious = result.results?.length && selectedIndex > 0;
     if (hasPrevious) {
-      this.updateQuery(result.results[selectedIndex - 1]);
+      this.updateQuery(selectedIndex - 1);
     }
   }
 
   render() {
     const { children, } = this.props;
+
+    console.log(this.props.selectedIndex)
 
     return (
       <HotKeysContainer
@@ -105,7 +102,7 @@ const mapStateToProps = (state, ownProps) => {
   const { location } = ownProps;
   const parsedHash = queryString.parse(location.hash);
 
-  return { selectedId: parsedHash.selectedId };
+  return { selectedIndex: parsedHash.selectedIndex ? +parsedHash.selectedIndex : -1 };
 }
 
 export default compose(

--- a/ui/src/components/common/EntityDecisionHotkeys.jsx
+++ b/ui/src/components/common/EntityDecisionHotkeys.jsx
@@ -1,12 +1,10 @@
 import React, { Component } from 'react';
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import queryString from 'query-string';
 import { withRouter } from 'react-router';
 
 import { ErrorSection, HotKeysContainer } from 'components/common';
-import { showWarningToast } from 'app/toast';
 
 
 class EntityDecisionHotkeys extends Component {
@@ -27,7 +25,7 @@ class EntityDecisionHotkeys extends Component {
   }
 
   onDecideSelected(judgement) {
-    const { history, location, onDecide, result, selectedIndex } = this.props;
+    const {onDecide, result, selectedIndex } = this.props;
 
     const selectedXrefResult = result.results?.[selectedIndex === -1 ? 0 : selectedIndex];
     if (selectedXrefResult) {
@@ -51,7 +49,7 @@ class EntityDecisionHotkeys extends Component {
   }
 
   selectNext() {
-    const { history, location, result, selectedIndex } = this.props;
+    const { result, selectedIndex } = this.props;
     const hasNext = result.results && result.results.length > (selectedIndex + 1)
 
     if (hasNext) {
@@ -60,7 +58,7 @@ class EntityDecisionHotkeys extends Component {
   }
 
   selectPrevious() {
-    const { history, location, result, selectedIndex } = this.props;
+    const { result, selectedIndex } = this.props;
     const hasPrevious = result.results?.length && selectedIndex > 0;
     if (hasPrevious) {
       this.updateQuery(selectedIndex - 1);
@@ -108,5 +106,4 @@ const mapStateToProps = (state, ownProps) => {
 export default compose(
   withRouter,
   connect(mapStateToProps),
-  injectIntl,
 )(EntityDecisionHotkeys);

--- a/ui/src/components/common/EntityDecisionRow.jsx
+++ b/ui/src/components/common/EntityDecisionRow.jsx
@@ -11,7 +11,6 @@ import './EntityDecisionRow.scss';
 class EntityDecisionRow extends Component {
   constructor(props) {
     super(props);
-    this.onSelect = this.onSelect.bind(this);
     this.ref = React.createRef();
   }
 
@@ -31,24 +30,11 @@ class EntityDecisionRow extends Component {
     }
   }
 
-  onSelect() {
-    const { history, location, objId } = this.props;
-
-    const parsedHash = queryString.parse(location.hash);
-    parsedHash.selectedId = objId;
-
-    history.replace({
-      pathname: location.pathname,
-      search: location.search,
-      hash: queryString.stringify(parsedHash),
-    });
-  }
-
   render() {
-    const { className, children, selected } = this.props;
+    const { className, children, objId, selected } = this.props;
 
     return (
-      <tr className={c("EntityDecisionRow", className, { selected })} ref={this.ref} onClick={this.onSelect} >
+      <tr key={objId} className={c("EntityDecisionRow", className, { selected })} ref={this.ref}>
         {children}
       </tr>
     );

--- a/ui/src/components/common/EntityDecisionRow.jsx
+++ b/ui/src/components/common/EntityDecisionRow.jsx
@@ -1,0 +1,68 @@
+import React, { Component } from 'react';
+import c from 'classnames';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import queryString from 'query-string';
+import { withRouter } from 'react-router';
+
+
+import './EntityDecisionRow.scss';
+
+class EntityDecisionRow extends Component {
+  constructor(props) {
+    super(props);
+    this.onSelect = this.onSelect.bind(this);
+    this.ref = React.createRef();
+  }
+
+  componentDidMount() {
+    const { selected } = this.props;
+
+    if (selected) {
+      this.ref.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { selected } = this.props;
+
+    if (selected && !prevProps.selected) {
+      this.ref.current.scrollIntoView({ behavior: "smooth" });
+    }
+  }
+
+  onSelect() {
+    const { history, location, objId } = this.props;
+
+    const parsedHash = queryString.parse(location.hash);
+    parsedHash.selectedId = objId;
+
+    history.replace({
+      pathname: location.pathname,
+      search: location.search,
+      hash: queryString.stringify(parsedHash),
+    });
+  }
+
+  render() {
+    const { className, children, selected } = this.props;
+
+    return (
+      <tr className={c("EntityDecisionRow", className, { selected })} ref={this.ref} onClick={this.onSelect} >
+        {children}
+      </tr>
+    );
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const { location, objId } = ownProps;
+  const parsedHash = queryString.parse(location.hash);
+
+  return { selected: parsedHash.selectedId === objId };
+}
+
+export default compose(
+  withRouter,
+  connect(mapStateToProps),
+)(EntityDecisionRow);

--- a/ui/src/components/common/EntityDecisionRow.jsx
+++ b/ui/src/components/common/EntityDecisionRow.jsx
@@ -27,7 +27,7 @@ class EntityDecisionRow extends Component {
   }
 
   render() {
-    const { className, children, objId, selected } = this.props;
+    const { className, children, selected } = this.props;
 
     return (
       <tr className={c("EntityDecisionRow", className, { selected })} ref={this.ref}>

--- a/ui/src/components/common/EntityDecisionRow.jsx
+++ b/ui/src/components/common/EntityDecisionRow.jsx
@@ -1,9 +1,5 @@
 import React, { Component } from 'react';
 import c from 'classnames';
-import { compose } from 'redux';
-import { connect } from 'react-redux';
-import queryString from 'query-string';
-import { withRouter } from 'react-router';
 
 
 import './EntityDecisionRow.scss';
@@ -34,21 +30,11 @@ class EntityDecisionRow extends Component {
     const { className, children, objId, selected } = this.props;
 
     return (
-      <tr key={objId} className={c("EntityDecisionRow", className, { selected })} ref={this.ref}>
+      <tr className={c("EntityDecisionRow", className, { selected })} ref={this.ref}>
         {children}
       </tr>
     );
   }
 }
 
-const mapStateToProps = (state, ownProps) => {
-  const { location, objId } = ownProps;
-  const parsedHash = queryString.parse(location.hash);
-
-  return { selected: parsedHash.selectedId === objId };
-}
-
-export default compose(
-  withRouter,
-  connect(mapStateToProps),
-)(EntityDecisionRow);
+export default EntityDecisionRow;

--- a/ui/src/components/common/EntityDecisionRow.scss
+++ b/ui/src/components/common/EntityDecisionRow.scss
@@ -1,0 +1,7 @@
+@import "app/variables.scss";
+
+.EntityDecisionRow {
+  &.selected {
+    background: $light-gray4;
+  }
+}

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -3,6 +3,8 @@ import Breadcrumbs from './Breadcrumbs';
 import SignInCallout from './SignInCallout';
 import ClipboardInput from './ClipboardInput';
 import Category from './Category';
+import EntityDecisionHotkeys from './EntityDecisionHotkeys';
+import EntityDecisionRow from './EntityDecisionRow';
 import Frequency from './Frequency';
 import Restricted from './Restricted';
 import HotKeysContainer from './HotKeysContainer';
@@ -68,6 +70,8 @@ export {
   SectionLoading,
   TextLoading,
   ErrorSection,
+  EntityDecisionHotkeys,
+  EntityDecisionRow,
   SinglePane,
   SortableTH,
   Statistics,


### PR DESCRIPTION
Wrapped entity decision tables (as seen in collectionXrefMode, EntitySimilarMode, ProfileItemsMode, ProfileSimilarMode) in hotkeys wrapper

- Y: positive
- H: not enough information
- N: negative
- up: previous
- down: next