### PR TITLE
Bugfix in logic/matching:_make_queries

### DIFF
--- a/aleph/logic/matching.py
+++ b/aleph/logic/matching.py
@@ -30,7 +30,7 @@ def _make_queries(type_, value):
             yield {
                 "match": {
                     "fingerprints.text": {
-                        "query": value,
+                        "query": fp,
                         "operator": "and",
                         "minimum_should_match": "60%",
                     }


### PR DESCRIPTION
`_make_queries` was creating fingerprints but just re-using the raw input