### PR TITLE
Downloadable table CSVs + other UI tweaks

### DIFF
--- a/ui/src/app/App.scss
+++ b/ui/src/app/App.scss
@@ -173,10 +173,6 @@ a {
 
     &__text {
       display: inline-flex;
-
-      .bp3-icon {
-        margin-top: 2px;
-      }
     }
   }
 
@@ -241,4 +237,3 @@ a {
     display: none !important;
   }
 }
-

--- a/ui/src/app/tables.scss
+++ b/ui/src/app/tables.scss
@@ -144,10 +144,6 @@ table.data-table {
     opacity: 0.5;
   }
 
-  tr.viewed td {
-    opacity: 0.5;
-  }
-
   td {
     border-bottom: 1px solid $aleph-table-border-color;
   }

--- a/ui/src/app/variables.scss
+++ b/ui/src/app/variables.scss
@@ -18,7 +18,6 @@ $aleph-navbar-mobile-max-width: $aleph-screen-sm-max-width + $aleph-grid-size*12
 $aleph-breadcrumbs-background: $light-gray4;
 $aleph-page-background: white;
 $aleph-link-color: $pt-link-color;
-$aleph-visited-link-color: darken($aleph-link-color, 15%);
 // $aleph-sidebar-background: $dark-gray5;
 $aleph-sidebar-background: $pt-link-color;
 $aleph-sidebar-foreground: white;

--- a/ui/src/app/variables.scss
+++ b/ui/src/app/variables.scss
@@ -47,7 +47,7 @@ $aleph-sidebar-sm-width: $aleph-grid-size * 20;
 $aleph-sidepane-md-width: $aleph-grid-size * 27;
 
 $aleph-text-highlight-color: yellow;
-
+$aleph-visited-link-color: rgba($aleph-link-color, .6);
 $warning-border-color: #faebcc;
 $warning-background-color: #fcf8e3;
 $warning-text-color: #8a6d3b;

--- a/ui/src/components/CollectionIndex/CollectionIndex.scss
+++ b/ui/src/components/CollectionIndex/CollectionIndex.scss
@@ -10,4 +10,8 @@
       margin-bottom: $aleph-grid-size;
     }
   }
+
+  .index-item .bp3-icon {
+    margin-top: 2px;
+  }
 }

--- a/ui/src/components/Diagram/DiagramEditor.scss
+++ b/ui/src/components/Diagram/DiagramEditor.scss
@@ -5,7 +5,7 @@ $breadcrumb-height: 44px;
 
 .DiagramEditor {
   .NetworkDiagram {
-    height: calc(100vh - #{$top-nav-height + $breadcrumb-height});
+    height: calc(100vh - #{$top-nav-height + (2*$breadcrumb-height)});
     background: white;
     overflow: hidden;
   }

--- a/ui/src/components/EntitySearch/EntitySearchResults.scss
+++ b/ui/src/components/EntitySearch/EntitySearchResults.scss
@@ -26,6 +26,10 @@
     background: $aleph-text-highlight-color;
     font-style: normal;
   }
+
+  .highlights {
+    @include rtlSupportInvertedProp(padding, left, $aleph-grid-size*3.2, null);
+  }
 }
 
 //medium and small screen

--- a/ui/src/components/EntitySearch/EntitySearchResultsRow.jsx
+++ b/ui/src/components/EntitySearch/EntitySearchResultsRow.jsx
@@ -73,7 +73,7 @@ class EntitySearchResultsRow extends Component {
     // highlighted automatically.
     const isActive = parsedHash['preview:id'] && parsedHash['preview:id'] === entity.id;
     const isPrefix = !!highlights.length;
-    const resultClass = c('EntitySearchResultsRow', 'nowrap', { active: isActive }, { prefix: isPrefix }, { viewed: !!entity.lastViewed });
+    const resultClass = c('EntitySearchResultsRow', 'nowrap', { active: isActive }, { prefix: isPrefix });
     const highlightsClass = c('EntitySearchResultsRow', { active: isActive });
 
     return (

--- a/ui/src/components/Investigation/InvestigationHeading.scss
+++ b/ui/src/components/Investigation/InvestigationHeading.scss
@@ -40,7 +40,7 @@ $inner-padding: 15px;
 
     .metadata-shown & {
       width: 100%;
-      margin-top: 20px;
+      margin-top: 0;
       margin-bottom: $aleph-grid-size;
     }
   }
@@ -112,5 +112,9 @@ $inner-padding: 15px;
 
   .CollectionLink, .CategoryLink {
     color: white !important;
+  }
+
+  .CollectionInfo__item .value {
+    font-weight: 500;
   }
 }

--- a/ui/src/components/MappingIndex/MappingIndexItem.jsx
+++ b/ui/src/components/MappingIndex/MappingIndexItem.jsx
@@ -56,8 +56,6 @@ class MappingIndexItem extends PureComponent {
   getTitle() {
     const { link, tableEntity } = this.props;
 
-    console.log(tableEntity, link);
-
     if (tableEntity && !tableEntity.isPending) {
       const title = <Entity.Label entity={tableEntity} icon />;
       if (link) {

--- a/ui/src/components/Notification/Notification.scss
+++ b/ui/src/components/Notification/Notification.scss
@@ -14,9 +14,6 @@ $notification-items-padding: 1px;
   .notification-action {
     .param {
       font-weight: bold;
-      .bp3-icon, .bp3-icon svg {
-        @include rtlSupportInvertedProp(margin, right, $notification-items-padding*1.5, null);
-      }
       .Role {
         span {
           @include rtlSupportInvertedProp(padding, right, $notification-items-padding, null);

--- a/ui/src/components/Toolbar/DownloadButton.jsx
+++ b/ui/src/components/Toolbar/DownloadButton.jsx
@@ -63,7 +63,9 @@ class DownloadButton extends React.PureComponent {
     const { intl, document, dontWarnOnDownload } = this.props;
     const { checkboxChecked, isOpen } = this.state;
 
-    if (!document?.links?.file) {
+    const file = document?.links?.file || document?.links?.csv;
+
+    if (!file) {
       return null;
     }
 
@@ -74,7 +76,7 @@ class DownloadButton extends React.PureComponent {
           position={Position.BOTTOM_RIGHT}
         >
           <AnchorButton
-            href={document.links.file}
+            href={file}
             icon="download"
             download
             target="_blank"
@@ -134,7 +136,7 @@ class DownloadButton extends React.PureComponent {
           </div>
           <div className={Classes.ALERT_FOOTER}>
             <AnchorButton
-              href={document.links.file}
+              href={file}
               icon="download"
               download
               target="_blank"

--- a/ui/src/components/common/Entity.jsx
+++ b/ui/src/components/common/Entity.jsx
@@ -39,7 +39,7 @@ class EntityLink extends PureComponent {
       <Link
         to={link}
         onClick={preview ? this.onClick : undefined}
-        className={c('EntityLink', className)}
+        className={c('EntityLink', className, {visited: !!entity.lastViewed})}
       >
         {content}
       </Link>

--- a/ui/src/components/common/Entity.scss
+++ b/ui/src/components/common/Entity.scss
@@ -1,10 +1,7 @@
 @import "app/variables.scss";
 
 .EntityLink {
-  .active & {
-    opacity: 1 !important;
-  }
   &.visited, &:visited {
-    opacity: .65;
+    color: $aleph-visited-link-color;
   }
 }

--- a/ui/src/components/common/Entity.scss
+++ b/ui/src/components/common/Entity.scss
@@ -1,14 +1,10 @@
 @import "app/variables.scss";
 
 .EntityLink {
-  &:visited {
-    color: $aleph-visited-link-color;
+  .active & {
+    opacity: 1 !important;
   }
-
-  // &.profile {
-  //   color: $aleph-profile-dark;
-  //   &:visited {
-  //     color: $aleph-profile-dark-visited;
-  //   }
-  // }  
+  &.visited, &:visited {
+    opacity: .65;
+  }
 }

--- a/ui/src/components/common/EntityDecisionHotkeys.jsx
+++ b/ui/src/components/common/EntityDecisionHotkeys.jsx
@@ -68,8 +68,6 @@ class EntityDecisionHotkeys extends Component {
   render() {
     const { children, } = this.props;
 
-    console.log(this.props.selectedIndex)
-
     return (
       <HotKeysContainer
         hotKeys={[

--- a/ui/src/components/common/Mention.jsx
+++ b/ui/src/components/common/Mention.jsx
@@ -35,10 +35,16 @@ class MentionLink extends Component {
         hoverOpenDelay={100}
       >
         <Link to={href} className="Mention">
-          <Bp3Tag minimal interactive multiline>
-            <Tag.Icon field={prop.type.group} />
-            <span><Property.Value {...this.props} translitLookup={null} /></span>
-            <Count count={count} className="no-fill" />
+          <Bp3Tag
+            minimal
+            interactive
+            multiline
+            icon={<Tag.Icon field={prop.type.group} />}
+            rightIcon={<Count count={count} class="bp3-tag-remove" />}
+          >
+            <span className="Mention__text">
+              <Property.Value {...this.props} translitLookup={null} />
+            </span>
           </Bp3Tag>
         </Link>
       </Tooltip>

--- a/ui/src/components/common/Mention.scss
+++ b/ui/src/components/common/Mention.scss
@@ -1,4 +1,5 @@
 @import "app/variables.scss";
+@import "app/mixins.scss";
 
 .Mention {
   text-decoration: none !important;
@@ -16,5 +17,13 @@
       border: none;
       background: none !important;
     }
+  }
+
+  &__text {
+    @include breakText;
+    overflow: hidden;
+    max-width: 100%;
+    display: block;
+    padding: 0 $aleph-grid-size/4;
   }
 }

--- a/ui/src/dialogs/DocumentUploadDialog/DocumentUploadView.jsx
+++ b/ui/src/dialogs/DocumentUploadDialog/DocumentUploadView.jsx
@@ -91,15 +91,13 @@ export class DocumentUploadView extends PureComponent {
           numberOfFiles: filesToUpload.length,
           totalSize: <FileSize value={totalFileSize} />
         })}</p>
-        <div className="bp3-dialog-footer">
-          <div className="bp3-dialog-footer-actions">
-            <Button
-              type="submit"
-              intent={Intent.PRIMARY}
-              text={intl.formatMessage(messages.save)}
-              onClick={this.submit}
-            />
-          </div>
+        <div className="bp3-dialog-footer-actions">
+          <Button
+            type="submit"
+            intent={Intent.PRIMARY}
+            text={intl.formatMessage(messages.save)}
+            onClick={this.submit}
+          />
         </div>
       </div>
     );

--- a/ui/src/screens/SearchScreen/SearchScreen.jsx
+++ b/ui/src/screens/SearchScreen/SearchScreen.jsx
@@ -26,6 +26,10 @@ const messages = defineMessages({
     id: 'search.title',
     defaultMessage: 'Search: {title}',
   },
+  title_emptyq: {
+    id: 'search.title_emptyq',
+    defaultMessage: 'Search',
+  },
   loading: {
     id: 'search.loading',
     defaultMessage: 'Loading...',
@@ -35,8 +39,11 @@ const messages = defineMessages({
 export class SearchScreen extends React.Component {
   render() {
     const { query, result, intl } = this.props;
-    const titleStatus = result.query_text ? result.query_text : intl.formatMessage(messages.loading);
-    const title = intl.formatMessage(messages.title, { title: titleStatus });
+
+    const titleStatus = (result.isPending && !result.results?.length) ? intl.formatMessage(messages.loading) : query.getString('q');
+    const title = titleStatus
+      ? intl.formatMessage(messages.title, { title: titleStatus })
+      : intl.formatMessage(messages.title_emptyq);
 
     return (
       <Screen title={title} >


### PR DESCRIPTION
Diagram Screen
- [x] Removed extra scroll height

Mentions
- [x] Improved wrapping formatting for multiline tags

Table Document Viewer
- [x] Allow csv uploads

Search Screen
- [x] Fixed screen title is super strange while loading and with empty query
- [x] Standardized browser :visited and localStorage visited to use same styling instead and slightly increased seen item opacity
- [x] Indented search highlights row for better readability of results

Upload Dialog 
- [x] Removed dp3-dialog-footer class from within dialog body

Investigation Sidebar
- [x] Slightly more contrast between investigation metadata labels and values

Notifications
- [x] Uniform icon spacing