### PR TITLE
Group entities search

### DIFF
--- a/ui/src/components/QueryTags/QueryTags.jsx
+++ b/ui/src/components/QueryTags/QueryTags.jsx
@@ -4,11 +4,15 @@ import _ from 'lodash';
 import { Button } from '@blueprintjs/core';
 import QueryFilterTag from './QueryFilterTag';
 
+const HIDDEN_TAGS_CUTOFF = 10;
+
 class QueryTags extends Component {
   constructor(props) {
     super(props);
     this.removeFilterValue = this.removeFilterValue.bind(this);
     this.removeAllFilterValues = this.removeAllFilterValues.bind(this);
+
+    this.state = { showHidden: false };
   }
 
   removeFilterValue(filter, value) {
@@ -30,6 +34,8 @@ class QueryTags extends Component {
 
   render() {
     const { query } = this.props;
+    const { showHidden } = this.state;
+
     let activeFilters = query ? query.filters() : [];
 
     if (activeFilters.length === 0) {
@@ -51,7 +57,9 @@ class QueryTags extends Component {
         .map(filter => query.getFilter(filter).map(value => ({ filter, value })))
     );
     const allTags = [...filterTags, ...addlTags];
+    const visibleTags = showHidden ? allTags : allTags.slice(0, HIDDEN_TAGS_CUTOFF);
 
+    const showHiddenToggle = !showHidden && allTags.length > HIDDEN_TAGS_CUTOFF;
     const showClearAll = allTags.length > 1;
 
     // @FIXME This should still selectively display filters for the following:
@@ -60,7 +68,7 @@ class QueryTags extends Component {
     // "?ancestors={id}"
     return (
       <div className="QueryTags">
-        {allTags.map(({ filter, value }) => (
+        {visibleTags.map(({ filter, value }) => (
           <QueryFilterTag
             filter={filter}
             value={value}
@@ -68,6 +76,19 @@ class QueryTags extends Component {
             key={value}
           />
         ))}
+        {showHiddenToggle && (
+          <Button
+            className="filter-clear-tag bp3-tag bp3-large QueryFilterTag"
+            onClick={() => this.setState({ showHidden: true })}
+            outlined
+          >
+            <FormattedMessage
+              id="queryFilters.showHidden"
+              defaultMessage="Show {count} more filters..."
+              values={{ count: allTags.length - visibleTags.length }}
+            />
+          </Button>
+        )}
         {showClearAll && (
           <Button
             className="filter-clear-tag bp3-tag bp3-large QueryFilterTag"

--- a/ui/src/screens/GroupScreen/GroupScreen.jsx
+++ b/ui/src/screens/GroupScreen/GroupScreen.jsx
@@ -8,7 +8,7 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import queryString from 'query-string';
-import { Button, Callout, Icon, Intent } from '@blueprintjs/core';
+import { Callout, Intent } from '@blueprintjs/core';
 
 import Query from 'app/Query';
 import Dashboard from 'components/Dashboard/Dashboard';
@@ -95,12 +95,13 @@ export class GroupScreen extends Component {
                 defaultMessage="The list below shows all datasets and investigations that belong to this group."
               />
             </p>
-            <Callout intent={Intent.PRIMARY}>
+            <Callout intent={Intent.PRIMARY} style={{ marginTop: '20px' }}>
               <FormattedMessage
                 id="group.page.description"
-                defaultMessage="If you would like to search for specific entities or documents within the datasets that this group has access to, <link>click here</link>."
+                defaultMessage="If you would like to search for specific entities or documents within the datasets that this group has access to, <link>click here</link> instead."
                 values={{
-                  link: chunks => <a role="button" onClick={this.goToEntitySearch} style={{ fontWeight: 'bold' }}>{chunks}</a>,
+                  // eslint-disable-next-line
+                  link: chunks => <a role="button" onClick={this.goToEntitySearch}>{chunks}</a>,
                 }}
               />
             </Callout>

--- a/ui/src/screens/GroupScreen/GroupScreen.jsx
+++ b/ui/src/screens/GroupScreen/GroupScreen.jsx
@@ -25,7 +25,7 @@ const messages = defineMessages({
   },
   placeholder: {
     id: 'sources.index.placeholder',
-    defaultMessage: 'Search datasets and investigations belonging to {group}...',
+    defaultMessage: 'Search for a dataset or investigation belonging to {group}...',
   },
 });
 


### PR DESCRIPTION
- Link from group screen to `/search` with group's collections pre-selected as filters
- Togglable display cutoff for query tags component to handle cases where many filters are active