### PR TITLE
Replace deprecated blueprint Menu.* and Icon.* references

### DIFF
--- a/ui/src/app/initializeIconRenderer.jsx
+++ b/ui/src/app/initializeIconRenderer.jsx
@@ -2,13 +2,17 @@ import React from 'react';
 import { IconRegistry } from '@alephdata/followthemoney';
 import { Icon as BlueprintIcon } from '@blueprintjs/core';
 
-const defaultIconSize = BlueprintIcon.SIZE_STANDARD;
+const FTM_ICON_SIZE = IconRegistry.SIZE;
 
 /* eslint-disable no-underscore-dangle */
 const renderSvgPaths = (pathsSize, iconName) => {
   const iconPaths = IconRegistry.getIcon(iconName);
   if (iconPaths) {
-    return iconPaths.map(d => <path key={d} d={d} fillRule="evenodd" />);
+    return (
+      <g transform={`scale(${pathsSize/FTM_ICON_SIZE})`}>
+        {iconPaths.map(d => <path key={d} d={d} fillRule="evenodd" />)}
+      </g>
+    );
   } return BlueprintIcon.prototype._renderSvgPaths(pathsSize, iconName);
 };
 
@@ -20,28 +24,12 @@ export default function initializeIconRenderer() {
   if (!BlueprintIcon.prototype._renderSvgPaths) {
     BlueprintIcon.prototype._renderSvgPaths = BlueprintIcon.prototype.renderSvgPaths;
   }
-  
+
   Object.assign(BlueprintIcon.prototype, {
     render() {
-      const props = { ...this.props };
-      if (!!IconRegistry.getIcon(this.props.icon)) {
-        // for internal icons, viewport needs to be 25 * 25, while svg dimensions
-        //  should be set to standard blueprint size
-        props.iconSize = props.iconSize || defaultIconSize;
-
-        Object.assign(BlueprintIcon, {
-          SIZE_STANDARD: 25,
-          SIZE_LARGE: 25,
-        });
-      }
-      const renderedIcon = BlueprintIcon.prototype._render.apply(
-        { ...this, props, renderSvgPaths },
+      return BlueprintIcon.prototype._render.apply(
+        { ...this, renderSvgPaths },
       );
-      Object.assign(BlueprintIcon, {
-        SIZE_STANDARD: 16,
-        SIZE_LARGE: 20,
-      });
-      return renderedIcon;
     },
   });
 }

--- a/ui/src/components/Collection/CollectionManageMenu.jsx
+++ b/ui/src/components/Collection/CollectionManageMenu.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { injectIntl, defineMessages } from 'react-intl';
-import { Button, Popover, Menu, Intent } from '@blueprintjs/core';
+import { Button, Popover, Menu, MenuItem, Intent } from '@blueprintjs/core';
 
 import CollectionEditDialog from 'dialogs/CollectionEditDialog/CollectionEditDialog';
 import CollectionAccessDialog from 'dialogs/CollectionAccessDialog/CollectionAccessDialog';
@@ -60,31 +60,31 @@ class CollectionManageMenu extends React.Component {
         <Popover>
           <Button icon="cog" rightIcon="caret-down" />
           <Menu>
-            <Menu.Item
+            <MenuItem
               key={"edit"}
               onClick={() => this.toggleDialog('isEditOpen')}
               text={intl.formatMessage(messages.edit)}
               icon="cog"
             />
-            <Menu.Item
+            <MenuItem
               key={"access"}
               onClick={() => this.toggleDialog('isAccessOpen')}
               text={intl.formatMessage(messages.access)}
               icon="key"
             />
-            <Menu.Item
+            <MenuItem
               key={"reingest"}
               onClick={() => this.toggleDialog('isReingestOpen')}
               text={intl.formatMessage(messages.reingest)}
               icon="automatic-updates"
             />
-            <Menu.Item
+            <MenuItem
               key={"reindex"}
               onClick={() => this.toggleDialog('isReindexOpen')}
               text={intl.formatMessage(messages.reindex)}
               icon="search-template"
             />
-            <Menu.Item
+            <MenuItem
               key={"delete"}
               onClick={() => this.toggleDialog('isDeleteOpen')}
               text={intl.formatMessage(deleteMessage)}

--- a/ui/src/components/Timeline/TimelineItemMenu.jsx
+++ b/ui/src/components/Timeline/TimelineItemMenu.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { compose } from 'redux';
 import { withRouter } from 'react-router';
 import { defineMessages, injectIntl } from 'react-intl';
-import { Button, Intent, Menu, Popover } from '@blueprintjs/core';
+import { Button, Intent, Menu, MenuDivider, MenuItem, Popover } from '@blueprintjs/core';
 import { ColorPicker } from '@alephdata/react-ftm';
 import queryString from 'query-string';
 
@@ -68,22 +68,22 @@ class TimelineItemMenu extends Component {
                   currSelected={color}
                   onSelect={onColorSelect}
                 />
-                <Menu.Divider />
+                <MenuDivider />
               </>
             )}
-            <Menu.Item
+            <MenuItem
               onClick={this.onCopyLink}
               text={intl.formatMessage(messages.link_copy)}
               icon="link"
             />
             {writeable && (
               <>
-                <Menu.Item
+                <MenuItem
                   onClick={() => onRemove(entity.id)}
                   text={intl.formatMessage(messages.remove)}
                   icon="remove"
                 />
-                <Menu.Item
+                <MenuItem
                   onClick={() => onDelete(entity.id)}
                   text={intl.formatMessage(messages.delete, { collection: <Collection.Label collection={entity.collection} icon={false} /> })}
                   icon="trash"


### PR DESCRIPTION
- Replaces deprecated blueprint Menu.Item and Menu.Divider with MenuItem and MenuDivider
- Replaces reference to deprecated blueprint Icon.SIZE_* 
- Implements a slightly different (better?) approach for overloading the default blueprint icon renderer to render custom ftm icons, by using a scale transform instead of messing with the svg viewport prop