### PR TITLE
Add followthemoney-compare model to XREF

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 # build-essential 
 RUN apt-get -qq -y update \
     && apt-get -qq -y install locales \
-    ca-certificates postgresql-client libpq-dev curl jq\
+    ca-certificates postgresql-client libpq-dev curl jq \
     python3-pip python3-icu python3-psycopg2 \
     python3-lxml python3-crypto \
     && apt-get -qq -y autoremove \
@@ -29,13 +29,20 @@ WORKDIR /aleph
 ENV PYTHONPATH /aleph
 RUN pip install -q -e /aleph
 
+RUN mkdir -p /opt/ftm-compare/word-frequencies/ && \
+    curl -L -o "/opt/ftm-compare/word-frequencies/word-frequencies.zip" "https://public.data.occrp.org/develop/models/word-frequencies/word_frequencies.zip" && \
+    python3 -m zipfile --extract /opt/ftm-compare/word-frequencies/word-frequencies.zip /opt/ftm-compare/word-frequencies/ && \
+    curl -L -o "/opt/ftm-compare/model.pkl" "https://public.data.occrp.org/develop/models/xref/glm_bernoulli_2e_wf-v0.4.1.pkl"
+
 # Configure some docker defaults:
 ENV ALEPH_ELASTICSEARCH_URI=http://elasticsearch:9200/ \
     ALEPH_DATABASE_URI=postgresql://aleph:aleph@postgres/aleph \
     FTM_STORE_URI=postgresql://aleph:aleph@postgres/aleph \
     REDIS_URL=redis://redis:6379/0 \
     ARCHIVE_TYPE=file \
-    ARCHIVE_PATH=/data
+    ARCHIVE_PATH=/data \
+    FTM_COMPARE_FREQUENCIES_DIR=/opt/ftm-compare/word-frequencies/ \
+    FTM_COMPARE_MODEL=/opt/ftm-compare/model.pkl
 
 # Run the green unicorn
 CMD gunicorn -w 5 -b 0.0.0.0:8000 --log-level info --log-file - aleph.manage:app

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,10 +29,12 @@ WORKDIR /aleph
 ENV PYTHONPATH /aleph
 RUN pip install -q -e /aleph
 
+ENV ALEPH_WORD_FREQUENCY_URI=https://public.data.occrp.org/develop/models/word-frequencies/word_frequencies-v0.4.1.zip
+ENV ALEPH_FTM_COMPARE_MODEL_URI=https://public.data.occrp.org/develop/models/xref/glm_bernoulli_2e_wf-v0.4.1.pkl
 RUN mkdir -p /opt/ftm-compare/word-frequencies/ && \
-    curl -L -o "/opt/ftm-compare/word-frequencies/word-frequencies.zip" "https://public.data.occrp.org/develop/models/word-frequencies/word_frequencies.zip" && \
+    curl -L -o "/opt/ftm-compare/word-frequencies/word-frequencies.zip" "$ALEPH_WORD_FREQUENCY_URI" && \
     python3 -m zipfile --extract /opt/ftm-compare/word-frequencies/word-frequencies.zip /opt/ftm-compare/word-frequencies/ && \
-    curl -L -o "/opt/ftm-compare/model.pkl" "https://public.data.occrp.org/develop/models/xref/glm_bernoulli_2e_wf-v0.4.1.pkl"
+    curl -L -o "/opt/ftm-compare/model.pkl" "$ALEPH_FTM_COMPARE_MODEL_URI"
 
 # Configure some docker defaults:
 ENV ALEPH_ELASTICSEARCH_URI=http://elasticsearch:9200/ \

--- a/aleph/index/xref.py
+++ b/aleph/index/xref.py
@@ -62,6 +62,7 @@ def _index_form(collection, matches):
             "_source": {
                 "score": match.score,
                 "doubt": match.doubt,
+                "method": match.method,
                 "random": randint(1, 2 ** 31),
                 "entity_id": match.entity.id,
                 "schema": match.match.schema.name,

--- a/aleph/logic/xref.py
+++ b/aleph/logic/xref.py
@@ -68,6 +68,7 @@ def _bulk_compare(proxies):
         return
     if settings.XREF_MODEL is None:
         yield from _bulk_compare_ftm(proxies)
+        return
     global MODEL
     if MODEL is None:
         try:
@@ -77,6 +78,7 @@ def _bulk_compare(proxies):
             log.exception(f"Could not find model file: {settings.XREF_MODEL}")
             settings.XREF_MODEL = None
             yield from _bulk_compare_ftm(proxies)
+            return
     yield from _bulk_compare_ftmc_model(proxies)
 
 

--- a/aleph/search/__init__.py
+++ b/aleph/search/__init__.py
@@ -88,6 +88,7 @@ class XrefQuery(Query):
     SORT_DEFAULT = [{"score": "desc"}]
     SORT_FIELDS = {
         "random": "random",
+        "doubt": "doubt",
         "score": "_score",
     }
     AUTHZ_FIELD = "match_collection_id"
@@ -103,7 +104,7 @@ class XrefQuery(Query):
         filters = super(XrefQuery, self).get_filters(**kwargs)
         filters.append({"term": {"collection_id": self.collection_id}})
         sorts = [f for (f, _) in self.parser.sorts]
-        if "random" not in sorts:
+        if "random" not in sorts and "doubt" not in sorts:
             filters.append({"range": {"score": {"gt": self.SCORE_CUTOFF}}})
         return filters
 

--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -177,3 +177,7 @@ INDEX_EXPAND_CLAUSE_LIMIT = env.to_int("ALEPH_INDEX_EXPAND_CLAUSE_LIMIT", 10)
 INDEX_DELETE_BY_QUERY_BATCHSIZE = env.to_int(
     "ALEPH_INDEX_DELETE_BY_QUERY_BATCHSIZE", 100
 )
+
+###############################################################################
+# XREF Model Selection
+XREF_MODEL = env.get("FTM_COMPARE_MODEL", None)

--- a/aleph/views/xref_api.py
+++ b/aleph/views/xref_api.py
@@ -33,12 +33,6 @@ def index(collection_id):
         required: true
         schema:
           type: integer
-      - in: query
-        name: evaluation_mode
-        required: false
-        schema:
-          type: bool
-          default: false
       responses:
         '200':
           description: OK

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 banal==1.0.6
 followthemoney==2.7.3
 followthemoney-store[postgresql]==3.0.3
+followthemoney-compare==0.4.1
 fingerprints==1.0.3
 servicelayer[google,amazon]==1.18.2
 normality==2.2.5


### PR DESCRIPTION
This PR puts the glm-bernoulli-2e model from `followthemoney-compare` into use for aleph's XREF system. In order to do so, the Dockerfile now downloads word frequency information and the model data from public.data.occrp.org and it's all loaded in `aleph.logic.xref`. The model is lazy-loaded on xref evaluation and we fall back to `followthemoney.compare` if the model can't be loaded.

Since the new model also has a measure of confidence associated to it, we added a `doubt` field to the xref index. The smaller this doubt is, the more confident we are in the result. This doubt parameter can be sorted on when requesting XREF from the API. (@kjacks afaik all we need to change the evaluation mode from random to this doubt is to change the requsted sort parameter to `&sort=doubt:desc`).

In order to maintain some sort of insight as to what is calculated by who, we also add a `method` field into the xref index which contains version information about the model which calculated that particular xref.