### PR TITLE
Search Results: use date histogram for all date-type property filters

### DIFF
--- a/ui/src/app/Query.js
+++ b/ui/src/app/Query.js
@@ -191,14 +191,15 @@ class Query {
 
   addFacet(facet) {
     const field = facet.isProperty ? `properties.${facet.name}` : facet.name;
-    const newQuery = this.add('facet', field)
+    let newQuery = this.add('facet', field)
       .set(`facet_size:${field}`, facet.defaultSize || 10)
       .set(`facet_total:${field}`, true);
 
-    if (field === 'dates') {
-      return newQuery.add('facet_interval:dates', 'year');
-    } else if (facet.isProperty) {
-      return newQuery.set(`facet_type:${field}`, facet.type);
+    if (field === 'dates' || facet.type === 'date') {
+      newQuery = newQuery.add(`facet_interval:${field}`, 'year');
+    }
+    if (facet.isProperty) {
+      newQuery = newQuery.set(`facet_type:${field}`, facet.type);
     }
     return newQuery;
   }
@@ -209,11 +210,12 @@ class Query {
       .set(`facet_size:${field}`, undefined)
       .set(`facet_total:${field}`, undefined)
       .set(`facet_type:${field}`, undefined)
-      .remove('facet_interval:dates', 'year');
+      .remove(`facet_interval:${field}`, 'year');
   }
 
   getFacetType(field) {
-    return this.getString(`facet_type:${field}`);
+    const cleanedField = field.replace('gte:', '').replace('lte:', '').replace('eq:', '')
+    return this.getString(`facet_type:${cleanedField}`);
   }
 
   hasFacet(field) {

--- a/ui/src/components/Facet/DateFacet.jsx
+++ b/ui/src/components/Facet/DateFacet.jsx
@@ -29,7 +29,7 @@ export class DateFilter extends Component {
   }
 
   onSelect(selected) {
-    const { query, updateQuery } = this.props;
+    const { field, query, updateQuery } = this.props;
 
     let newRange;
     if (Array.isArray(selected)) {
@@ -38,8 +38,8 @@ export class DateFilter extends Component {
       const year = formatDateQParam(selected);
       newRange = [year, year];
     }
-    const newQuery = query.setFilter('gte:dates', newRange[0])
-      .setFilter('lte:dates', newRange[1]);
+    const newQuery = query.setFilter(`gte:${field}`, newRange[0])
+      .setFilter(`lte:${field}`, newRange[1]);
 
     updateQuery(newQuery)
   }

--- a/ui/src/components/Facet/Facet.jsx
+++ b/ui/src/components/Facet/Facet.jsx
@@ -55,10 +55,10 @@ class Facet extends Component {
 
   onClearDates(event) {
     event.stopPropagation();
-    const { query } = this.props;
+    const { field, query } = this.props;
     const newQuery = query
-      .clearFilter('lte:dates')
-      .clearFilter('gte:dates');
+      .clearFilter(`lte:${field}`)
+      .clearFilter(`gte:${field}`);
 
     this.props.updateQuery(newQuery);
   }
@@ -76,7 +76,7 @@ class Facet extends Component {
   }
 
   renderDates() {
-    const { query } = this.props;
+    const { field, query } = this.props;
     const { facet } = this.state;
     const { intervals } = facet;
 
@@ -86,6 +86,7 @@ class Facet extends Component {
         query={query}
         updateQuery={this.props.updateQuery}
         showLabel={false}
+        field={field}
         emptyComponent={(
           <div className="Facet__no-options">
             <FormattedMessage
@@ -142,7 +143,7 @@ class Facet extends Component {
     const current = query.getFilter(field);
     const count = current ? current.length : 0;
     const isFiltered = query.getFilter(field).length > 0;
-    const isDate = field === 'dates';
+    const isDate = field === 'dates' || this.props.facet.type === 'date';
     const isUpdating = result.total === undefined;
 
     return (
@@ -188,7 +189,7 @@ class Facet extends Component {
               )}
             </>
           )}
-          {(isDate && isOpen && (query.hasFilter('gte:dates') || query.hasFilter('lte:dates'))) && (
+          {(isDate && isOpen && (query.hasFilter(`gte:${field}`) || query.hasFilter(`lte:${field}`))) && (
             <Button small minimal icon="reset" className="Facet__action" intent={Intent.DANGER} onClick={this.onClearDates}>
               <FormattedMessage
                 id="search.facets.clearDates"

--- a/ui/src/components/QueryTags/QueryFilterTag.jsx
+++ b/ui/src/components/QueryTags/QueryFilterTag.jsx
@@ -103,9 +103,9 @@ class QueryFilterTag extends PureComponent {
       case 'gte:dates':
       case 'date':
         let prefix;
-        if (filter === 'gte:dates') {
+        if (filter.includes('gte')) {
           prefix = <FormattedMessage id="search.filterTag.dates_after" defaultMessage="After " />
-        } else if (filter === 'lte:dates') {
+        } else if (filter.includes('lte')) {
           prefix = <FormattedMessage id="search.filterTag.dates_before" defaultMessage="Before " />
         }
 

--- a/ui/src/components/QueryTags/QueryTags.jsx
+++ b/ui/src/components/QueryTags/QueryTags.jsx
@@ -18,9 +18,10 @@ class QueryTags extends Component {
   removeFilterValue(filter, value) {
     const { query, updateQuery } = this.props;
     let newQuery;
-    if (filter === 'eq:dates') {
-      newQuery = query.removeFilter('gte:dates', value)
-        .removeFilter('lte:dates', value);
+    if (filter.includes('eq:')) {
+      const field = filter.replace('eq:', '')
+      newQuery = query.removeFilter(`gte:${field}`, value)
+        .removeFilter(`lte:${field}`, value);
     } else {
       newQuery = query.removeFilter(filter, value);
     }
@@ -37,20 +38,25 @@ class QueryTags extends Component {
     const { showHidden } = this.state;
 
     let activeFilters = query ? query.filters() : [];
-
     if (activeFilters.length === 0) {
       return null;
     }
 
+    // if gte and lte are equal to the same value for a field, remove and replace with a single equals tag
     let addlTags = [];
-    if (query.hasFilter('gte:dates') && query.hasFilter('lte:dates')) {
-      const gte = query.getFilter('gte:dates')[0];
-      const lte = query.getFilter('lte:dates')[0];
-      if (gte === lte) {
-        activeFilters = activeFilters.filter(f => (f !== 'gte:dates' && f !== 'lte:dates'))
-        addlTags.push({ filter: 'eq:dates', value: gte });
-      }
-    }
+    activeFilters
+      .filter(f => f.includes('gte:'))
+      .forEach(f => {
+        const field = f.replace('gte:', '');
+        if (query.hasFilter(`lte:${field}`)) {
+          const gte = query.getFilter(`gte:${field}`)[0];
+          const lte = query.getFilter(`lte:${field}`)[0];
+          if (gte === lte) {
+            activeFilters = activeFilters.filter(f => (f !== `gte:${field}` && f !== `lte:${field}`))
+            addlTags.push({ filter: `eq:${field}`, value: gte, type: 'date' });
+          }
+        }
+      })
 
     const filterTags = _.flatten(
       activeFilters


### PR DESCRIPTION
Fixes #1893 

@sunu @Rosencrantz - I realized we could use the existing supported elastic search operators on these date properties for the histogram API requests, so it was only some front-end component adaptation to show all of the date props as histograms :)