### PR TITLE
Make sure sorting by undefined field doesn't leave out entities

### DIFF
--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -16,6 +16,7 @@ from aleph.index.util import (
 from aleph.search.result import SearchQueryResult
 from aleph.search.parser import SearchQueryParser
 from aleph.index.entities import get_field_type
+from aleph.search.utils import get_index_field_type
 
 log = structlog.get_logger(__name__)
 
@@ -204,6 +205,9 @@ class Query(object):
             field = self.SORT_FIELDS.get(field, field)
             type_ = get_field_type(field)
             config = {"order": direction, "missing": "_last"}
+            es_type = get_index_field_type(type_)
+            if es_type:
+                config["unmapped_type"] = es_type
             if field == registry.date.group:
                 field = "numeric.dates"
                 config["mode"] = "min"

--- a/aleph/search/utils.py
+++ b/aleph/search/utils.py
@@ -1,0 +1,16 @@
+import logging
+
+from aleph.index.indexes import TYPE_MAPPINGS
+from aleph.index.util import NUMERIC_TYPES, NUMERIC, KEYWORD
+
+
+log = logging.getLogger(__name__)
+
+
+def get_index_field_type(type_):
+    """Given a FtM property type, return the corresponding ElasticSearch field type"""
+    es_type = TYPE_MAPPINGS.get(type_, KEYWORD)
+    if type_ in NUMERIC_TYPES:
+        es_type = NUMERIC
+    if es_type:
+        return es_type.get("type")


### PR DESCRIPTION
When we sort by a field that may be undefined in certain schemas, by
default ElasticSearch will  leave out the entities where the field is
undefined from the sorted results.

We use the `unmapped_type` argument to force ElasticSearch not to leave
out those entities from the sorted search results.

Fixes #1857