### PR TITLE
Improved Error Handling for Network Diagrams

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@alephdata/followthemoney": "2.6.0",
-    "@alephdata/react-ftm": "2.5.1",
+    "@alephdata/react-ftm": "2.5.3",
     "@blueprintjs/core": "3.47.0",
     "@blueprintjs/icons": "3.27.0",
     "@blueprintjs/popover2": "^0.11.0",

--- a/ui/src/components/common/ErrorBoundary.jsx
+++ b/ui/src/components/common/ErrorBoundary.jsx
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+
+import ErrorSection from './ErrorSection'
+
+class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { error: null };
+  }
+
+  componentDidCatch(error) {
+    this.setState({ error });
+  }
+
+  render() {
+    const { children, errorTitle } = this.props;
+
+    if (!!this.state.error) {
+      return (
+        <ErrorSection
+          title={errorTitle}
+          description={this.state.error.toString()}
+        />
+      )
+    }
+    return children;
+  }
+}
+
+export default ErrorBoundary;

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -24,6 +24,7 @@ import Role from './Role';
 import Schema from './Schema';
 import SectionLoading from './SectionLoading';
 import TextLoading from './TextLoading';
+import ErrorBoundary from './ErrorBoundary';
 import ErrorSection from './ErrorSection';
 import SinglePane from './SinglePane';
 import SortableTH from './SortableTH';
@@ -67,6 +68,7 @@ export {
   Schema,
   SectionLoading,
   TextLoading,
+  ErrorBoundary,
   ErrorSection,
   EntityDecisionHotkeys,
   EntityDecisionRow,

--- a/ui/src/screens/DiagramScreen/DiagramScreen.jsx
+++ b/ui/src/screens/DiagramScreen/DiagramScreen.jsx
@@ -15,7 +15,7 @@ import LoadingScreen from 'components/Screen/LoadingScreen';
 import ErrorScreen from 'components/Screen/ErrorScreen';
 import collectionViewIds from 'components/Collection/collectionViewIds';
 import CollectionView from 'components/Collection/CollectionView';
-import { Breadcrumbs, SearchBox, UpdateStatus } from 'components/common';
+import { Breadcrumbs, ErrorBoundary, SearchBox, UpdateStatus } from 'components/common';
 import { showErrorToast } from 'app/toast';
 
 const fileDownload = require('js-file-download');
@@ -24,6 +24,10 @@ const messages = defineMessages({
   export_error: {
     id: 'diagram.export.error',
     defaultMessage: 'Error exporting diagram',
+  },
+  render_error: {
+    id: 'diagram.render.error',
+    defaultMessage: 'Error rendering diagram',
   },
 })
 
@@ -89,7 +93,7 @@ export class DiagramScreen extends Component {
   }
 
   render() {
-    const { diagram, entitiesResult } = this.props;
+    const { diagram, entitiesResult, intl } = this.props;
     const { filterText, updateStatus } = this.state;
 
     if (diagram.isError) {
@@ -134,14 +138,16 @@ export class DiagramScreen extends Component {
         >
           <CollectionWrapper collection={diagram.collection}>
             {breadcrumbs}
-            <DiagramEditor
-              setRef={ref => this.editorRef = ref}
-              collection={diagram.collection}
-              onStatusChange={this.onStatusChange}
-              diagram={diagram}
-              entities={entitiesResult?.results}
-              filterText={filterText}
-            />
+            <ErrorBoundary errorTitle={intl.formatMessage(messages.render_error)}>
+              <DiagramEditor
+                setRef={ref => this.editorRef = ref}
+                collection={diagram.collection}
+                onStatusChange={this.onStatusChange}
+                diagram={diagram}
+                entities={entitiesResult?.results}
+                filterText={filterText}
+              />
+            </ErrorBoundary>
           </CollectionWrapper>
         </Screen>
       </>


### PR DESCRIPTION
Introduces ErrorBoundary wrapper component (see https://reactjs.org/docs/error-boundaries.html) to catch errors rendered deeper in the component tree of a given component.

In the case of Network Diagrams this allows the page to still render even if the diagram renderer encounters an error, allowing for better error messaging to the user, easier debugging, and still allowing a user to access parts of the diagram like the export and metadata functionality even if there is a bug in the rendering flow.

Also includes a bugfix version bump for @alephdata/react-ftm 