### PR TITLE
HOT FIX: Modified CDN url for diagram embeds to fetch latest version of package

### DIFF
--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -143,7 +143,7 @@ PAGES_PATH = env.get("ALEPH_PAGES_PATH", PAGES_PATH)
 
 # Publishing network diagram embeds
 REACT_FTM_URL = (
-    "https://cdn.jsdelivr.net/npm/@alephdata/react-ftm@2.3.1/dist/react-ftm-embed.js"
+    "https://cdn.jsdelivr.net/npm/@alephdata/react-ftm@latest/dist/react-ftm-embed.js"
 )
 
 ##############################################################################


### PR DESCRIPTION
The CDN url in settings.py was set to a fixed version number, preventing us from pushing updates to the network diagrams code that is bundled with an embed.

@sunu @Rosencrantz I'm not so familiar with the python settings config, but if there is a way to fetch the version number from `ui/package.json` that would be preferable to using `latest`. But if not, then this works too.