### PR TITLE
Add support for Oauth2 Bearer Tokens

### DIFF
--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -166,6 +166,19 @@ class Authz(object):
         )
 
     @classmethod
+    def from_access_token(cls, token):
+        email = token.get("email", token.get("upn"))
+        sub = token.get("sub", email)
+        if not sub:
+            raise Unauthorized()
+        role_id = "%s:%s" % (settings.OAUTH_HANDLER, sub)
+        role = Role.by_foreign_id(role_id)
+        if role is None:
+            name = token.get("name", token.get("given_name"))
+            role = Role.load_or_create(role_id, Role.USER, name, email=email)
+        return Authz.from_role(role)
+
+    @classmethod
     def flush(cls):
         cache.kv.delete(cls.ACCESS)
 

--- a/aleph/oauth.py
+++ b/aleph/oauth.py
@@ -29,7 +29,10 @@ def _parse_access_token(provider, oauth_token):
     token = oauth_token.get("access_token")
     if token is None:
         return {}
+    return parse_jwt_token(provider, token)
 
+
+def parse_jwt_token(provider, token):
     def load_key(header, payload):
         jwk_set = JsonWebKey.import_key_set(provider.fetch_jwk_set(force=True))
         return jwk_set.find_by_kid(header.get("kid"))

--- a/aleph/tests/test_authz.py
+++ b/aleph/tests/test_authz.py
@@ -76,3 +76,31 @@ class AuthzTestCase(TestCase):
             Authz.from_token("banana")
         sauthz = Authz.from_token(token)
         assert sauthz.id == authz.id
+
+    def test_access_token(self):
+        with self.assertRaises(Unauthorized):
+            Authz.from_access_token({})
+
+        authz_from_upn = Authz.from_access_token({
+            'name': self.user.name,
+            'upn': 'user.upn'
+        })
+        authz_from_email = Authz.from_access_token({
+            'name': self.user.name,
+            'email': self.user.email
+        })
+        authz_from_sub = Authz.from_access_token({
+            'name': self.user.name,
+            'sub': 'user.sub'
+        })
+        authz_from_all = Authz.from_access_token({
+            'name': self.user.name,
+            'upn': 'user.upn',
+            'email': self.user.email,
+            'sub': 'user.sub'
+        })
+
+        assert authz_from_email.id != authz_from_upn.id
+        assert authz_from_sub.id != authz_from_upn.id
+        assert authz_from_sub.id != authz_from_email.id
+        assert authz_from_sub.id == authz_from_all.id


### PR DESCRIPTION
**Context**
In order to call Alephs REST endpoints using a JWT token,
support for "Bearer" tokens needs to be added. With it,
Aleph will be able to serve requests from other clients
that use OIDC with the same Identity Server.

**Solution**
The changes are somewhat similar to the logic present in
the OAuth callback endpoint. Aleph tries to determine the
Role based on the foreign ID derived from the JWT token fields
but if it doesn't find one it will create it.
There is no support for groups yet since I haven't found the
need just yet, later tests with an actual Aleph setup and a
configured Indentity Server may uncover that they're needed.