### PR TITLE
Show documents tab to non-admin users for datasets

### DIFF
--- a/ui/src/components/Collection/CollectionView.jsx
+++ b/ui/src/components/Collection/CollectionView.jsx
@@ -52,6 +52,10 @@ const messages = defineMessages({
     id: 'collection.info.browse',
     defaultMessage: 'Documents',
   },
+  source_files: {
+    id: 'collection.info.source_files',
+    defaultMessage: 'Source files',
+  },
   entities: {
     id: 'collection.info.entities',
     defaultMessage: 'Entities',
@@ -81,6 +85,7 @@ const messages = defineMessages({
 const icons = {
   overview: 'grouped-bar-chart',
   documents: 'document',
+  source_files: 'document',
   entities: 'list-columns',
   xref: 'comparison',
   diagrams: 'graph',

--- a/ui/src/components/Collection/CollectionView.jsx
+++ b/ui/src/components/Collection/CollectionView.jsx
@@ -52,9 +52,9 @@ const messages = defineMessages({
     id: 'collection.info.browse',
     defaultMessage: 'Documents',
   },
-  source_files: {
-    id: 'collection.info.source_files',
-    defaultMessage: 'Source files',
+  source_documents: {
+    id: 'collection.info.source_documents',
+    defaultMessage: 'Source documents',
   },
   entities: {
     id: 'collection.info.entities',
@@ -85,7 +85,6 @@ const messages = defineMessages({
 const icons = {
   overview: 'grouped-bar-chart',
   documents: 'document',
-  source_files: 'document',
   entities: 'list-columns',
   xref: 'comparison',
   diagrams: 'graph',
@@ -104,9 +103,9 @@ const CollectionViewIcon = ({ id, className }) => {
 
 class CollectionViewLabel extends PureComponent {
   render() {
-    const { icon, id, intl } = this.props;
+    const { icon, id, intl, isCasefile } = this.props;
     if (!id) { return null; }
-    const messageKey = messages[id];
+    const messageKey = messages[id === 'documents' && !isCasefile ? 'source_documents' : id];
     if (!messageKey) { return null; }
 
     return (
@@ -119,7 +118,7 @@ class CollectionViewLabel extends PureComponent {
 }
 
 const CollectionViewLink = ({ id, collection, hash, search, children, ...rest }) => {
-  const content = children || <CollectionViewLabel id={id} {...rest} />
+  const content = children || <CollectionViewLabel id={id} isCasefile={collection.casefile} {...rest} />
   return (
     <Link to={getCollectionLink({ collection, mode: id, hash, search })}>
       {content}

--- a/ui/src/components/Collection/CollectionViews.jsx
+++ b/ui/src/components/Collection/CollectionViews.jsx
@@ -64,18 +64,16 @@ class CollectionViews extends React.Component {
             <CollectionOverviewMode isCasefile={false} collectionId={collectionId} />
           )}
         />
-        {collection.writeable && (
-          <Tab
-            id={collectionViewIds.DOCUMENTS}
-            className="CollectionViews__tab"
-            title={
-              <>
-                <CollectionView.Label id={collectionViewIds.DOCUMENTS} icon />
-                <CollectionView.Count id={collectionViewIds.DOCUMENTS} collectionId={collectionId} />
-              </>}
-            panel={<CollectionDocumentsMode collectionId={collectionId} />}
-          />
-        )}
+        <Tab
+          id={collectionViewIds.DOCUMENTS}
+          className="CollectionViews__tab"
+          title={
+            <>
+              <CollectionView.Label id={collectionViewIds.SOURCE_FILES} icon />
+              <CollectionView.Count id={collectionViewIds.DOCUMENTS} collectionId={collectionId} />
+            </>}
+          panel={<CollectionDocumentsMode collectionId={collectionId} />}
+        />
         <Tab
           id={collectionViewIds.XREF}
           className="CollectionViews__tab"

--- a/ui/src/components/Collection/CollectionViews.jsx
+++ b/ui/src/components/Collection/CollectionViews.jsx
@@ -69,10 +69,10 @@ class CollectionViews extends React.Component {
           className="CollectionViews__tab"
           title={
             <>
-              <CollectionView.Label id={collectionViewIds.SOURCE_FILES} icon />
+              <CollectionView.Label id={collectionViewIds.DOCUMENTS} icon isCasefile={false} />
               <CollectionView.Count id={collectionViewIds.DOCUMENTS} collectionId={collectionId} />
             </>}
-          panel={<CollectionDocumentsMode collectionId={collectionId} />}
+          panel={<CollectionDocumentsMode collectionId={collectionId} showSearch={false} />}
         />
         <Tab
           id={collectionViewIds.XREF}

--- a/ui/src/components/Collection/collectionViewIds.js
+++ b/ui/src/components/Collection/collectionViewIds.js
@@ -1,7 +1,6 @@
 const viewIds = {
   OVERVIEW: 'overview',
   DOCUMENTS: 'documents',
-  SOURCE_FILES: 'source_files',
   ENTITIES: 'entities',
   XREF: 'xref',
   DIAGRAMS: 'diagrams',

--- a/ui/src/components/Collection/collectionViewIds.js
+++ b/ui/src/components/Collection/collectionViewIds.js
@@ -1,6 +1,7 @@
 const viewIds = {
   OVERVIEW: 'overview',
   DOCUMENTS: 'documents',
+  SOURCE_FILES: 'source_files',
   ENTITIES: 'entities',
   XREF: 'xref',
   DIAGRAMS: 'diagrams',

--- a/ui/src/components/Document/DocumentManager.jsx
+++ b/ui/src/components/Document/DocumentManager.jsx
@@ -107,7 +107,7 @@ export class DocumentManager extends Component {
 
   render() {
     const {
-      collection, document, fileSizeProp, query, result, hasPending, intl,
+      collection, document, fileSizeProp, query, result, hasPending, intl, showSearch = true
     } = this.props;
     const { selection } = this.state;
     const mutableDocument = document === undefined || document?.schema?.name === 'Folder';
@@ -139,47 +139,49 @@ export class DocumentManager extends Component {
 
     return (
       <div className="DocumentManager">
-        <EntityActionBar
-          query={query}
-          writeable={showActions}
-          selection={selection}
-          resetSelection={() => this.setState({ selection: [] })}
-          onSearchSubmit={this.onSearchSubmit}
-          searchPlaceholder={searchPlaceholder}
-          searchDisabled={result.total === 0 && !query.hasQuery()}
-        >
-          {canUpload && (
+        {(showSearch || showActions) && (
+          <EntityActionBar
+            query={query}
+            writeable={showActions}
+            selection={selection}
+            resetSelection={() => this.setState({ selection: [] })}
+            onSearchSubmit={this.onSearchSubmit}
+            searchPlaceholder={searchPlaceholder}
+            searchDisabled={result.total === 0 && !query.hasQuery()}
+          >
+            {canUpload && (
+              <DialogToggleButton
+                buttonProps={{
+                  text: intl.formatMessage(messages.upload),
+                  icon: "upload"
+                }}
+                Dialog={DocumentUploadDialog}
+                dialogProps={{ collection, parent: document }}
+              />
+            )}
             <DialogToggleButton
               buttonProps={{
-                text: intl.formatMessage(messages.upload),
-                icon: "upload"
+                text: intl.formatMessage(messages.new),
+                icon: "folder-new"
               }}
-              Dialog={DocumentUploadDialog}
+              Dialog={DocumentFolderDialog}
               dialogProps={{ collection, parent: document }}
             />
-          )}
-          <DialogToggleButton
-            buttonProps={{
-              text: intl.formatMessage(messages.new),
-              icon: "folder-new"
-            }}
-            Dialog={DocumentFolderDialog}
-            dialogProps={{ collection, parent: document }}
-          />
-          <Divider />
-          <Tooltip content={canMap ? null : intl.formatMessage(messages.cannot_map)} className="prevent-flex-grow">
-            <AnchorButton icon="new-object" disabled={!canMap} onClick={this.openMappingEditor}>
-              <FormattedMessage id="document.mapping.start" defaultMessage="Generate entities" />
-            </AnchorButton>
-          </Tooltip>
-          <EntityDeleteButton
-            entities={selection}
-            onSuccess={() => this.setState({ selection: [] })}
-            actionType="delete"
-            deleteEntity={this.props.deleteEntity}
-            showCount
-          />
-        </EntityActionBar>
+            <Divider />
+            <Tooltip content={canMap ? null : intl.formatMessage(messages.cannot_map)} className="prevent-flex-grow">
+              <AnchorButton icon="new-object" disabled={!canMap} onClick={this.openMappingEditor}>
+                <FormattedMessage id="document.mapping.start" defaultMessage="Generate entities" />
+              </AnchorButton>
+            </Tooltip>
+            <EntityDeleteButton
+              entities={selection}
+              onSuccess={() => this.setState({ selection: [] })}
+              actionType="delete"
+              deleteEntity={this.props.deleteEntity}
+              showCount
+            />
+          </EntityActionBar>
+        )}
         {hasPending && (
           <Callout className="bp3-icon-info-sign bp3-intent-warning">
             <FormattedMessage

--- a/ui/src/components/Document/DocumentManager.jsx
+++ b/ui/src/components/Document/DocumentManager.jsx
@@ -119,23 +119,30 @@ export class DocumentManager extends Component {
       ? intl.formatMessage(messages.search_placeholder_document, { label: document.getCaption() })
       : intl.formatMessage(messages.search_placeholder);
 
-    const emptyComponent = (
-      <div className="DocumentManager__content__empty">
-        <DialogToggleButton
-          buttonProps={{
-            minimal: true,
-            fill: true,
-          }}
-          Dialog={DocumentUploadDialog}
-          dialogProps={{ collection, parent: document }}
-        >
-          <ErrorSection
-            icon={canUpload ? 'plus' : 'folder-open'}
-            title={intl.formatMessage(canUpload ? messages.emptyCanUpload : messages.empty)}
-          />
-        </DialogToggleButton>
-      </div>
-    );
+    const emptyComponent = canUpload
+      ? (
+        <div className="DocumentManager__content__empty">
+          <DialogToggleButton
+            buttonProps={{
+              minimal: true,
+              fill: true,
+            }}
+            Dialog={DocumentUploadDialog}
+            dialogProps={{ collection, parent: document }}
+          >
+            <ErrorSection
+              icon='plus'
+              title={intl.formatMessage(messages.emptyCanUpload)}
+            />
+          </DialogToggleButton>
+        </div>
+      )
+      : (
+        <ErrorSection
+          icon='folder-open'
+          title={intl.formatMessage(messages.empty)}
+        />
+      );
 
     return (
       <div className="DocumentManager">

--- a/ui/src/components/Investigation/InvestigationSidebar.jsx
+++ b/ui/src/components/Investigation/InvestigationSidebar.jsx
@@ -37,7 +37,7 @@ class InvestigationSidebar extends React.Component {
       <Button
         key={id}
         icon={<CollectionView.Icon id={id} />}
-        text={<CollectionView.Label id={id} />}
+        text={<CollectionView.Label id={id} isCasefile />}
         rightIcon={<CollectionView.Count id={id} collectionId={collection.id} />}
         onClick={() => this.navigate(id)}
         active={activeMode === id}

--- a/ui/src/components/Investigation/InvestigationViews.jsx
+++ b/ui/src/components/Investigation/InvestigationViews.jsx
@@ -73,7 +73,7 @@ class InvestigationViews extends React.Component {
       title = <Schema.Label schema={activeType} plural icon />;
       subheading = <Schema.Description schema={activeType} />
     } else if (!!activeMode) {
-      title = <CollectionView.Label id={activeMode} icon />;
+      title = <CollectionView.Label id={activeMode} icon isCasefile />;
       subheading = <CollectionView.Description id={activeMode} />
     }
 

--- a/ui/src/components/common/Schema.jsx
+++ b/ui/src/components/common/Schema.jsx
@@ -12,18 +12,19 @@ import collectionViewIds from 'components/Collection/collectionViewIds';
 
 function SchemaLink({ collection, location, schema, ...rest }) {
   const viewProps = { collection };
-  if (collection.casefile) {
-    if (schema.isDocument()) {
-      return <CollectionView.Link collection={collection} id={collectionViewIds.DOCUMENTS} icon />
-    } else {
+
+  if (schema.isDocument()) {
+    return <CollectionView.Link collection={collection} id={collectionViewIds.DOCUMENTS} icon />
+  } else {
+    if (collection.casefile) {
       viewProps.id = collectionViewIds.ENTITIES;
       viewProps.hash = { type: schema };
+    } else {
+      viewProps.id = collectionViewIds.SEARCH;
+      const query = collectionSearchQuery(location, collection.id)
+        .setFilter('schema', schema);
+      viewProps.search = query.toLocation();
     }
-  } else {
-    viewProps.id = collectionViewIds.SEARCH;
-    const query = collectionSearchQuery(location, collection.id)
-      .setFilter('schema', schema);
-    viewProps.search = query.toLocation();
   }
 
   return (


### PR DESCRIPTION
Fixes #2045 

Allows non-admin users to view the documents tab of a dataset 

@jlstro any thoughts on naming? I chose "Source documents" instead of something involving "File" because we're using "document" throughout the rest of the interface, but happy to change it to something else

<img width="1050" alt="Screen Shot 2021-11-11 at 12 43 45" src="https://user-images.githubusercontent.com/6720200/141296480-ac9ff057-1c20-4c95-b232-3e62edaab56d.png">
