### PR TITLE
Fix issue with Google OAuth integration

### DIFF
--- a/aleph/oauth.py
+++ b/aleph/oauth.py
@@ -1,6 +1,8 @@
 import logging
+from pprint import pformat  # noqa
 from authlib.jose import JsonWebToken, JsonWebKey
 from authlib.integrations.flask_client import OAuth
+from authlib.jose.errors import DecodeError
 
 from aleph import settings
 
@@ -43,7 +45,13 @@ def _parse_access_token(provider, oauth_token):
 
 def _get_groups(provider, oauth_token, id_token):
     """Groups are not standardised in OIDC, so this is provider-specific."""
-    access_token = _parse_access_token(provider, oauth_token)
+    try:
+        access_token = _parse_access_token(provider, oauth_token)
+    except DecodeError:
+        # Failed to parse the access_token as JWT. Most probably, the required
+        # information about groups is in the id_token.
+        access_token = {}
+
     groups = []
 
     # Amazon Cognito


### PR DESCRIPTION
OIDC doesn't specify the format for access_token. Some providers use it
as a JWT to store information about groups (eg: Keycloak), some don't
use it as a JWT (eg: Google).

So we try to parse it as a JWT but if that fails we ignore the error
and move on. In case the access_token is not an JWT, the groups info is
stored in the id_token and that's where we look.

Fixes #2003