### PR TITLE
Update helm examples

### DIFF
--- a/helm/examples/kind/Makefile
+++ b/helm/examples/kind/Makefile
@@ -1,5 +1,4 @@
 ENV="staging"
-PREFIX="aleph"
 
 create-cluster:
 	@echo "🔴 Creating a k8s cluster ..."
@@ -25,20 +24,20 @@ update-helm:
 
 install-postgres: update-helm
 	@echo "🔴 Installing Postgres database ..."
-	helm install $(PREFIX)-postgres bitnami/postgresql -f values/postgres.yml -n $(ENV)
+	helm install aleph-postgres bitnami/postgresql -f values/postgres.yml -n $(ENV)
 
 install-elasticsearch: update-helm
 	@echo "🔴 Installing Elasticsearch cluster ..."
-	helm install $(PREFIX)-index-master elastic/elasticsearch -f values/elasticsearch-master.yml --set masterService="$(PREFIX)-index-master" --set clusterName="$(PREFIX)-index" -n $(ENV)
-	helm install $(PREFIX)-index-data elastic/elasticsearch -f values/elasticsearch-data.yml --set masterService="$(PREFIX)-index-master" --set clusterName="$(PREFIX)-index" -n $(ENV)
+	helm install aleph-index-master elastic/elasticsearch -f values/elasticsearch-master.yml -n $(ENV)
+	helm install aleph-index-data elastic/elasticsearch -f values/elasticsearch-data.yml -n $(ENV)
 
 install-redis: update-helm
 	@echo "🔴 Installing Redis ..."
-	helm install $(PREFIX)-redis bitnami/redis -f values/redis.yml -n $(ENV)
+	helm install aleph-redis bitnami/redis -f values/redis.yml -n $(ENV)
 
 install-minio: update-helm
 	@echo "🔴 Installing MinIO ..."
-	helm install $(PREFIX)-minio minio/minio --set accessKey=myaccesskey,secretKey=mysecretkey -n $(ENV)
+	helm install aleph-minio minio/minio --set accessKey=myaccesskey,secretKey=mysecretkey -n $(ENV)
 
 install-ingress:
 	@echo "🔴 Installing Nginx Ingress  ..."

--- a/helm/examples/kind/k8s/ingress.dev.yaml
+++ b/helm/examples/kind/k8s/ingress.dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: aleph-ingress-dev
@@ -9,10 +9,16 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: aleph-ui
-              servicePort: 80
+              service: 
+                name: aleph-ui
+                port: 
+                  number: 80
           - path: /api
+            pathType: Prefix
             backend:
-              serviceName: aleph-api
-              servicePort: 8000
+              service: 
+                name: aleph-api
+                port: 
+                  number: 8000

--- a/helm/examples/kind/k8s/ingress.staging.yaml
+++ b/helm/examples/kind/k8s/ingress.staging.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: aleph-ingress-staging
@@ -9,10 +9,16 @@ spec:
       http:
         paths:
           - path: /
+            pathType: Prefix
             backend:
-              serviceName: aleph-ui
-              servicePort: 80
+              service: 
+                name: aleph-ui
+                port: 
+                  number: 80
           - path: /api
+            pathType: Prefix
             backend:
-              serviceName: aleph-api
-              servicePort: 8000
+              service: 
+                name: aleph-api
+                port: 
+                  number: 8000

--- a/helm/examples/kind/values/elasticsearch-data.yml
+++ b/helm/examples/kind/values/elasticsearch-data.yml
@@ -1,19 +1,21 @@
 ---
-clusterName: "search-index"
 nodeGroup: "data"
-masterService: "search-index-master"
+masterService: "aleph-index-master"
+clusterName: "aleph-index"
 
 roles:
   master: "false"
   ingest: "true"
   data: "true"
-
+  ml: "false"
+  remote_cluster_client: "false"
+  
 replicas: 3
-esMajorVersion: 7
 
-image: "alephdata/aleph-elasticsearch"
-imageTag: "latest"
+image: "ghcr.io/alephdata/aleph-elasticsearch"
+imageTag: "3bb5dbed97cfdb9955324d11e5c623a5c5bbc410"
 imagePullPolicy: "IfNotPresent"
+
 esJavaOpts: "-Xmx2g -Xms2g"
 esConfig:
   elasticsearch.yml: |
@@ -24,10 +26,6 @@ esConfig:
         enabled: "false"
       security:
         enabled: "false"
-# secretMounts:
-#   - name: search-index-secret
-#     secretName: search-index-secret
-#     path: /secrets
 
 resources:
   requests:
@@ -44,12 +42,4 @@ volumeClaimTemplate:
     requests:
       storage: 10Gi
 
-protocol: http
-httpPort: 9200
-transportPort: 9300
-
-# antiAffinity: "disable"
-# podManagementPolicy: "Parallel"
-# nodeSelector:
-#   tier: backend
-#   lifespan: permanent
+antiAffinity: disable

--- a/helm/examples/kind/values/elasticsearch-master.yml
+++ b/helm/examples/kind/values/elasticsearch-master.yml
@@ -1,19 +1,19 @@
 ---
-clusterName: "search-index"
 nodeGroup: "master"
-masterService: "search-index-master"
+masterService: "aleph-index-master"
+clusterName: "aleph-index"
 
 roles:
   master: "true"
   ingest: "false"
   data: "false"
+  ml: "false"
+  remote_cluster_client: "false"
 
 replicas: 2
-minimumMasterNodes: 1
-esMajorVersion: 7
 
-image: "alephdata/aleph-elasticsearch"
-imageTag: "latest"
+image: "ghcr.io/alephdata/aleph-elasticsearch"
+imageTag: "3bb5dbed97cfdb9955324d11e5c623a5c5bbc410"
 imagePullPolicy: "IfNotPresent"
 
 esJavaOpts: "-Xmx1g -Xms1g"
@@ -26,10 +26,6 @@ esConfig:
         enabled: "false"
       security:
         enabled: "false"
-# secretMounts:
-#   - name: search-index-secret
-#     secretName: search-index-secret
-#     path: /secrets
 
 resources:
   requests:
@@ -46,11 +42,4 @@ volumeClaimTemplate:
     requests:
       storage: 1Gi
 
-protocol: http
-httpPort: 9200
-transportPort: 9300
-
-# antiAffinity: "disable"
-# podManagementPolicy: "Parallel"
-# nodeSelector:
-#   lifespan: permanent
+antiAffinity: disable

--- a/helm/examples/kind/values/redis.yml
+++ b/helm/examples/kind/values/redis.yml
@@ -1,3 +1,3 @@
-cluster:
+architecture: standalone
+auth:
   enabled: false
-usePassword: false


### PR DESCRIPTION
When setting up a local staging environment, i noticed that in the helm examples, elastic was using an old image and the ingresses were using a deprecated api.

besides that i removed configuration that matched the defaults, and removed the `PREFIX` from the makefile as "aleph" was also used in the default secrets.