### PR TITLE
Notifications relative local time bug

### DIFF
--- a/ui/src/util/convertUTCDateToLocalDate.js
+++ b/ui/src/util/convertUTCDateToLocalDate.js
@@ -1,9 +1,3 @@
 export default function convertUTCDateToLocalDate(date) {
-  const newDate = new Date(
-    date.getTime() + date.getTimezoneOffset() * 60 * 1000
-  );
-  const offset = date.getTimezoneOffset() / 60;
-  const hours = date.getHours();
-  newDate.setHours(hours - offset);
-  return newDate;
+  return new Date(`${date} UTC`);
 }


### PR DESCRIPTION
While being 9 hours time zone shifted, I noticed an issue with how we're converting UTC time stamps from the db into local time when the difference crosses a date line - the UI was showing times in the future, which would never be possible.

<img width="113" alt="Screen Shot 2022-01-14 at 09 06 30" src="https://user-images.githubusercontent.com/6720200/149568342-7122e1db-d058-450d-a831-6d49fbcb9add.png">

We were previously using the solution proposed here: https://stackoverflow.com/a/18330682
But as comments suggest, there are some issues with this approach, so now using the top-rated solution. (tested in Chrome, Firefox, and Safari)