### PR TITLE
Hotfix: Use the correct collection_id while generating xref matches

### DIFF
--- a/aleph/logic/xref.py
+++ b/aleph/logic/xref.py
@@ -1,7 +1,7 @@
 import shutil
 import logging
 import typing
-from pprint import pprint  # noqa
+from pprint import pformat, pprint  # noqa
 from tempfile import mkdtemp
 from dataclasses import dataclass
 
@@ -131,7 +131,7 @@ def _query_item(entity, entitysets=True):
                 doubt=doubt,
                 method=method,
                 entity=entity,
-                collection_id=result.get("collection_id"),
+                collection_id=match.context.get("collection_id"),
                 match=match,
                 entityset_ids=entityset_ids,
             )

--- a/aleph/tests/test_xref.py
+++ b/aleph/tests/test_xref.py
@@ -23,59 +23,59 @@ class XrefTestCase(TestCase):
         _, headers = self.login(foreign_id=self.user.foreign_id)
         url = "/api/2/entities"
 
-        entity = {
+        entity1 = {
             "schema": "Person",
             "collection_id": str(self.coll_a.id),
             "properties": {"name": "Carlos Danger", "nationality": "US"},
         }
-        self.client.post(
+        self.entity1 = self.client.post(
             url,
-            data=json.dumps(entity),
+            data=json.dumps(entity1),
             headers=headers,
             content_type=JSON,
         )
-        entity = {
+        entity2 = {
             "schema": "Person",
             "collection_id": str(self.coll_b.id),
             "properties": {"name": "Carlos Danger", "nationality": "US"},
         }
-        self.client.post(
+        self.entity2 = self.client.post(
             url,
-            data=json.dumps(entity),
+            data=json.dumps(entity2),
             headers=headers,
             content_type=JSON,
         )
-        entity = {
+        entity3 = {
             "schema": "LegalEntity",
             "collection_id": str(self.coll_b.id),
             "properties": {"name": "Carlos Danger", "country": "GB"},
         }
-        self.client.post(
+        self.entity3 = self.client.post(
             url,
-            data=json.dumps(entity),
+            data=json.dumps(entity3),
             headers=headers,
             content_type=JSON,
         )
-        entity = {
+        entity4 = {
             "schema": "Person",
             "collection_id": str(self.coll_b.id),
             "properties": {"name": "Pure Risk", "nationality": "US"},
         }
-        self.client.post(
+        self.entity4 = self.client.post(
             url,
-            data=json.dumps(entity),
+            data=json.dumps(entity4),
             headers=headers,
             content_type=JSON,
         )
 
-        entity = {
+        entity5 = {
             "schema": "LegalEntity",
             "collection_id": str(self.coll_c.id),
             "properties": {"name": "Carlos Danger", "country": "GB"},
         }
-        self.client.post(
+        self.entity5 = self.client.post(
             url,
-            data=json.dumps(entity),
+            data=json.dumps(entity5),
             headers=headers,
             content_type=JSON,
         )
@@ -85,4 +85,21 @@ class XrefTestCase(TestCase):
         assert 0 == len(matches), len(matches)
         xref_collection(self.coll_a)
         matches = list(iter_matches(self.coll_a, self.authz))
+        match_collection_ids = set(
+            [match.get("match_collection_id") for match in matches]
+        )
+        assert match_collection_ids == {
+            self.coll_b.id,
+            self.coll_c.id,
+        }, match_collection_ids
+        match_ids = set([match.get("match_id") for match in matches])
+        assert match_ids == {
+            self.entity2.get_json().get("id"),
+            self.entity3.get_json().get("id"),
+            self.entity5.get_json().get("id"),
+        }, match_ids
         assert 3 == len(matches), len(matches)
+        for match in matches:
+            if match.get("id") == self.entity5.get_json().get("id"):
+                assert match.get("match_collection_id") == self.coll_c.id, match
+                assert match.get("collection_id") == self.coll_a.id, match


### PR DESCRIPTION
Match.collection_id should be set to the collection_id of the xref match