### PR TITLE
Fix search handler on home screen

### DIFF
--- a/ui/src/screens/HomeScreen/HomeScreen.jsx
+++ b/ui/src/screens/HomeScreen/HomeScreen.jsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { Callout, Intent } from '@blueprintjs/core';
 
+import withRouter from 'app/withRouter'
 import { AnimatedCount, SearchBox, Category, Country, Schema, Statistics } from 'components/common';
 import { fetchStatistics } from 'actions/index';
 import { selectMetadata, selectSession, selectStatistics } from 'selectors';
@@ -207,6 +208,7 @@ const mapStateToProps = (state) => ({
 });
 
 export default compose(
+  withRouter,
   connect(mapStateToProps, { fetchStatistics }),
   injectIntl,
 )(HomeScreen);


### PR DESCRIPTION
This PR fixes the submit handler for the search input on the home screen.

To reproduce, open the [OCCRP Aleph instance](https://data.occrp.org), make sure you’re logged-out, enter any string into the search input, and press enter. The app should navigate to the `/search` route, but instead nothing happens.

Navigation fails, because the navigate prop on the `HomeScreen` component is undefined. The `HomeScreen` component needs to be wrapped in the `withRouter` HOC in order to have access to the `navigate` prop.