### PR TITLE
Specify aleph api image specifically in helm charts

### DIFF
--- a/helm/charts/aleph/templates/api.yaml
+++ b/helm/charts/aleph/templates/api.yaml
@@ -20,7 +20,7 @@ spec:
       securityContext: {{- toYaml .Values.api.podSecurityContext | nindent 8 }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.global.image.repository }}:{{ .Values.global.image.tag }}"
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
           imagePullPolicy: {{ .Values.api.image.pullPolicy }}
           command:
             - gunicorn

--- a/helm/charts/aleph/values.yaml
+++ b/helm/charts/aleph/values.yaml
@@ -65,6 +65,8 @@ api:
     fsGroup: 1000
 
   image:
+    repository: alephdata/aleph
+    tag: "3.12.1"
     pullPolicy: Always
 
   containerSecurityContext:


### PR DESCRIPTION
I wanted to create & [deploy an image](https://github.com/ftmnl/pages) to override the default info pages, as i [read here in the docs](https://docs.alephdata.org/developers/technical-faq#can-i-customise-the-text-of-the-about-page) but the helm charts did not support overriding the API image only, as the API chart used the `global.image` config.

I tried overriding the `global.image` config with my own API image, but the UI deployment uses the same `global.image.tag` field, so that did not work.

This is the most simple fix i could think of, seperate `api.image` config values.