### PR TITLE
Fix label in ensure_collection

### DIFF
--- a/aleph/manage.py
+++ b/aleph/manage.py
@@ -61,8 +61,9 @@ def ensure_collection(foreign_id, label):
     authz = Authz.from_role(Role.load_cli_user())
     config = {
         "foreign_id": foreign_id,
-        "label": label,
     }
+    if label is not None:
+        config["label"] = label
     create_collection(config, authz)
     return Collection.by_foreign_id(foreign_id)
 
@@ -115,7 +116,8 @@ def worker(blocking=True, threads=None):
 @click.argument("path", type=click.Path(exists=True))
 @click.option("-l", "--language", multiple=True, help="ISO language codes for OCR")
 @click.option("-f", "--foreign_id", help="Foreign ID of the collection")
-def crawldir(path, language=None, foreign_id=None):
+@click.option("-n", "--name", help="Name of collection")
+def crawldir(path, language=None, foreign_id=None, name=None):
     """Crawl the given directory."""
     path = Path(path)
     if foreign_id is None:

--- a/aleph/manage.py
+++ b/aleph/manage.py
@@ -122,7 +122,7 @@ def crawldir(path, language=None, foreign_id=None, name=None):
     path = Path(path)
     if foreign_id is None:
         foreign_id = "directory:%s" % slugify(path)
-    collection = ensure_collection(foreign_id, path.name)
+    collection = ensure_collection(foreign_id, name)
     log.info("Crawling %s to %s (%s)...", path, foreign_id, collection.id)
     crawl_directory(collection, path)
     log.info("Complete. Make sure a worker is running :)")


### PR DESCRIPTION
When calling `aleph crawldir` with a `foreign_id` of an already existing collection, `ensure_collection` was overwriting the collection's name (`label`).

The assumption appeared to be that the path name would be used as the collection's label, but this isn't always the desired behavior.

This PR adds a new flag `-n` to `aleph crawldir` allowing the user to specify the name (`label`) of the collection.

If `-n` isn't called, `aleph crawldir` does not attempt to give the collection a label.