### PR TITLE
Fixed Gunicorn worker timeout issue

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,7 @@ services:
 
   api:
     image: alephdata/aleph:${ALEPH_TAG:-3.12.2}
-    command: gunicorn -w 6 -b 0.0.0.0:8000 --log-level debug --log-file - aleph.wsgi:app
+    command: gunicorn -w 6 -b 0.0.0.0:8000 --timeout 3600 --log-level debug --log-file - aleph.wsgi:app
     expose:
       - 8000
     depends_on:


### PR DESCRIPTION
Gunicorn's workers crash when uploading large files to Aleph Api due to short default timeout. Added a timeout flag to docker compose file. This fixes the issue.