### PR TITLE
Remove ALEPH_SAMPLE_SEARCHES from aleph.env.tmpl

### DIFF
--- a/aleph.env.tmpl
+++ b/aleph.env.tmpl
@@ -7,8 +7,6 @@
 # Random string:
 ALEPH_SECRET_KEY=
 
-# Visible instance name in the UI
-ALEPH_APP_TITLE=Aleph
 # Name needs to be a slug, as it is used e.g. for the ES index, SQS queue name:
 ALEPH_APP_NAME=aleph
 ALEPH_UI_URL=http://localhost:8080/
@@ -16,9 +14,6 @@ ALEPH_UI_URL=http://localhost:8080/
 # ALEPH_URL_SCHEME=https
 # ALEPH_FAVICON=https://investigativedashboard.org/static/favicon.ico
 # ALEPH_LOGO=http://assets.pudo.org/img/logo_bigger.png
-
-# Other customisations
-ALEPH_SAMPLE_SEARCHES=Vladimir Putin:TeliaSonera
 
 # Set email addresses, separated by colons, that will be made admin.
 # ALEPH_ADMINS=friedrich@pudo.org:demo@pudo.org

--- a/aleph.env.tmpl
+++ b/aleph.env.tmpl
@@ -7,6 +7,8 @@
 # Random string:
 ALEPH_SECRET_KEY=
 
+# Visible instance name in the UI
+ALEPH_APP_TITLE=Aleph
 # Name needs to be a slug, as it is used e.g. for the ES index, SQS queue name:
 ALEPH_APP_NAME=aleph
 ALEPH_UI_URL=http://localhost:8080/


### PR DESCRIPTION
Sample searches are now configured in `aleph/pages/home.en.md` and `ALEPH_SAMPLE_SEARCHES` is not used anymore