### PR TITLE
Concatenate error messages for the same path

### DIFF
--- a/aleph/tests/test_view_util.py
+++ b/aleph/tests/test_view_util.py
@@ -1,7 +1,10 @@
+import json
+
 from lxml.html import document_fromstring
+from werkzeug.exceptions import BadRequest
 
 from aleph.logic.html import sanitize_html
-from aleph.views.util import get_url_path
+from aleph.views.util import get_url_path, validate
 from aleph.tests.util import TestCase
 
 
@@ -32,3 +35,33 @@ class ViewUtilTest(TestCase):
         assert attr == "https://example.org/blockchain", html
         assert html.find(".//a").get("target") == "_blank", html
         assert "nofollow" in html.find(".//a").get("rel"), html
+
+    def test_validate_returns_errors_for_paths(self):
+        # given
+        schema = "RoleCreate" # name min length 4, password min length 6
+        data = json.loads('{"name":"Bob","password":"1234","code":"token"}')
+
+        # then
+        with self.assertRaises(BadRequest):
+            validate(data, schema)
+
+        # and
+        try:
+            validate(data, schema)
+        except BadRequest as err:
+            self.assertEqual(err.response.get_json().get("errors"), {"name": "'Bob' is too short", "password": "'1234' is too short"})
+
+    def test_validate_concatenates_multiple_errors_for_the_same_path(self):
+        # given
+        schema = "RoleCreate" # requires password and code 
+        data = json.loads('{"wrong":"No password nor code"}')
+
+        # then
+        with self.assertRaises(BadRequest):
+            validate(data, schema)
+
+        # and
+        try:
+            validate(data, schema)
+        except BadRequest as err:
+            self.assertEqual(err.response.get_json().get("errors"), {"": "'password' is a required property; 'code' is a required property"})

--- a/aleph/tests/test_view_util.py
+++ b/aleph/tests/test_view_util.py
@@ -42,26 +42,18 @@ class ViewUtilTest(TestCase):
         data = json.loads('{"name":"Bob","password":"1234","code":"token"}')
 
         # then
-        with self.assertRaises(BadRequest):
+        with self.assertRaises(BadRequest) as ctx:
             validate(data, schema)
 
-        # and
-        try:
-            validate(data, schema)
-        except BadRequest as err:
-            self.assertEqual(err.response.get_json().get("errors"), {"name": "'Bob' is too short", "password": "'1234' is too short"})
+        self.assertEqual(ctx.exception.response.get_json().get("errors"), {"name": "'Bob' is too short", "password": "'1234' is too short"})
 
     def test_validate_concatenates_multiple_errors_for_the_same_path(self):
         # given
         schema = "RoleCreate" # requires password and code 
-        data = json.loads('{"wrong":"No password nor code"}')
+        data = json.loads('{"wrong":"No password, no code"}')
 
         # then
-        with self.assertRaises(BadRequest):
+        with self.assertRaises(BadRequest) as ctx:
             validate(data, schema)
 
-        # and
-        try:
-            validate(data, schema)
-        except BadRequest as err:
-            self.assertEqual(err.response.get_json().get("errors"), {"": "'password' is a required property; 'code' is a required property"})
+        self.assertEqual(ctx.exception.response.get_json().get("errors"), {"": "'password' is a required property; 'code' is a required property"})

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -59,11 +59,13 @@ def parse_request(schema):
 def validate(data, schema):
     """Validate the data inside a request against a schema."""
     validator = get_validator(schema)
-    # data = clean_object(data)
     errors = {}
     for error in validator.iter_errors(data):
         path = ".".join((str(c) for c in error.path))
-        errors[path] = error.message
+        if path not in errors:
+            errors[path] = error.message
+        else:
+            errors[path] += '; ' + error.message
         log.info("ERROR [%s]: %s", path, error.message)
 
     if not len(errors):


### PR DESCRIPTION
When there are multiple validation errors for the same path, the response error messages get overrided

This PR fixes that by concatenating error messages for the same path