### PR TITLE
Fix worker target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ web: services
 	$(COMPOSE) up api ui
 
 worker: services
-	$(COMPOSE) run -p 127.0.0.1:5679:5679 --rm app python3 -m debugpy --listen 0.0.0.0:5679 /usr/local/bin/aleph worker
+	$(COMPOSE) run -p 127.0.0.1:5679:5679 --rm app python3 -m debugpy --listen 0.0.0.0:5679 -c "from aleph.manage import cli; cli()" worker
 
 tail:
 	$(COMPOSE) logs -f


### PR DESCRIPTION
Currently, running `make worker` fails as the aleph CLI is installed at `/usr/bin/aleph` (not `/usr/local/bin/aleph`). This has previously been reported in #2093.

I’m not really sure though what has changed since the commit that introduced the absolute path to `/usr/local/bin/aleph` (https://github.com/alephdata/aleph/commit/f2824360c7032e98bb9944710feb978641a93181). I quickly looked through the history of files that might be relevant (setup.py, Dockerfile + compose config, …), but didn’t find anything.