### PR TITLE
Add LinkMenuItem, LinkButton to replace inaccessible workarounds

### DIFF
--- a/ui/src/components/Dashboard/Dashboard.jsx
+++ b/ui/src/components/Dashboard/Dashboard.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { Classes, Menu, MenuItem, MenuDivider } from '@blueprintjs/core';
+import { Classes, Menu, MenuDivider } from '@blueprintjs/core';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
-import { Count, Skeleton, AppItem } from 'components/common';
+import { Count, Skeleton, AppItem, LinkMenuItem } from 'components/common';
 import c from 'classnames';
 
 import withRouter from 'app/withRouter'
@@ -53,11 +53,6 @@ const messages = defineMessages({
 
 
 class Dashboard extends React.Component {
-  constructor(props) {
-    super(props);
-    this.navigate = this.navigate.bind(this);
-  }
-
   componentDidMount() {
     this.fetchIfNeeded();
   }
@@ -71,10 +66,6 @@ class Dashboard extends React.Component {
     if (groupsResult.shouldLoad) {
       this.props.queryRoles({ query: groupsQuery });
     }
-  }
-
-  navigate(path) {
-    this.props.navigate(path);
   }
 
   render() {
@@ -91,24 +82,24 @@ class Dashboard extends React.Component {
                   <FormattedMessage id="dashboard.activity" defaultMessage="Activity" />
                 </h6>
               </li>
-              <MenuItem
+              <LinkMenuItem
                 icon="notifications"
                 text={intl.formatMessage(messages.notifications)}
-                onClick={() => this.navigate('/notifications')}
+                to="/notifications"
                 active={current === '/notifications'}
               />
-              <MenuItem
+              <LinkMenuItem
                 icon="feed"
                 text={intl.formatMessage(messages.alerts)}
                 label={<Count count={role?.counts?.alerts} />}
-                onClick={() => this.navigate('/alerts')}
+                to="/alerts"
                 active={current === '/alerts'}
               />
-              <MenuItem
+              <LinkMenuItem
                 icon="export"
                 text={intl.formatMessage(messages.exports)}
                 label={<Count count={role?.counts?.exports} />}
-                onClick={() => this.navigate('/exports')}
+                to="/exports"
                 active={current === '/exports'}
               />
               <MenuDivider />
@@ -117,32 +108,32 @@ class Dashboard extends React.Component {
                   <FormattedMessage id="dashboard.workspace" defaultMessage="Workspace" />
                 </h6>
               </li>
-              <MenuItem
+              <LinkMenuItem
                 icon="briefcase"
                 text={intl.formatMessage(messages.cases)}
                 label={<Count count={role?.counts?.casefiles} />}
-                onClick={() => this.navigate('/investigations')}
+                to="/investigations"
                 active={current === '/investigations'}
               />
-              <MenuItem
+              <LinkMenuItem
                 icon="graph"
                 text={intl.formatMessage(messages.diagrams)}
                 label={<Count count={role?.counts?.entitysets?.diagram} />}
-                onClick={() => this.navigate('/diagrams')}
+                to="/diagrams"
                 active={current === '/diagrams'}
               />
-              <MenuItem
+              <LinkMenuItem
                 icon="gantt-chart"
                 text={intl.formatMessage(messages.timelines)}
                 label={<Count count={role?.counts?.entitysets?.timeline} />}
-                onClick={() => this.navigate('/timelines')}
+                to="/timelines"
                 active={current === '/timelines'}
               />
-              <MenuItem
+              <LinkMenuItem
                 icon="list"
                 text={intl.formatMessage(messages.lists)}
                 label={<Count count={role?.counts?.entitysets?.list} />}
-                onClick={() => this.navigate('/lists')}
+                to="/lists"
                 active={current === '/lists'}
               />
               {(groupsResult.total === undefined || groupsResult.total > 0) && (
@@ -154,11 +145,11 @@ class Dashboard extends React.Component {
                     </h6>
                   </li>
                   {groupsResult.results !== undefined && groupsResult.results.map(group => (
-                    <MenuItem
+                    <LinkMenuItem
                       key={group.id}
                       icon="shield"
                       text={group.label}
-                      onClick={() => this.navigate(`/groups/${group.id}`)}
+                      to={`/groups/${group.id}`}
                       active={current === `/groups/${group.id}`}
                     />
                   ))}
@@ -168,16 +159,16 @@ class Dashboard extends React.Component {
                 </>
               )}
               <MenuDivider />
-              <MenuItem
+              <LinkMenuItem
                 icon="dashboard"
                 text={intl.formatMessage(messages.status)}
-                onClick={() => this.navigate('/status')}
+                to="/status"
                 active={current === '/status'}
               />
-              <MenuItem
+              <LinkMenuItem
                 icon="cog"
                 text={intl.formatMessage(messages.settings)}
-                onClick={() => this.navigate('/settings')}
+                to="/settings"
                 active={current === '/settings'}
               />
               <MenuDivider />

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -12,7 +12,7 @@ import AdvancedSearch from 'components/AdvancedSearch/AdvancedSearch';
 import AuthButtons from 'components/AuthButtons/AuthButtons';
 import { selectMetadata, selectSession, selectPages, selectEntitiesResult } from 'selectors';
 import SearchAlert from 'components/SearchAlert/SearchAlert';
-import { HotkeysContainer, SearchBox } from 'components/common';
+import { HotkeysContainer, SearchBox, LinkButton } from 'components/common';
 import getPageLink from 'util/getPageLink';
 import { entitiesQuery } from 'queries';
 
@@ -126,24 +126,33 @@ export class Navbar extends React.Component {
               )}
               {!mobileSearchOpen && (
                 <>
-                  <Link to="/datasets">
-                    <Button icon="database" className="Navbar_collections-button bp3-minimal">
-                      <FormattedMessage id="nav.collections" defaultMessage="Datasets" />
-                    </Button>
-                  </Link>
+                  <LinkButton
+                    to="/datasets"
+                    icon="database"
+                    minimal={true}
+                    className="Navbar_collections-button"
+                  >
+                    <FormattedMessage id="nav.collections" defaultMessage="Datasets" />
+                  </LinkButton>
                   {session.loggedIn && (
-                    <Link to="/investigations">
-                      <Button icon="briefcase" className="Navbar__collections-button mobile-hide bp3-minimal">
-                        <FormattedMessage id="nav.cases" defaultMessage="Investigations" />
-                      </Button>
-                    </Link>
+                    <LinkButton
+                      to="/investigations"
+                      icon="briefcase"
+                      minimal={true}
+                      className="Navbar__collections-button mobile-hide"
+                    >
+                      <FormattedMessage id="nav.cases" defaultMessage="Investigations" />
+                    </LinkButton>
                   )}
                   {menuPages.map(page => (
-                    <Link to={getPageLink(page)} key={page.name}>
-                      <Button icon={page.icon} className="Navbar__collections-button mobile-hide bp3-minimal">
-                        {page.short}
-                      </Button>
-                    </Link>
+                    <LinkButton
+                      key={page.name}
+                      to={getPageLink(page)}
+                      icon={page.icon}
+                      minimal={true}
+                      className="Navbar__collections-button mobile-hide">
+                      {page.short}
+                    </LinkButton>
                   ))}
                 </>
               )}

--- a/ui/src/components/common/LinkButton.jsx
+++ b/ui/src/components/common/LinkButton.jsx
@@ -1,0 +1,9 @@
+import { AnchorButton } from '@blueprintjs/core';
+import { useLinkClickHandler, useHref } from 'react-router-dom';
+
+export default function LinkButton({ to, ...props }) {
+  const href = useHref(to);
+  const clickHandler = useLinkClickHandler(to);
+
+  return <AnchorButton href={href} onClick={clickHandler} {...props} />;
+}

--- a/ui/src/components/common/LinkMenuItem.jsx
+++ b/ui/src/components/common/LinkMenuItem.jsx
@@ -1,0 +1,9 @@
+import { MenuItem } from '@blueprintjs/core';
+import { useLinkClickHandler, useHref } from 'react-router-dom';
+
+export default function LinkMenuItem({ to, ...props }) {
+  const href = useHref(to);
+  const clickHandler = useLinkClickHandler(to);
+
+  return <MenuItem href={href} onClick={clickHandler} {...props} />;
+}

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -43,6 +43,8 @@ import SelectWrapper from './SelectWrapper';
 import ExportLink from './ExportLink';
 import UpdateStatus from './UpdateStatus';
 import JudgementButtons from './JudgementButtons';
+import LinkMenuItem from './LinkMenuItem';
+import LinkButton from './LinkButton';
 
 
 export {
@@ -91,6 +93,8 @@ export {
   ExportLink,
   UpdateStatus,
   JudgementButtons,
+  LinkMenuItem,
+  LinkButton,
 };
 
 export * from './types';

--- a/ui/src/screens/PagesScreen/PagesScreen.jsx
+++ b/ui/src/screens/PagesScreen/PagesScreen.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import { defineMessages, injectIntl } from 'react-intl';
-import { Menu, MenuItem, MenuDivider } from '@blueprintjs/core';
+import { Menu, MenuDivider } from '@blueprintjs/core';
 import { isLangRtl } from '@alephdata/react-ftm';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -9,7 +9,7 @@ import { connect } from 'react-redux';
 import withRouter from 'app/withRouter'
 import Screen from 'components/Screen/Screen';
 import ErrorScreen from 'components/Screen/ErrorScreen';
-import { AppItem } from 'components/common';
+import { AppItem, LinkMenuItem } from 'components/common';
 import { selectPages, selectPage } from 'selectors';
 
 import './PagesScreen.scss';
@@ -27,17 +27,7 @@ const messages = defineMessages({
   },
 });
 
-
 export class PagesScreen extends React.Component {
-  constructor(props) {
-    super(props);
-    this.navigate = this.navigate.bind(this);
-  }
-
-  navigate(path) {
-    this.props.navigate(path);
-  }
-
   render() {
     const { intl, page, pages } = this.props;
     if (!page) {
@@ -62,11 +52,11 @@ export class PagesScreen extends React.Component {
               <div className="Pages__menu">
                 <Menu>
                   {menuPages.map(menuPage => (
-                    <MenuItem
+                    <LinkMenuItem
                       key={menuPage.name}
-                      icon={menuPage.icon}
+                      to={getPageLink(menuPage)}
                       text={menuPage.short}
-                      onClick={() => this.navigate(getPageLink(menuPage))}
+                      icon={menuPage.icon}
                       active={menuPage.name === page.name}
                     />
                   ))}


### PR DESCRIPTION
Unfortunately, Blueprint makes it quiet hard to render valid, accessible HTML markup with its `AnchorButton` and `MenuItem` components. Currently, we’ve been using different workarounds (e.g. using `onclick` handlers rather than links or nesting buttons withink anchor tags), which e.g. makes it impossible to copy the URL or open a link in a new tab, and breaks assistive technology.

Fortunately, with recent versions of React Router, it’s become easier to do this in a way that doesn’t produce inaccessible markup: The `useLinkClickHandler` and `useHref` tags provide the behavior needed to support client-side navigation with existing components like `AnchorButton` and `MenuItem`.

The `LinkMenuItem`/`LinkButton` components behave like React Router’s `Link` component and render like their `MenuItem`/`AnchorButton` Blueprint counterparts.

I’ve started using these two components in the dashboard sidebar menu, the pages sidebar menu and the top navbar menu. There are a few more locations where we currently make use of workarounds, but I’d prefer to keep this PR rather small.

https://user-images.githubusercontent.com/1512805/173228953-e93fc22a-ecc7-432d-9cad-1975b9bf6cb9.mov
