### PR TITLE
Fix infinite scroll in case no results are returned

### DIFF
--- a/ui/src/components/XrefTable/XrefTable.jsx
+++ b/ui/src/components/XrefTable/XrefTable.jsx
@@ -17,6 +17,10 @@ const messages = defineMessages({
     id: 'collection.xref.empty',
     defaultMessage: 'There are no cross-referencing results.',
   },
+  emptyError: {
+    id: 'collection.xref.empty_error',
+    defaultMessage: 'There are cross-referencing results, but for some reason we could not load them.',
+  },
 });
 
 
@@ -81,6 +85,11 @@ class XrefTable extends Component {
     if (result.isError) {
       return <ErrorSection error={result.error} />;
     }
+
+    if (result.total > 0 && result.results.length === 0) {
+      return <ErrorSection title={intl.formatMessage(messages.emptyError)} />;
+    }
+
     if (result.total === 0) {
       return (
         <ErrorSection

--- a/ui/src/components/common/QueryInfiniteLoad.jsx
+++ b/ui/src/components/common/QueryInfiniteLoad.jsx
@@ -33,7 +33,14 @@ class QueryInfiniteLoad extends Component {
 
   render() {
     const { loadOnScroll = true, result } = this.props;
-    const canLoadMore = result && result.next && !result.isPending && !result.isError && result.results.length < result.total;
+    const canLoadMore = (
+      result &&
+      result.next &&
+      !result.isPending &&
+      !result.isError &&
+      result.results.length > 0 &&
+      result.results.length < result.total
+    );
 
     if (canLoadMore) {
       if (loadOnScroll) {


### PR DESCRIPTION
As I haven’t been able to reproduce an API response that leads to this bug locally, I’ve been using mitmproxy to intercept the API requests and modify the response.

I’ve been wondering though if we should actually merge this. In most cases where we get an inconsistent API response (i.e. a response that should contain results, but doesn’t), we would want to look into the underlying issue/bug. This change would basically hide the bug from the UI, which will make it more difficult to notice in the first place. @Rosencrantz what do you think?

***

If you want to test this locally, follow these steps:

1. Start Aleph.
2. Install mitmproxy if you haven’t yet: `brew install mitmproxy`.
3. Run `mitmweb -p 8888` to start the proxy and open the web UI.
4. Set up your web browser to use `localhost:8888` as an HTTP proxy. (In Firefox, open the settings and search for "proxy".)
5. In the mitproxy web UI, enter the following filter to intercept responses from the collections API endpoint: `~s http://0.0.0.0:8080/api/2/collections`.
6. Open the "Network" tab in the browser dev tools.
7. Open http://0.0.0.0:8080/datasets.
8. Find the intercepted request/response (highlighted in orange) in the mitproxy, click it and select the "Response" tab in the right pane.
9. Click on the "edit" button next to the response body.
10. Paste the modified response body below. (Note how it has an empty results list, but indicates that there should be 300 results.)
11. You should be able to see an additional request in the network tab.

```json
{
    "status": "ok",
    "results": [],
    "total": 300,
    "total_type": "eq",
    "page": 1,
    "limit": 30,
    "offset": 0,
    "pages": 10,
    "next": "http://0.0.0.0:8080/api/2/collections?filter%3Acategory=casefile&limit=30&sort=created_at%3Adesc",
    "previous": null,
    "facets": {},
    "query_text": "category:\"casefile\""
}
```