### PR TITLE
Navigate to entites referenced in entity tables

### DIFF
--- a/ui/src/components/EntityTable/EntityTable.jsx
+++ b/ui/src/components/EntityTable/EntityTable.jsx
@@ -183,7 +183,7 @@ export class EntityTable extends Component {
   render() {
     const { collection, entityManager, query, intl, result, schema, isEntitySet, sort, updateStatus, writeable } = this.props;
     const { selection } = this.state;
-    const visitEntity = schema.isThing() ? this.onEntityClick : undefined;
+    const visitEntity = this.onEntityClick;
     const showEmptyComponent = result.total === 0 && query.hasQuery();
     const selectedEntities = selection.map(this.getEntity).filter(e => e !== undefined);
 


### PR DESCRIPTION
Previously, we only linked to referenced entities in case the *referencing* entity is a thing.

As discussed in #2338, we actually considered this a bug. The original intent of this condition was probably to check if the *referenced* entity is a thing. Non-thingy entity views do not offer a lot of additional information and are mostly blank, so it doesn’t make a lot of sense to link to them.

That doesn’t seem something that’s possible right now with FtM – referenced entities are always things (see https://github.com/alephdata/aleph/issues/2338#issuecomment-1170420470), so I devided to simply render links to referenced entities in all cases.

Closes #2338 

<img width="1667" alt="Screenshot 2022-06-30 at 13 20 07" src="https://user-images.githubusercontent.com/1512805/176664949-f5974513-64ab-49d4-9e4b-24b5856dc9b9.png">