### PR TITLE
Use gettext placeholder

### DIFF
--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -95,9 +95,10 @@ class Serializer(object):
             data = {
                 "status": "error",
                 "message": gettext(
-                    f"We found {total} results, but could not load them due "
+                    "We found %(total)d results, but could not load them due "
                     "to a technical problem. Please check back later and if "
-                    "the problem persists contact an Aleph administrator"
+                    "the problem persists contact an Aleph administrator",
+                    total=total
                 ),
             }
             return jsonify(data, status=500)


### PR DESCRIPTION
@sunu Sorry, that’s another thing I wasn’t aware of when I reviewed that PR. 🙃 We can’t use format strings for messages to be translated and need to use gettext placeholders instead.

See https://github.com/alephdata/aleph/pull/2380#discussion_r913464101