### PR TITLE
Display highlights in document plaintext view mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run linter
         run: make lint-ui
 
+      - name: Run tests
+        run: make test-ui
+
       - name: Build production image
         run: docker build -t alephdata/aleph-ui-production:${GITHUB_SHA} -f ui/Dockerfile.production ui
 

--- a/aleph/search/parser.py
+++ b/aleph/search/parser.py
@@ -132,10 +132,12 @@ class SearchQueryParser(QueryParser):
         # index.
         self.facet_names = set(self.getlist("facet"))
 
+        # Query to use for highlighting, defaults to the search query
+        self.highlight_text = self.get("highlight_text", self.text)
         # Include highlighted fragments of matching text in the result.
         self.highlight = self.getbool("highlight", False)
         self.highlight = self.highlight and settings.RESULT_HIGHLIGHT
-        self.highlight = self.highlight and self.text
+        self.highlight = self.highlight and self.highlight_text
         # Length of each snippet in characters
         self.highlight_length = self.getint("highlight_length", 120)
         # Number of snippets per document, 0 = return full document text.

--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -219,7 +219,7 @@ class Query(object):
     def get_highlight(self):
         if not self.parser.highlight:
             return {}
-        query = query_string_query(self.HIGHLIGHT_FIELD, self.parser.text)
+        query = query_string_query(self.HIGHLIGHT_FIELD, self.parser.highlight_text)
         return {
             "encoder": "html",
             "fields": {

--- a/aleph/tests/test_search_query.py
+++ b/aleph/tests/test_search_query.py
@@ -111,3 +111,38 @@ class QueryTestCase(TestCase):
                 }
             },
         )
+
+    def test_highlight(self):
+        q = query([("q", "foo"), ("highlight", "true")])
+
+        self.assertEqual(
+            q.get_highlight(),
+            {
+                "encoder": "html",
+                "fields": {
+                    "text": {
+                        "highlight_query": {
+                            "query_string": {
+                                "query": "foo",
+                                "lenient": True,
+                                "fields": ["text"],
+                                "default_operator": "AND",
+                                "minimum_should_match": "66%",
+                            },
+                        },
+                        "require_field_match": False,
+                        "number_of_fragments": 3,
+                        "fragment_size": 120,
+                    },
+                },
+            },
+        )
+
+    def test_highlight_text(self):
+        q = query([("q", "foo"), ("highlight", "true"), ("highlight_text", "bar")])
+        highlight = q.get_highlight()
+
+        self.assertEqual(
+            highlight["fields"]["text"]["highlight_query"]["query_string"]["query"],
+            "bar",
+        )

--- a/aleph/tests/test_search_query.py
+++ b/aleph/tests/test_search_query.py
@@ -133,6 +133,7 @@ class QueryTestCase(TestCase):
                         "require_field_match": False,
                         "number_of_fragments": 3,
                         "fragment_size": 120,
+                        "max_analyzed_offset": 999999,
                     },
                 },
             },

--- a/ui/package.json
+++ b/ui/package.json
@@ -74,6 +74,9 @@
   "eslintConfig": {
     "extends": "react-app"
   },
+  "jest": {
+    "transformIgnorePatterns": []
+  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,8 @@
     "@formatjs/intl-pluralrules": "^5.0.2",
     "@formatjs/intl-relativetimeformat": "^11.0.1",
     "@formatjs/intl-utils": "^3.8.4",
+    "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react": "^12.1.5",
     "@types/jest": "^28.1.4",
     "@types/node": "^17.0.8",
     "@types/react": "^17.0.1",

--- a/ui/src/components/EntitySearch/EntitySearchResults.scss
+++ b/ui/src/components/EntitySearch/EntitySearchResults.scss
@@ -21,17 +21,6 @@
 }
 
 .EntitySearchResultsRow {
-  &.active {
-    em {
-      background: inherit;
-    }
-  }
-
-  em {
-    background: $aleph-text-highlight-color;
-    font-style: normal;
-  }
-
   .highlights {
     @include rtlSupportInvertedProp(
       padding,

--- a/ui/src/components/EntitySearch/EntitySearchResultsRow.jsx
+++ b/ui/src/components/EntitySearch/EntitySearchResultsRow.jsx
@@ -12,6 +12,7 @@ import {
   FileSize,
   Property,
   Schema,
+  SearchHighlight,
   Skeleton,
 } from 'components/common';
 
@@ -172,13 +173,7 @@ class EntitySearchResultsRow extends Component {
         {!!highlights.length && (
           <tr key={`${entity.id}-hl`} className={highlightsClass}>
             <td colSpan="100%" className="highlights">
-              <div className="highlights__content">
-                {highlights.map((phrase, index) => (
-                  <span key={index}>
-                    <span dangerouslySetInnerHTML={{ __html: phrase }} />
-                  </span>
-                ))}
-              </div>
+              <SearchHighlight highlight={highlights} />
             </td>
           </tr>
         )}

--- a/ui/src/components/common/SearchHighlight.jsx
+++ b/ui/src/components/common/SearchHighlight.jsx
@@ -1,0 +1,16 @@
+import convertHighlightsToReactElements from 'util/convertHighlightsToReactElements';
+import './SearchHighlight.scss';
+
+export default function SearchHighlight({ highlight }) {
+  if (!highlight || highlight.length <= 0) {
+    return null;
+  }
+
+  return (
+    <p className="SearchHighlight">
+      {highlight
+        .map((fragment) => convertHighlightsToReactElements(fragment))
+        .reduce((prev, curr) => [prev, ' … ', curr])}
+    </p>
+  );
+}

--- a/ui/src/components/common/SearchHighlight.scss
+++ b/ui/src/components/common/SearchHighlight.scss
@@ -1,0 +1,6 @@
+@import 'app/variables.scss';
+
+.SearchHighlight em {
+  background-color: $aleph-text-highlight-color;
+  font-style: inherit;
+}

--- a/ui/src/components/common/SearchHighlight.test.jsx
+++ b/ui/src/components/common/SearchHighlight.test.jsx
@@ -1,0 +1,19 @@
+import { render } from '@testing-library/react';
+import SearchHighlight from './SearchHighlight';
+
+it('renders `em` tags correctly', () => {
+  const { container } = render(
+    <SearchHighlight highlight={['Lorem <em>ipsum</em> dolor sit amet.']} />
+  );
+
+  expect(container).toHaveTextContent('Lorem ipsum dolor sit amet.');
+  expect(container.querySelectorAll('em')).toHaveLength(1);
+});
+
+it('concatenates multiple fragments', () => {
+  const { container } = render(
+    <SearchHighlight highlight={['Lorem ispum', 'dolor sit amet.']} />
+  );
+
+  expect(container).toHaveTextContent('Lorem ispum … dolor sit amet.');
+});

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -32,6 +32,7 @@ import Score from './Score';
 import Tag from './Tag';
 import SchemaCounts from './SchemaCounts';
 import SearchBox from './SearchBox';
+import SearchHighlight from './SearchHighlight';
 import Skeleton from './Skeleton';
 import Statistics from './Statistics';
 import Summary from './Summary';
@@ -82,6 +83,7 @@ export {
   Tag,
   SchemaCounts,
   SearchBox,
+  SearchHighlight,
   Skeleton,
   QueryText,
   QueryInfiniteLoad,

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/ui/src/util/convertHighlightsToReactElements.js
+++ b/ui/src/util/convertHighlightsToReactElements.js
@@ -1,4 +1,5 @@
 import { createElement } from 'react';
+import { decode } from './htmlEntities';
 
 // Converts a string containing `<em>` tags to a list of
 // React elements without using `dangerouslySetInnerHTML`.
@@ -21,12 +22,18 @@ export default function convertHighlightsToReactElements(string) {
       return;
     }
 
+    // Highlight snippets are HTML encoded. As we are creating
+    // proper React elements from those HTML snippets, and React
+    // will escape any HTML markup, we neede to decode the snippet.
+    // Otherwise, markup would get encoded twice.
+    const decodedToken = decode(token);
+
     if (isHighlight) {
-      nodes.push(createElement('em', { key: index }, token));
+      nodes.push(createElement('em', { key: index }, decodedToken));
       return;
     }
 
-    nodes.push(token);
+    nodes.push(decodedToken);
   });
 
   return nodes;

--- a/ui/src/util/convertHighlightsToReactElements.js
+++ b/ui/src/util/convertHighlightsToReactElements.js
@@ -1,0 +1,33 @@
+import { createElement } from 'react';
+
+// Converts a string containing `<em>` tags to a list of
+// React elements without using `dangerouslySetInnerHTML`.
+// This ensures that all other HTML markup is automatically
+// escaped by React.
+export default function convertHighlightsToReactElements(string) {
+  const tokens = string.split(/(<\/?em>)/i);
+  const nodes = [];
+
+  let isHighlight = false;
+
+  tokens.forEach((token, index) => {
+    if (token === '<em>') {
+      isHighlight = true;
+      return;
+    }
+
+    if (token === '</em>') {
+      isHighlight = false;
+      return;
+    }
+
+    if (isHighlight) {
+      nodes.push(createElement('em', { key: index }, token));
+      return;
+    }
+
+    nodes.push(token);
+  });
+
+  return nodes;
+}

--- a/ui/src/util/convertHighlightsToReactElements.test.jsx
+++ b/ui/src/util/convertHighlightsToReactElements.test.jsx
@@ -1,0 +1,29 @@
+import { render } from '@testing-library/react';
+import convertHighlightsToReactElements from './convertHighlightsToReactElements';
+
+it('converts `em` tags to React nodes', () => {
+  const { container } = render(
+    <div>
+      {convertHighlightsToReactElements(
+        'Lorem ipsum <em>dolor</em> sit <em>amet</em>.'
+      )}
+    </div>
+  );
+
+  expect(container).toHaveTextContent('Lorem ipsum dolor sit amet.');
+
+  const emTags = [...container.querySelectorAll('em')];
+  const highlighted = emTags.map((tag) => tag.textContent);
+  expect(highlighted).toEqual(['dolor', 'amet']);
+});
+
+it('escapes all other HTML markup', () => {
+  const { container } = render(
+    <div>
+      {convertHighlightsToReactElements("<script>alert('XSS!')</script>")}
+    </div>
+  );
+
+  expect(container).toHaveTextContent("<script>alert('XSS!')</script>");
+  expect(container.querySelector('script')).toBeNull();
+});

--- a/ui/src/util/htmlEntities.js
+++ b/ui/src/util/htmlEntities.js
@@ -1,0 +1,24 @@
+// The escpaing of HTML entities follows Lucenes implementation.
+// Lucene encodes some character that aren't stricktly required
+// to be encoded, e.g. slashes.
+// https://github.com/apache/lucene/blob/releases/lucene/9.2.0/lucene/highlighter/src/java/org/apache/lucene/search/highlight/SimpleHTMLEncoder.java
+const ESCAPES = [
+  ['"', '&quot;'],
+  ['&', '&amp;'],
+  ['<', '&lt;'],
+  ['>', '&gt;'],
+  ['\\', '&#x27;'],
+  ['/', '&#x2F;'],
+];
+
+export function decode(encoded) {
+  return ESCAPES.reduce((encoded, [char, replacement]) => {
+    return encoded.replaceAll(replacement, char);
+  }, encoded);
+}
+
+export function encode(decoded) {
+  return ESCAPES.reduce((decoded, [char, replacement]) => {
+    return decoded.replaceAll(char, replacement);
+  }, decoded);
+}

--- a/ui/src/util/insertHighlights.js
+++ b/ui/src/util/insertHighlights.js
@@ -1,0 +1,16 @@
+import { encode } from 'util/htmlEntities';
+
+export default function insertHighlights(text, highlights) {
+  // The highlights returned by the API are HTML encoded, but
+  // the document text is not. We need to encoded the document text
+  // as well. Otherwise, highlights that contain HTML entities
+  // would not get replaced.
+  text = encode(text);
+
+  return highlights.reduce((text, highlight) => {
+    // Highlights are enclosed with HTML `em` tags
+    const withoutMarkup = highlight.replaceAll(/<\/?em>/g, '');
+
+    return text.replace(withoutMarkup, highlight);
+  }, text);
+}

--- a/ui/src/util/insertHighlights.test.js
+++ b/ui/src/util/insertHighlights.test.js
@@ -1,0 +1,35 @@
+import insertHighlights from './insertHighlights';
+
+it('inserts highlighted snippets in full text', () => {
+  const text =
+    'Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo' +
+    'ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis';
+
+  const highlights = [
+    'Lorem ipsum <em>dolor sit amet</em>',
+    'Aenean <em>massa</em>',
+  ];
+
+  expect(insertHighlights(text, highlights)).toEqual(
+    'Lorem ipsum <em>dolor sit amet</em>, consectetuer adipiscing elit. Aenean commodo' +
+      'ligula eget dolor. Aenean <em>massa</em>. Cum sociis natoque penatibus et magnis dis'
+  );
+});
+
+it('handles highlights that span multiple lines', () => {
+  const text = 'This is the first line.\nThis is the second line.';
+  const highlights = ['first <em>line</em>.\nThis'];
+
+  expect(insertHighlights(text, highlights)).toEqual(
+    'This is the first <em>line</em>.\nThis is the second line.'
+  );
+});
+
+it('handles HTML-escaped highlights', () => {
+  const text = 'https://occrp.org/';
+  const highlights = ['https:&#x2F;&#x2F;<em>occrp</em>.org&#x2F;'];
+
+  expect(insertHighlights(text, highlights)).toEqual(
+    'https:&#x2F;&#x2F;<em>occrp</em>.org&#x2F;'
+  );
+});

--- a/ui/src/viewers/PdfViewer.jsx
+++ b/ui/src/viewers/PdfViewer.jsx
@@ -99,12 +99,16 @@ export class PdfViewer extends Component {
   }
 
   onSearch(queryText) {
-    const { navigate, location, baseQuery } = this.props;
-    const newQuery = baseQuery.setString('q', queryText);
+    const { navigate, location } = this.props;
+    const hash = queryString.parse(location.hash);
 
     navigate({
       pathname: location.pathname,
-      search: newQuery.toLocation(),
+      hash: queryString.stringify({
+        ...hash,
+        page: undefined,
+        q: queryText || undefined,
+      }),
     });
   }
 
@@ -164,6 +168,7 @@ export class PdfViewer extends Component {
     const { document, page, rotate, numPages, pdfUrl } = this.props;
     const { effectiveRotation, width } = this.state;
     const { Document, Page } = this.state.components;
+
     const loading = <Skeleton.Text type="div" length={4000} />;
 
     return (
@@ -209,12 +214,12 @@ export class PdfViewer extends Component {
       document,
       dir,
       activeMode,
-      baseQuery,
+      pageQuery,
       searchQuery,
       intl,
       page,
-      queryText,
       numPages,
+      shouldRenderSearch,
     } = this.props;
 
     if (document.isPending || numPages === undefined || numPages === null) {
@@ -233,23 +238,24 @@ export class PdfViewer extends Component {
         <div className="outer">
           <div id="PdfViewer" className="inner">
             <div className="document">
-              <PdfViewerSearch
-                document={document}
-                dir={dir}
-                activeMode={activeMode}
-                query={searchQuery}
-              >
-                {activeMode === 'text' && (
-                  <PdfViewerPage
-                    document={document}
-                    dir={dir}
-                    page={page}
-                    numPages={numPages}
-                    baseQuery={baseQuery}
-                  />
-                )}
-                {activeMode === 'view' && !queryText && this.renderPdf()}
-              </PdfViewerSearch>
+              {shouldRenderSearch && (
+                <PdfViewerSearch
+                  document={document}
+                  dir={dir}
+                  activeMode={activeMode}
+                  query={searchQuery}
+                />
+              )}
+              {activeMode === 'text' && !shouldRenderSearch && (
+                <PdfViewerPage
+                  document={document}
+                  dir={dir}
+                  page={page}
+                  numPages={numPages}
+                  query={pageQuery}
+                />
+              )}
+              {activeMode === 'view' && !shouldRenderSearch && this.renderPdf()}
             </div>
           </div>
         </div>
@@ -270,14 +276,25 @@ const mapStateToProps = (state, ownProps) => {
 
   const countQuery = baseQuery.setString('q', undefined).offset(0).limit(0);
 
+  const queryText = hashQuery.q;
+
   const searchQuery = baseQuery
     .set('highlight', true)
+    .set('q', queryText)
     .sortBy('properties.index', 'asc')
     .clear('limit')
     .clear('offset');
 
+  const pageQuery = baseQuery
+    .set('highlight', true)
+    .set('highlight_text', queryText)
+    .setFilter('properties.index', page)
+    .set('limit', 1);
+
   const countResult = selectEntitiesResult(state, countQuery);
   const pdfUrl = document.links?.pdf || document.links?.file;
+  const shouldRenderSearch = queryText && !hashQuery.page;
+
   return {
     page,
     pdfUrl,
@@ -286,8 +303,11 @@ const mapStateToProps = (state, ownProps) => {
     baseQuery,
     countQuery,
     searchQuery,
-    queryText: baseQuery.getString('q'),
+    pageQuery,
+    queryText,
     countResult,
+    hashQuery,
+    shouldRenderSearch,
   };
 };
 

--- a/ui/src/viewers/PdfViewer.jsx
+++ b/ui/src/viewers/PdfViewer.jsx
@@ -288,6 +288,7 @@ const mapStateToProps = (state, ownProps) => {
   const pageQuery = baseQuery
     .set('highlight', true)
     .set('highlight_text', queryText)
+    .set('highlight_count', 15)
     .setFilter('properties.index', page)
     .set('limit', 1);
 

--- a/ui/src/viewers/PdfViewer.jsx
+++ b/ui/src/viewers/PdfViewer.jsx
@@ -228,7 +228,7 @@ export class PdfViewer extends Component {
     return (
       <div className="PdfViewer">
         <EntityActionBar
-          query={searchQuery}
+          query={shouldRenderSearch ? searchQuery : pageQuery}
           onSearchSubmit={this.onSearch}
           searchPlaceholder={intl.formatMessage(messages.placeholder, {
             label: document.getCaption(),

--- a/ui/src/viewers/PdfViewer.scss
+++ b/ui/src/viewers/PdfViewer.scss
@@ -62,11 +62,6 @@ $pagesWidth: 150px;
             a {
               text-decoration: none;
             }
-
-            em {
-              background: $aleph-text-highlight-color;
-              font-style: normal;
-            }
           }
 
           p:first-child {

--- a/ui/src/viewers/PdfViewerPage.jsx
+++ b/ui/src/viewers/PdfViewerPage.jsx
@@ -46,7 +46,7 @@ const mapStateToProps = (state, ownProps) => {
   const query = baseQuery
     .set('highlight', true)
     // TODO: This should not be hard coded
-    .setString('q', 'balance')
+    .setString('highlight_text', 'balance')
     .setFilter('properties.index', page);
   const result = selectEntitiesResult(state, query);
   const entity = result.results.length

--- a/ui/src/viewers/PdfViewerPage.jsx
+++ b/ui/src/viewers/PdfViewerPage.jsx
@@ -44,7 +44,9 @@ class PdfViewerPage extends Component {
 const mapStateToProps = (state, ownProps) => {
   const { baseQuery, page } = ownProps;
   const query = baseQuery
-    .setString('q', undefined)
+    .set('highlight', true)
+    // TODO: This should not be hard coded
+    .setString('q', 'balance')
     .setFilter('properties.index', page);
   const result = selectEntitiesResult(state, query);
   const entity = result.results.length

--- a/ui/src/viewers/PdfViewerPage.jsx
+++ b/ui/src/viewers/PdfViewerPage.jsx
@@ -42,16 +42,14 @@ class PdfViewerPage extends Component {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const { baseQuery, page } = ownProps;
-  const query = baseQuery
-    .set('highlight', true)
-    // TODO: This should not be hard coded
-    .setString('highlight_text', 'balance')
-    .setFilter('properties.index', page);
+  const { query } = ownProps;
+
   const result = selectEntitiesResult(state, query);
+
   const entity = result.results.length
     ? result.results[0]
     : selectEntity(state, undefined);
+
   return {
     query,
     result,

--- a/ui/src/viewers/PdfViewerSearch.jsx
+++ b/ui/src/viewers/PdfViewerSearch.jsx
@@ -83,15 +83,7 @@ class PdfViewerSearch extends Component {
                   />
                 </Link>
               </p>
-              <p>
-                {res.highlight !== undefined && (
-                  <span
-                    dangerouslySetInnerHTML={{
-                      __html: res.highlight.join('  …  '),
-                    }}
-                  />
-                )}
-              </p>
+              <SearchHighlight highlight={res.highlight} />
             </li>
           ))}
         </ul>

--- a/ui/src/viewers/PdfViewerSearch.jsx
+++ b/ui/src/viewers/PdfViewerSearch.jsx
@@ -3,8 +3,8 @@ import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
-import getEntityLink from 'util/getEntityLink';
-import { SectionLoading } from 'components/common';
+import queryString from 'query-string';
+import { SectionLoading, SearchHighlight } from 'components/common';
 import { queryEntities } from 'actions';
 import { selectEntitiesResult } from 'selectors';
 
@@ -26,10 +26,16 @@ class PdfViewerSearch extends Component {
   }
 
   getResultLink(result) {
-    const { document, activeMode } = this.props;
-    const path = getEntityLink(document);
+    const { activeMode, query } = this.props;
     const page = result.getProperty('index').toString();
-    return `${path}#page=${page}&mode=${activeMode}`;
+
+    const hashQuery = {
+      page,
+      mode: activeMode,
+      q: query.getString('q'),
+    };
+
+    return `#${queryString.stringify(hashQuery)}`;
   }
 
   fetchPage() {
@@ -40,13 +46,12 @@ class PdfViewerSearch extends Component {
   }
 
   render() {
-    const { page, dir, query, result } = this.props;
-    if (!query.getString('q')) {
-      return this.props.children;
-    }
+    const { page, dir, result } = this.props;
+
     if (result.total === undefined) {
       return <SectionLoading />;
     }
+
     return (
       <div className="pages">
         {result.total === 0 && (

--- a/ui/src/viewers/TextViewer.jsx
+++ b/ui/src/viewers/TextViewer.jsx
@@ -2,9 +2,10 @@ import React, { PureComponent } from 'react';
 import { Pre } from '@blueprintjs/core';
 
 import { Skeleton } from 'components/common';
+import insertHighlights from 'util/insertHighlights';
+import convertHighlightsToReactElements from 'util/convertHighlightsToReactElements';
 
 import './TextViewer.scss';
-import convertHighlightsToReactElements from 'util/convertHighlightsToReactElements';
 
 class TextViewer extends PureComponent {
   constructor() {
@@ -28,18 +29,14 @@ class TextViewer extends PureComponent {
 
   highlightedText() {
     const { document } = this.props;
-    const text = document.getFirst('bodyText');
+    let text = document.getFirst('bodyText');
 
     if (!document.highlight) {
       return text;
     }
 
-    const withoutMarkup = highlight.replaceAll(/<\/?em>/g, '');
-    const html = document.highlight.reduce((text, highlight) => {
-      return text.replace(withoutMarkup, highlight);
-    }, text);
-
-    return convertHighlightsToReactElements(html);
+    const highlightedText = insertHighlights(text, document.highlight);
+    return convertHighlightsToReactElements(highlightedText);
   }
 }
 

--- a/ui/src/viewers/TextViewer.jsx
+++ b/ui/src/viewers/TextViewer.jsx
@@ -4,24 +4,42 @@ import { Pre } from '@blueprintjs/core';
 import { Skeleton } from 'components/common';
 
 import './TextViewer.scss';
+import convertHighlightsToReactElements from 'util/convertHighlightsToReactElements';
 
 class TextViewer extends PureComponent {
+  constructor() {
+    super();
+    this.highlightedText.bind(this);
+  }
+
   render() {
-    const { document, dir, noStyle } = this.props;
-    const text = document.isPending ? (
-      <Skeleton.Text type="pre" length={4000} />
-    ) : (
-      <Pre>{document.getFirst('bodyText')}</Pre>
+    const { document, dir } = this.props;
+
+    if (document.isPending) {
+      return <Skeleton.Text type="pre" length={4000} />;
+    }
+
+    return (
+      <Pre className="TextViewer" dir={dir}>
+        {this.highlightedText()}
+      </Pre>
     );
-    return noStyle ? (
-      text
-    ) : (
-      <div className="outer">
-        <div className="inner TextViewer" dir={dir}>
-          {text}
-        </div>
-      </div>
-    );
+  }
+
+  highlightedText() {
+    const { document } = this.props;
+    const text = document.getFirst('bodyText');
+
+    if (!document.highlight) {
+      return text;
+    }
+
+    const withoutMarkup = highlight.replaceAll(/<\/?em>/g, '');
+    const html = document.highlight.reduce((text, highlight) => {
+      return text.replace(withoutMarkup, highlight);
+    }, text);
+
+    return convertHighlightsToReactElements(html);
   }
 }
 

--- a/ui/src/viewers/TextViewer.jsx
+++ b/ui/src/viewers/TextViewer.jsx
@@ -11,9 +11,24 @@ class TextViewer extends PureComponent {
   constructor() {
     super();
     this.highlightedText.bind(this);
+    this.contents.bind(this);
   }
 
   render() {
+    const { noStyle } = this.props;
+
+    if (noStyle) {
+      return this.contents();
+    }
+
+    return (
+      <div className="outer">
+        <div className="inner">{this.contents()}</div>
+      </div>
+    );
+  }
+
+  contents() {
     const { document, dir } = this.props;
 
     if (document.isPending) {

--- a/ui/src/viewers/TextViewer.scss
+++ b/ui/src/viewers/TextViewer.scss
@@ -1,18 +1,19 @@
 @import 'app/variables.scss';
 
-.TextViewer {
-  overflow-x: hidden;
+// This overrides Blueprint's default styles for code blocks.
+// When bundling our app, Blueprint styles are currently included
+// after component-specific styles, i.e. Blueprint styles override
+// component-specific styles if the selector specificity is the
+// same. The repeated class name in the selector is a hack to increase
+// the specificity.
+.TextViewer.TextViewer {
+  margin: 0;
   padding: $aleph-grid-size;
-  box-shadow: $pt-elevation-shadow-1;
-  margin-bottom: 2 * $aleph-grid-size;
+  border: none;
+  box-shadow: none;
+}
 
-  pre {
-    margin: 0;
-    padding: 0;
-    border: 0;
-    font-family: $pt-font-family;
-    line-height: 1.4;
-    font-size: 1.1 * $aleph-font-size;
-    box-shadow: unset;
-  }
+.TextViewer > em {
+  background-color: $aleph-text-highlight-color;
+  font-style: inherit;
 }

--- a/ui/src/viewers/TextViewer.test.jsx
+++ b/ui/src/viewers/TextViewer.test.jsx
@@ -1,0 +1,59 @@
+import { render } from '@testing-library/react';
+import { Model, defaultModel } from '@alephdata/followthemoney';
+import TextViewer from './TextViewer';
+
+const model = new Model(defaultModel);
+
+const getPageEntity = (bodyText, highlight) => {
+  const entity = model.getEntity({
+    schema: 'Page',
+    properties: {
+      bodyText: [bodyText],
+    },
+  });
+
+  entity.highlight = highlight;
+
+  return entity;
+};
+
+it('renders body text', () => {
+  const entity = getPageEntity(
+    'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.'
+  );
+  const { container } = render(<TextViewer document={entity} />);
+
+  expect(container).toHaveTextContent(
+    'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.'
+  );
+});
+
+it('displays highlights', () => {
+  const entity = getPageEntity(
+    'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.',
+    ['sit <em>amet</em>, consectetuer']
+  );
+
+  const { container } = render(<TextViewer document={entity} />);
+
+  expect(container).toHaveTextContent(
+    'Lorem ipsum dolor sit amet, consectetuer adipiscing elit.'
+  );
+  expect(container.querySelectorAll('em')).toHaveLength(1);
+});
+
+it('escapes HTML markup', () => {
+  const entity = getPageEntity(
+    'This document contains <em>HTML markup</em><script>alert()</script>',
+    ['This <em>document</em>']
+  );
+
+  const { container } = render(<TextViewer document={entity} />);
+
+  expect(container).toHaveTextContent(
+    'This document contains <em>HTML markup</em><script>alert()</script>'
+  );
+  expect(container.querySelectorAll('em')).toHaveLength(1);
+  expect(container.querySelector('em')).toHaveTextContent('document');
+  expect(container.querySelectorAll('script')).toHaveLength(0);
+});


### PR DESCRIPTION
This PR adds support to highlight search terms in document text while in plaintext mode. It would be nice to support this in view mode as well, but this is likely going to be less straight-forward and something I’d look into separately.

https://user-images.githubusercontent.com/1512805/178830658-b1071061-1523-4d77-8de3-04d7b0f7b575.mov

Example document that can be used for testing: [test_markup.pdf](https://github.com/alephdata/aleph/files/9071458/test_markup.pdf)

- [x] ~If the document text contains line breaks, and a snippet spans multiple lines, then the snippet does not contain line breaks.~ Actually, this is not an issue at all. Snippets returned by ES do contain line breaks.
- [x] Adjust the number (and length) of highlights/snippets?
- [x] Test escpaing in `TextViewer`
- [x] Test `SearchHighlight`
- [x] Remove unused imports/linting issues