### PR TITLE
Till/2400 message banner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,9 @@ jobs:
       - name: Run linter
         run: make lint-ui
 
+      - name: Run tests
+        run: make test-ui
+
       - name: Build production image
         run: docker build -t alephdata/aleph-ui-production:${GITHUB_SHA} -f ui/Dockerfile.production ui
 

--- a/aleph.env.tmpl
+++ b/aleph.env.tmpl
@@ -13,6 +13,15 @@ ALEPH_APP_TITLE=Aleph
 ALEPH_APP_NAME=aleph
 ALEPH_UI_URL=http://localhost:8080/
 
+# Set a static, app-wide message banner displayed at the top of every page.
+# This can be useful to inform users about planned downtime etc.
+# ALEPH_APP_BANNER="This is an app-wide message."
+
+# Instead of defining a static message using the `ALEPH_APP_BANNER` variable,
+# you can also define a JSON endpoint that Aleph will use to fetch app-wide
+# messages to display at the top of every page.
+# ALEPH_APP_MESSAGES_URL=https://example.org/messages.json
+
 # ALEPH_URL_SCHEME=https
 # ALEPH_FAVICON=https://investigativedashboard.org/static/favicon.ico
 # ALEPH_LOGO=http://assets.pudo.org/img/logo_bigger.png

--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -37,6 +37,7 @@ APP_FAVICON = env.get("ALEPH_FAVICON", "/static/favicon.png")
 
 # Show a system-wide banner in the user interface.
 APP_BANNER = env.get("ALEPH_APP_BANNER")
+APP_MESSAGES_URL = env.get("ALEPH_APP_MESSAGES_URL", None)
 
 # Force HTTPS here:
 FORCE_HTTPS = True if APP_UI_URL.lower().startswith("https") else False

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -51,6 +51,7 @@ def _metadata_locale(locale):
             "version": __version__,
             "banner": settings.APP_BANNER,
             "ui_uri": settings.APP_UI_URL,
+            "messages_url": settings.APP_MESSAGES_URL,
             "publish": archive.can_publish,
             "logo": app_logo,
             "favicon": settings.APP_FAVICON,

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,8 @@
     "@formatjs/intl-pluralrules": "^5.0.2",
     "@formatjs/intl-relativetimeformat": "^11.0.1",
     "@formatjs/intl-utils": "^3.8.4",
+    "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react": "^12.1.5",
     "@types/jest": "^28.1.4",
     "@types/node": "^17.0.8",
     "@types/react": "^17.0.1",
@@ -71,6 +73,9 @@
   "proxy": "http://api:5000/",
   "eslintConfig": {
     "extends": "react-app"
+  },
+  "jest": {
+    "transformIgnorePatterns": []
   },
   "browserslist": {
     "production": [

--- a/ui/src/actions/index.js
+++ b/ui/src/actions/index.js
@@ -58,6 +58,7 @@ export {
   fetchProfileTags,
   pairwiseJudgement,
 } from './profileActions';
+export { fetchMessages } from './messagesActions';
 export {
   fetchMetadata,
   fetchStatistics,

--- a/ui/src/actions/messagesActions.js
+++ b/ui/src/actions/messagesActions.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+import asyncActionCreator from 'actions/asyncActionCreator';
+
+const MESSAGES_ENDPOINT =
+  'https://tillprochaska.github.io/status-github-api/messages.json';
+
+export const fetchMessages = asyncActionCreator(
+  () => async () => {
+    const response = await axios.get(MESSAGES_ENDPOINT);
+    return { messages: response.data };
+  },
+  { name: 'FETCH_MESSAGES' }
+);

--- a/ui/src/actions/messagesActions.js
+++ b/ui/src/actions/messagesActions.js
@@ -1,12 +1,9 @@
 import axios from 'axios';
 import asyncActionCreator from 'actions/asyncActionCreator';
 
-const MESSAGES_ENDPOINT =
-  'https://tillprochaska.github.io/status-page-workflow/messages.json';
-
 export const fetchMessages = asyncActionCreator(
-  () => async () => {
-    const response = await axios.get(MESSAGES_ENDPOINT);
+  (endpoint) => async () => {
+    const response = await axios.get(endpoint);
     return { messages: response.data };
   },
   { name: 'FETCH_MESSAGES' }

--- a/ui/src/actions/messagesActions.js
+++ b/ui/src/actions/messagesActions.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import asyncActionCreator from 'actions/asyncActionCreator';
 
 const MESSAGES_ENDPOINT =
-  'https://tillprochaska.github.io/status-github-api/messages.json';
+  'https://tillprochaska.github.io/status-page-workflow/messages.json';
 
 export const fetchMessages = asyncActionCreator(
   () => async () => {

--- a/ui/src/app/App.scss
+++ b/ui/src/app/App.scss
@@ -40,7 +40,6 @@ body {
   margin: 0;
   padding: 0;
   font-family: $pt-font-family;
-  font-weight: 300;
   font-size: $aleph-font-size;
 
   display: flex;

--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -40,7 +40,7 @@ import ExportsScreen from 'src/screens/ExportsScreen/ExportsScreen';
 
 import './Router.scss';
 
-const MESSAGES_INTERVAL = 10 * 1000; // every 10 seconds
+const MESSAGES_INTERVAL = 15 * 60 * 1000; // every 15 minutes
 
 class Router extends Component {
   componentDidMount() {

--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -45,13 +45,7 @@ const MESSAGES_INTERVAL = 15 * 60 * 1000; // every 15 minutes
 class Router extends Component {
   componentDidMount() {
     this.fetchIfNeeded();
-
-    this.setState(() => ({
-      messagesInterval: setInterval(
-        () => this.props.fetchMessages(),
-        MESSAGES_INTERVAL
-      ),
-    }));
+    this.setMessagesInterval();
   }
 
   componentDidUpdate() {
@@ -59,9 +53,7 @@ class Router extends Component {
   }
 
   componentWillUnmount() {
-    if (this.state?.messagesInterval) {
-      clearInterval(this.state.messagesInterval);
-    }
+    this.clearMessagesInterval();
   }
 
   fetchIfNeeded() {
@@ -72,7 +64,26 @@ class Router extends Component {
     }
 
     if (messages.shouldLoad) {
-      this.props.fetchMessages();
+      this.fetchMessages();
+    }
+  }
+
+  fetchMessages() {
+    const { metadata } = this.props;
+
+    if (metadata?.app?.messages_url) {
+      this.props.fetchMessages(metadata.app.messages_url);
+    }
+  }
+
+  setMessagesInterval() {
+    const id = setInterval(() => this.fetchMessages(), MESSAGES_INTERVAL);
+    this.setState(() => ({ messagesInterval: id }));
+  }
+
+  clearMessagesInterval() {
+    if (this.state?.messagesInterval) {
+      clearInterval(this.state.messagesInterval);
     }
   }
 

--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -77,7 +77,7 @@ class Router extends Component {
   }
 
   render() {
-    const { metadata, session } = this.props;
+    const { metadata, session, pinnedMessage } = this.props;
     const isLoaded = metadata && metadata.app && session;
 
     const Loading = (
@@ -95,6 +95,7 @@ class Router extends Component {
     return (
       <>
         <Navbar />
+        <MessageBanner message={pinnedMessage} />
         <Suspense fallback={Loading}>
           <Routes>
             <Route path="oauth" element={<OAuthScreen />} />

--- a/ui/src/components/Dashboard/Dashboard.scss
+++ b/ui/src/components/Dashboard/Dashboard.scss
@@ -1,10 +1,8 @@
 @import 'app/variables.scss';
 @import 'app/mixins.scss';
 
-$dashboard-padding: $aleph-grid-size * 2.5;
-
 .Dashboard {
-  padding: $dashboard-padding;
+  padding: $aleph-content-padding;
 
   &__inner-container {
     display: flex;
@@ -24,8 +22,18 @@ $dashboard-padding: $aleph-grid-size * 2.5;
       1px solid $aleph-border-color,
       null
     );
-    @include rtlSupportInvertedProp(margin, right, $dashboard-padding, null);
-    @include rtlSupportInvertedProp(padding, right, $dashboard-padding, null);
+    @include rtlSupportInvertedProp(
+      margin,
+      right,
+      $aleph-content-padding,
+      null
+    );
+    @include rtlSupportInvertedProp(
+      padding,
+      right,
+      $aleph-content-padding,
+      null
+    );
     min-width: 235px;
 
     @media screen and (max-width: $aleph-screen-sm-max-width) {
@@ -76,7 +84,7 @@ $dashboard-padding: $aleph-grid-size * 2.5;
   }
 
   &__title-container {
-    margin: $dashboard-padding 0;
+    margin: $aleph-content-padding 0;
   }
 
   &__title {

--- a/ui/src/components/Entity/EntityHeading.jsx
+++ b/ui/src/components/Entity/EntityHeading.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { selectUnit } from '@formatjs/intl-utils';
-import { FormattedRelativeTime } from 'react-intl';
-import { Entity, Schema } from 'components/common';
+import { Entity, Schema, RelativeTime } from 'components/common';
 
 import 'components/common/ItemOverview.scss';
 
@@ -12,7 +10,6 @@ class EntityHeading extends React.PureComponent {
     const lastViewedDate = entity.lastViewed
       ? new Date(parseInt(entity.lastViewed, 10))
       : Date.now();
-    const { value, unit } = selectUnit(lastViewedDate, Date.now());
 
     return (
       <>
@@ -36,17 +33,7 @@ class EntityHeading extends React.PureComponent {
             <FormattedMessage
               id="entity.info.last_view"
               defaultMessage="Last viewed {time}"
-              values={{
-                time: (
-                  <FormattedRelativeTime
-                    value={value}
-                    unit={unit}
-                    // eslint-disable-next-line
-                    style="long"
-                    numeric="auto"
-                  />
-                ),
-              }}
+              values={{ time: <RelativeTime date={lastViewedDate} /> }}
             />
           </span>
         )}

--- a/ui/src/components/Exports/Export.jsx
+++ b/ui/src/components/Exports/Export.jsx
@@ -1,10 +1,12 @@
 import React, { PureComponent } from 'react';
-import { selectUnit } from '@formatjs/intl-utils';
-import { FormattedRelativeTime } from 'react-intl';
 import c from 'classnames';
 
-import { Skeleton, ExportLink, FileSize } from 'src/components/common';
-import convertUTCDateToLocalDate from 'util/convertUTCDateToLocalDate';
+import {
+  Skeleton,
+  ExportLink,
+  FileSize,
+  RelativeTime,
+} from 'src/components/common';
 
 import './Export.scss';
 
@@ -35,8 +37,6 @@ class Export extends PureComponent {
 
     const { id, expires_at: expiresAt, export_status: status } = export_;
 
-    const expiryDate = convertUTCDateToLocalDate(new Date(expiresAt));
-    const { value, unit } = selectUnit(expiryDate);
     return (
       <tr key={id} className={c('Export nowrap', status)}>
         <td className="export-label wide">
@@ -47,13 +47,7 @@ class Export extends PureComponent {
         </td>
         <td className="export-status">{export_.status}</td>
         <td className="timestamp">
-          <FormattedRelativeTime
-            value={value}
-            unit={unit}
-            // eslint-disable-next-line
-            style="long"
-            numeric="auto"
-          />
+          <RelativeTime utcDate={expiresAt} />
         </td>
       </tr>
     );

--- a/ui/src/components/MessageBanner/MessageBanner.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.jsx
@@ -1,0 +1,48 @@
+import { Callout, Intent, Classes } from '@blueprintjs/core';
+import { injectIntl } from 'react-intl';
+import { RelativeTime } from 'components/common';
+
+import './MessageBanner.scss';
+
+const MESSAGE_INTENTS = {
+  info: Intent.PRIMARY,
+  warning: Intent.WARNING,
+  error: Intent.ERROR,
+  success: Intent.SUCCESS,
+};
+
+function Wrapper({ children }) {
+  return (
+    <div className="MessageBanner" role="status" aria-atomic="true">
+      {children}
+    </div>
+  );
+}
+
+function MessageBanner({ message }) {
+  if (!message) {
+    return <Wrapper />;
+  }
+
+  const intent = MESSAGE_INTENTS[message.level] || Intent.WARNING;
+
+  const latestUpdate =
+    message.updates.length > 0
+      ? message.updates[message.updates.length - 1]
+      : message;
+
+  return (
+    <Wrapper>
+      <Callout intent={intent} icon={null} className="MessageBanner__callout">
+        <strong className={Classes.HEADING}>{message.title}</strong>
+        <br />
+        {latestUpdate.body}
+        <span className="MessageBanner__meta">
+          <RelativeTime date={latestUpdate.createdAt} />
+        </span>
+      </Callout>
+    </Wrapper>
+  );
+}
+
+export default injectIntl(MessageBanner);

--- a/ui/src/components/MessageBanner/MessageBanner.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.jsx
@@ -25,21 +25,28 @@ function MessageBanner({ message }) {
   }
 
   const intent = MESSAGE_INTENTS[message.level] || Intent.WARNING;
+  const updates = message.updates || [];
 
   const latestUpdate =
-    message.updates.length > 0
-      ? message.updates[message.updates.length - 1]
-      : message;
+    updates.length > 0 ? updates[updates.length - 1] : message;
 
   return (
     <Wrapper>
       <Callout intent={intent} icon={null} className="MessageBanner__callout">
-        <strong className={Classes.HEADING}>{message.title}</strong>
-        <br />
+        {message.title && (
+          <>
+            <strong className={Classes.HEADING}>{message.title}</strong>
+            <br />
+          </>
+        )}
+
         {latestUpdate.body}
-        <span className="MessageBanner__meta">
-          <RelativeTime date={latestUpdate.createdAt} />
-        </span>
+
+        {latestUpdate.createdAt && (
+          <span className="MessageBanner__meta">
+            <RelativeTime date={latestUpdate.createdAt} />
+          </span>
+        )}
       </Callout>
     </Wrapper>
   );

--- a/ui/src/components/MessageBanner/MessageBanner.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.jsx
@@ -7,7 +7,7 @@ import './MessageBanner.scss';
 const MESSAGE_INTENTS = {
   info: Intent.PRIMARY,
   warning: Intent.WARNING,
-  error: Intent.ERROR,
+  error: Intent.DANGER,
   success: Intent.SUCCESS,
 };
 

--- a/ui/src/components/MessageBanner/MessageBanner.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.jsx
@@ -33,20 +33,24 @@ function MessageBanner({ message }) {
   return (
     <Wrapper>
       <Callout intent={intent} icon={null} className="MessageBanner__callout">
-        {message.title && (
-          <>
-            <strong className={Classes.HEADING}>{message.title}</strong>
-            <br />
-          </>
-        )}
+        <p>
+          {message.title && (
+            <>
+              <strong className={Classes.HEADING}>{message.title}</strong>
+              <br />
+            </>
+          )}
 
-        {latestUpdate.body}
+          <span
+            dangerouslySetInnerHTML={{ __html: latestUpdate.safeHtmlBody }}
+          />
 
-        {latestUpdate.createdAt && (
-          <span className="MessageBanner__meta">
-            <RelativeTime date={latestUpdate.createdAt} />
-          </span>
-        )}
+          {latestUpdate.createdAt && (
+            <span className="MessageBanner__meta">
+              <RelativeTime date={latestUpdate.createdAt} />
+            </span>
+          )}
+        </p>
       </Callout>
     </Wrapper>
   );

--- a/ui/src/components/MessageBanner/MessageBanner.scss
+++ b/ui/src/components/MessageBanner/MessageBanner.scss
@@ -4,6 +4,17 @@
   padding: 0.5 * $aleph-content-padding $aleph-content-padding;
 }
 
+.MessageBanner p {
+  margin: 0;
+}
+
+.MessageBanner a,
+.MessageBanner a:hover {
+  color: inherit;
+  text-decoration: underline;
+  font-weight: 600;
+}
+
 .MessageBanner__meta {
   opacity: 0.6;
 }

--- a/ui/src/components/MessageBanner/MessageBanner.scss
+++ b/ui/src/components/MessageBanner/MessageBanner.scss
@@ -1,0 +1,13 @@
+@import '../../app/variables.scss';
+
+.MessageBanner__callout.MessageBanner__callout {
+  padding: 0.5 * $aleph-content-padding $aleph-content-padding;
+}
+
+.MessageBanner__meta {
+  opacity: 0.6;
+}
+
+.MessageBanner__meta::before {
+  content: ' — ';
+}

--- a/ui/src/components/MessageBanner/MessageBanner.test.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.test.jsx
@@ -22,12 +22,26 @@ it('renders empty wrapper without message', () => {
 it('renders level, title, body, date', () => {
   const message = {
     title: 'Degraded ingest performance',
-    body: 'Processing ingested files currently takes longer than usual.',
+    safeHtmlBody:
+      'Processing ingested files currently takes longer than usual.',
   };
 
   render(<MessageBanner message={message} />);
   expect(screen.getByText('Degraded ingest performance')).toBeInTheDocument();
-  expect(screen.getByText(message.body)).toBeInTheDocument();
+  expect(screen.getByText(message.safeHtmlBody)).toBeInTheDocument();
+});
+
+it('renders HTML body', () => {
+  const message = {
+    safeHtmlBody: '<a href="https://example.org">Read more</a>',
+  };
+
+  render(<MessageBanner message={message} />);
+  expect(screen.getByText('Read more')).toBeInTheDocument();
+  expect(screen.getByText('Read more').closest('a')).toHaveAttribute(
+    'href',
+    'https://example.org'
+  );
 });
 
 it('renders correct intent', () => {
@@ -42,7 +56,7 @@ it('uses warning intent by default', () => {
 
 it('renders date', () => {
   const message = {
-    body: 'Hello World!',
+    safeHtmlBody: 'Hello World!',
     createdAt: '2022-01-01T00:00:00.000Z',
   };
 
@@ -51,18 +65,18 @@ it('renders date', () => {
 });
 
 it('renders successfully with only a body', () => {
-  render(<MessageBanner message={{ body: 'Hello World!' }} />);
+  render(<MessageBanner message={{ safeHtmlBody: 'Hello World!' }} />);
   expect(screen.getByRole('status')).toBeInTheDocument();
 });
 
 it('renders latest update', () => {
   const message = {
-    body: 'Aleph will be down for maintenance on Sunday.',
+    safeHtmlBody: 'Aleph will be down for maintenance on Sunday.',
     createdAt: '2022-01-01T00:00:00.000Z',
     updates: [
       {
         createdAt: '2022-01-02T00:00:00.000Z',
-        body: 'We’re back online!',
+        safeHtmlBody: 'We’re back online!',
       },
     ],
   };

--- a/ui/src/components/MessageBanner/MessageBanner.test.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.test.jsx
@@ -1,0 +1,73 @@
+import { render, screen } from 'testUtils';
+import MessageBanner from './MessageBanner';
+
+const getCallout = (container, intent) => {
+  return container.querySelector(
+    `[class*="-callout"][class*="-intent-${intent}"]`
+  );
+};
+
+const getTime = (container, date) => {
+  return container.querySelector(`time[datetime="${date}"]`);
+};
+
+it('renders empty wrapper without message', () => {
+  // This ensures that the ARIA live region is already present in the DOM,
+  // even if no message is displayed. Required by some screenreaders so that
+  // they announce new messages correctly.
+  render(<MessageBanner message={null} />);
+  expect(screen.getByRole('status')).toBeInTheDocument();
+});
+
+it('renders level, title, body, date', () => {
+  const message = {
+    title: 'Degraded ingest performance',
+    body: 'Processing ingested files currently takes longer than usual.',
+  };
+
+  render(<MessageBanner message={message} />);
+  expect(screen.getByText('Degraded ingest performance')).toBeInTheDocument();
+  expect(screen.getByText(message.body)).toBeInTheDocument();
+});
+
+it('renders correct intent', () => {
+  const { container } = render(<MessageBanner message={{ level: 'info' }} />);
+  expect(getCallout(container, 'primary')).toBeInTheDocument();
+});
+
+it('uses warning intent by default', () => {
+  const { container } = render(<MessageBanner message={{}} />);
+  expect(getCallout(container, 'warning')).toBeInTheDocument();
+});
+
+it('renders date', () => {
+  const message = {
+    body: 'Hello World!',
+    createdAt: '2022-01-01T00:00:00.000Z',
+  };
+
+  const { container } = render(<MessageBanner message={message} />);
+  expect(getTime(container, message.createdAt)).toBeInTheDocument();
+});
+
+it('renders successfully with only a body', () => {
+  render(<MessageBanner message={{ body: 'Hello World!' }} />);
+  expect(screen.getByRole('status')).toBeInTheDocument();
+});
+
+it('renders latest update', () => {
+  const message = {
+    body: 'Aleph will be down for maintenance on Sunday.',
+    createdAt: '2022-01-01T00:00:00.000Z',
+    updates: [
+      {
+        createdAt: '2022-01-02T00:00:00.000Z',
+        body: 'We’re back online!',
+      },
+    ],
+  };
+
+  const { container } = render(<MessageBanner message={message} />);
+  expect(screen.getByRole('status')).toHaveTextContent('We’re back online!');
+  expect(getTime(container, message.createdAt));
+});

--- a/ui/src/components/Notification/Notification.jsx
+++ b/ui/src/components/Notification/Notification.jsx
@@ -1,6 +1,4 @@
 import React, { PureComponent } from 'react';
-import { selectUnit } from '@formatjs/intl-utils';
-import { FormattedRelativeTime } from 'react-intl';
 
 import {
   Collection,
@@ -10,8 +8,8 @@ import {
   Role,
   Skeleton,
   ExportLink,
+  RelativeTime,
 } from 'src/components/common';
-import convertUTCDateToLocalDate from 'util/convertUTCDateToLocalDate';
 
 import './Notification.scss';
 
@@ -94,19 +92,11 @@ class Notification extends PureComponent {
       }
     });
 
-    const createdDate = convertUTCDateToLocalDate(new Date(createdAt));
-    const { value, unit } = selectUnit(createdDate, Date.now());
     return (
       <li key={id} className="Notification">
         <div className="notification-action">{message}</div>
         <div className="timestamp">
-          <FormattedRelativeTime
-            value={value}
-            unit={unit}
-            // eslint-disable-next-line
-            style="long"
-            numeric="auto"
-          />
+          <RelativeTime utcDate={createdAt} />
         </div>
       </li>
     );

--- a/ui/src/components/Screen/Screen.jsx
+++ b/ui/src/components/Screen/Screen.jsx
@@ -63,11 +63,6 @@ export class Screen extends React.Component {
             <link rel="shortcut icon" href={metadata.app.favicon} />
           )}
         </Helmet>
-        {hasMetadata && !!metadata.app.banner && (
-          <div className="app-banner bp3-callout bp3-intent-warning bp3-icon-warning-sign">
-            {metadata.app.banner}
-          </div>
-        )}
         {!forceAuth && (
           <>
             <main>{this.props.children}</main>

--- a/ui/src/components/common/RelativeTime.jsx
+++ b/ui/src/components/common/RelativeTime.jsx
@@ -1,0 +1,22 @@
+import convertUTCDateToLocalDate from 'util/convertUTCDateToLocalDate';
+import { selectUnit } from '@formatjs/intl-utils';
+import { FormattedRelativeTime } from 'react-intl';
+
+export default function ({ date, utcDate }) {
+  const dateObj = utcDate
+    ? convertUTCDateToLocalDate(new Date(utcDate))
+    : new Date(date);
+
+  const { value, unit } = selectUnit(dateObj, Date.now());
+
+  return (
+    <time dateTime={dateObj.toISOString()}>
+      <FormattedRelativeTime
+        value={value}
+        unit={unit}
+        style="long"
+        numeric="auto"
+      />
+    </time>
+  );
+}

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -37,6 +37,7 @@ import Statistics from './Statistics';
 import Summary from './Summary';
 import QueryText from './QueryText';
 import QueryInfiniteLoad from './QueryInfiniteLoad';
+import RelativeTime from './RelativeTime';
 import ResultCount from './ResultCount';
 import ResultText from './ResultText';
 import SelectWrapper from './SelectWrapper';
@@ -86,6 +87,7 @@ export {
   QueryText,
   QueryInfiniteLoad,
   QuickLinks,
+  RelativeTime,
   ResultCount,
   ResultText,
   SelectWrapper,

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -1,5 +1,6 @@
 import { combineReducers } from 'redux';
 
+import messages from './messages';
 import metadata from './metadata';
 import mutation from './mutation';
 import session from './session';
@@ -20,6 +21,7 @@ import systemStatus from './systemStatus';
 import exports from './exports';
 
 const rootReducer = combineReducers({
+  messages,
   metadata,
   mutation,
   session,

--- a/ui/src/reducers/messages.js
+++ b/ui/src/reducers/messages.js
@@ -1,0 +1,14 @@
+import { createReducer } from 'redux-act';
+import { fetchMessages } from 'actions';
+import { loadState, loadStart, loadError, loadComplete } from 'reducers/util';
+
+const initialState = loadState();
+
+export default createReducer(
+  {
+    [fetchMessages.START]: (state) => loadStart(state),
+    [fetchMessages.ERROR]: (state, { error }) => loadError(state, error),
+    [fetchMessages.COMPLETE]: (state, messages) => loadComplete(messages),
+  },
+  initialState
+);

--- a/ui/src/screens/HomeScreen/HomeScreen.jsx
+++ b/ui/src/screens/HomeScreen/HomeScreen.jsx
@@ -7,7 +7,6 @@ import queryString from 'query-string';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
-import { Callout, Intent } from '@blueprintjs/core';
 
 import withRouter from 'app/withRouter';
 import {
@@ -80,8 +79,7 @@ export class HomeScreen extends Component {
     }
 
     const appHomePage = metadata.pages.find((page) => page.home);
-    const { description, samples, title, warning_title, warning_body } =
-      appHomePage;
+    const { description, samples, title } = appHomePage;
     const samplesList = wordList(samples, ', ').join('');
 
     return (
@@ -96,15 +94,6 @@ export class HomeScreen extends Component {
               <h1 className="HomeScreen__app-title">{title}</h1>
               {description && (
                 <p className="HomeScreen__description">{description}</p>
-              )}
-              {(warning_title || warning_body) && (
-                <Callout
-                  intent={Intent.WARNING}
-                  className="HomeScreen__auth-warning"
-                  title={warning_title}
-                >
-                  {warning_body}
-                </Callout>
               )}
               <div className="HomeScreen__search">
                 <SearchBox

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -92,7 +92,7 @@ export function selectPinnedMessage(state) {
   }
 
   const activeMessages = messages.filter(({ displayUntil }) => {
-    return !displayUntil || Date.now() <= displayUntil;
+    return !displayUntil || Date.now() <= new Date(displayUntil);
   });
 
   if (activeMessages.length <= 0) {

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -75,6 +75,20 @@ export function selectMetadata(state) {
   return metadata;
 }
 
+export function selectMessages(state) {
+  return selectObject(state, state, 'messages');
+}
+
+export function selectPinnedMessage(state) {
+  const { messages } = selectMessages(state);
+
+  if (!messages || messages.length <= 0) {
+    return null;
+  }
+
+  return messages[0];
+}
+
 export function selectPages(state) {
   return selectMetadata(state).pages;
 }

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -87,11 +87,19 @@ export function selectPinnedMessage(state) {
     return { body: metadata.app.banner };
   }
 
-  if (!messages || messages.length <= 0) {
+  if (!messages) {
     return null;
   }
 
-  return messages[0];
+  const activeMessages = messages.filter(({ displayUntil }) => {
+    return !displayUntil || Date.now() <= displayUntil;
+  });
+
+  if (activeMessages.length <= 0) {
+    return null;
+  }
+
+  return activeMessages[0];
 }
 
 export function selectPages(state) {

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -80,7 +80,12 @@ export function selectMessages(state) {
 }
 
 export function selectPinnedMessage(state) {
+  const metadata = selectMetadata(state);
   const { messages } = selectMessages(state);
+
+  if (metadata?.app?.banner) {
+    return { body: metadata.app.banner };
+  }
 
   if (!messages || messages.length <= 0) {
     return null;

--- a/ui/src/setupTests.js
+++ b/ui/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/ui/src/testUtils.jsx
+++ b/ui/src/testUtils.jsx
@@ -1,0 +1,13 @@
+import { render as rtlRender } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+function render(ui, { locale = 'en', ...renderOptions } = {}) {
+  const Wrapper = ({ children }) => {
+    return <IntlProvider locale={locale}>{children}</IntlProvider>;
+  };
+
+  return rtlRender(ui, { wrapper: Wrapper, ...renderOptions });
+}
+
+export * from '@testing-library/react';
+export { render };


### PR DESCRIPTION
* Messages can have a title, a date, and a level (info, warning, error, success).
* Messages can be loaded dynamically from a remote JSON endpoint (configured via `ALEPH_APP_MESSAGES_URL`) or set to a static value via the `ALEPH_APP_BANNER` variable.
* If a JSON endpoint is configured, the app will poll for changes every 15 minutes. This way, even users that keep the Aleph session open for a long time will be shown new messages with a max. 15 minutes delay.
* Messages can be hidden after a fixed amount of time. This can be useful to display a messages for some time once an incident has be resolved.
* Messages can have updates. If a message has updates, the most recent update (and the time it was posted) is displayed.

**A few things to consider:**
* The messages JSON endpoint can be configured via an environment variable. The value of that variable is exposed to the frontend via the app metadata. This isn’t optimal for two reasons:
  1. It creates a request waterfall, i.e. the metadata has to be loaded before being able to load messages. This only happens once on app startup and honestly this also isn’t the worst performance bottleneck, so this should be fine.
  2. If the metadata endpoint is unavailable (e.g. because the API service crashed), the frontend won’t be able to load messages, i.e. we can’t display a message banner in case of a full outage.
  
     The only way to change that would be to include the messages endpoint in the frontend image. That means that everyone who’d like to use this feature would have to build a customized UI Docker image. Additionally, configuring this feature would be different from configuring everything else.
  
     I don’t think it’s worth the effort. As an alternative generating a simple, static HTML status page with the same information would be much more sensible. Users would be able to find status information there even in case of a full outage.

* I’m unsure about naming. "Messages" is pretty generic. On the other hand, this might be used for things other than incidents/system status (e.g. announcing new features or datasets). We already use the terms alerts, notifications for different concepts.