### PR TITLE
removed code smell of function args with mutable defaults

### DIFF
--- a/aleph/core.py
+++ b/aleph/core.py
@@ -34,7 +34,10 @@ babel = Babel()
 talisman = Talisman()
 
 
-def create_app(config={}):
+def create_app(config=None):
+    if config is None:
+        config = {}
+
     configure_logging(level=logging.DEBUG)
     app = Flask("aleph")
     app.config.from_object(settings)

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -224,13 +224,13 @@ class Role(db.Model, IdModel, SoftDeleteModel):
         return set([cls.load_id(cls.SYSTEM_USER), cls.load_id(cls.SYSTEM_GUEST)])
 
     @classmethod
-    def by_prefix(cls, prefix, exclude=[]):
+    def by_prefix(cls, prefix, exclude=None):
         """Load a list of roles matching a name, email address, or foreign_id.
 
         :param str pattern: Pattern to match.
         """
         q = cls.all_users()
-        if len(exclude):
+        if exclude:
             q = q.filter(not_(Role.id.in_(exclude)))
         q = q.filter(
             or_(func.lower(cls.email) == prefix.lower(), query_like(cls.name, prefix))


### PR DESCRIPTION
Because:

```python
>>> def foo(x, y=[]):
...   y.append(x)
...   print(y)
... 
>>> foo(1)
[1]
>>> foo(2)
[1, 2]
```

None of the code here mutates, but this removes the possibility of introducing errors down the line.