### PR TITLE
Fix timelines editor

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@alephdata/followthemoney": "2.9.7",
-    "@alephdata/react-ftm": "2.6.7",
+    "@alephdata/react-ftm": "2.6.8",
     "@blueprintjs/colors": "^3.0.0",
     "@blueprintjs/core": "3.54.0",
     "@blueprintjs/icons": "3.31.0",


### PR DESCRIPTION
This bumps `react-ftm` to include a fix that prevented the timeline editor being rendered in Aleph. See https://github.com/alephdata/react-ftm/pull/895.

Steps to verify the fix:

1. Rebuild the UI container to ensure the latest packages are installed:
   
   ```
   docker compose -f docker-compose.dev.yml build ui
   ```

2. Upgrade indices and start Aleph:

   ```
   make upgrade
   make web
   ```

3. Open the UI: http://localhost:8080

4. Create a new timeline.

5. Navigate to the timeline and click the button "Create new item".

6. You should see the timeline editor. You should be able to hover over the color picker’s swatches and see tooltips with the color names.