### PR TITLE
Make the hide filter button persistent

### DIFF
--- a/ui/src/components/EntitySearch/FacetedEntitySearch.jsx
+++ b/ui/src/components/EntitySearch/FacetedEntitySearch.jsx
@@ -273,6 +273,9 @@ class FacetedEntitySearch extends React.Component {
       hasCustomColumns,
     } = this.props;
     const { hideFacets, isMobile } = this.state;
+    const toggleButtonLabel = intl.formatMessage(
+      messages[hideFacets ? 'show_facets' : 'hide_facets']
+    );
 
     const empty = (
       <ErrorSection
@@ -343,9 +346,7 @@ class FacetedEntitySearch extends React.Component {
                 <Button
                   className="FacetedEntitySearch__mobile-expand-toggle"
                   onClick={this.toggleFacets}
-                  text={intl.formatMessage(
-                    messages[hideFacets ? 'show_facets' : 'hide_facets']
-                  )}
+                  text={toggleButtonLabel}
                   icon={hideFacets ? 'add' : 'remove'}
                   alignText={Alignment.LEFT}
                   intent={Intent.PRIMARY}
@@ -402,6 +403,7 @@ class FacetedEntitySearch extends React.Component {
               <Button
                 onClick={this.toggleFacets}
                 icon={hideFacets ? 'chevron-right' : 'chevron-left'}
+                aria-label={toggleButtonLabel}
                 outlined
                 className="FacetedEntitySearch__expand-toggle__button"
               />

--- a/ui/src/components/EntitySearch/FacetedEntitySearch.scss
+++ b/ui/src/components/EntitySearch/FacetedEntitySearch.scss
@@ -93,15 +93,10 @@
     top: 30px;
     width: $toggle-width;
     z-index: 100;
-    opacity: 0;
     display: flex;
     flex-direction: column;
     height: 100vh;
     transform: translateX($aleph-sidebar-width - $toggle-width/2);
-
-    &:hover {
-      opacity: 1;
-    }
 
     .collapsed & {
       transform: translateX(0);


### PR DESCRIPTION
It's a really small change which makes the toggle filters sidebar button persistent within Aleph. Currently unless you are hovering over the very find line you would not know that this thing exists.