### PR TITLE
Quickfix: Set the `max_analyzed_offset` setting to prevent ES errors

### DIFF
--- a/aleph/search/parser.py
+++ b/aleph/search/parser.py
@@ -140,6 +140,17 @@ class SearchQueryParser(QueryParser):
         self.highlight_length = self.getint("highlight_length", 120)
         # Number of snippets per document, 0 = return full document text.
         self.highlight_count = self.getint("highlight_count", 3)
+        # By default, the maximum number of characters analyzed for a highlight
+        # request is bounded by the value defined in the
+        # index.highlight.max_analyzed_offset setting (1000000 by default),
+        # and when the number of characters exceeds this limit an error is
+        # returned. By setting `max_analyzed_offset` to a non-negative value
+        # lower than `index.highlight.max_analyzed_offset`, the highlighting
+        # stops at this defined maximum limit, and the rest of the text is not
+        # processed, thus not highlighted and no error is returned.
+        self.max_highlight_analyzed_offset = self.getint(
+            "max_highlight_analyzed_offset", 999999
+        )
 
     def get_facet_size(self, name):
         """Number of distinct values to be included (i.e. top N)."""

--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -228,6 +228,7 @@ class Query(object):
                     "require_field_match": False,
                     "number_of_fragments": self.parser.highlight_count,
                     "fragment_size": self.parser.highlight_length,
+                    "max_analyzed_offset": self.parser.max_highlight_analyzed_offset,
                 }
             },
         }


### PR DESCRIPTION
ES errors out when the length of a result body is larger than the global limit for highlight analysis (defined by
`index.highlight.max_analyzed`_offset). We set [`max_analyzed_offset`](https://www.elastic.co/guide/en/elasticsearch/reference/current/highlighting.html#:~:text=to%20true.-,max_analyzed_offset,-By%20default%2C%20the) to be lower than the global setting in highlight queries to prevent those errors.

The other option was to increase the global limit. But that puts more pressure on the index.