### PR TITLE
Fix date helper

### DIFF
--- a/ui/src/util/convertUTCDateToLocalDate.js
+++ b/ui/src/util/convertUTCDateToLocalDate.js
@@ -1,3 +1,8 @@
+// The Aleph API returns dates as ISO strings without timezone
+// designators. When initializing new `Date` objects, those dates
+// will by default be initialized with the local timezone of the
+// user agent.
 export default function convertUTCDateToLocalDate(date) {
-  return new Date(`${date} UTC`);
+  const dateObj = new Date(date);
+  return new Date(dateObj.getTime() - dateObj.getTimezoneOffset() * 60 * 1000);
 }


### PR DESCRIPTION
Closes #2488. Related to #2489.

The Aleph API returns dates in UTC as ISO strings without timezone designators. Parsing a date in JS (`new Date(dateString)`) uses the local timezone, and there’s no way to explicitly specify a timezone to use.

We currently have a helper function that replaces the local timezone with UTC. It does this by simply appending "UTC" to the string representation of a date in order to override the time zone.

This does however results in a date string that has multiple time zones:

```js
const date = new Date()
console.log(`${date} UTC`);
// "Wed Aug 31 2022 20:01:20 GMT+0200 (Central European Summer Time) UTC"
```

Firefox and Chrome parse these date strings, even though they are invalid. Safari throws an error.

This PR replaces the helper implementation with a way to adjust the timezone using only standard, broadly supported date methods.