### PR TITLE
Fix activation screen

### DIFF
--- a/ui/src/screens/ActivateScreen/ActivateScreen.jsx
+++ b/ui/src/screens/ActivateScreen/ActivateScreen.jsx
@@ -3,6 +3,7 @@ import { Navigate } from 'react-router-dom';
 import { FormattedMessage, injectIntl } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
+import withRouter from 'app/withRouter';
 import Screen from 'components/Screen/Screen';
 import { endpoint } from 'app/api';
 import { loginWithPassword } from 'actions/sessionActions';
@@ -16,10 +17,7 @@ export class ActivateScreen extends Component {
   }
 
   onActivate(data) {
-    const {
-      match: { params },
-      intl,
-    } = this.props;
+    const { params, intl } = this.props;
 
     endpoint
       .post('/roles', { code: params.code, ...data })
@@ -32,11 +30,9 @@ export class ActivateScreen extends Component {
   }
 
   render() {
-    const {
-      match: { params },
-      session,
-      intl,
-    } = this.props;
+    debugger;
+
+    const { params, session, intl } = this.props;
 
     if (!params.code || session.loggedIn) {
       return <Navigate to="/" replace />;
@@ -69,5 +65,6 @@ const mapStateToProps = ({ session }) => ({ session });
 const mapDispatchToProps = { loginWithPassword };
 export default compose(
   connect(mapStateToProps, mapDispatchToProps),
+  withRouter,
   injectIntl
 )(ActivateScreen);


### PR DESCRIPTION
This bug was probably introduced when upgrading to React Router v6. `ActivationScreen` needs to be wrapped in the `withRouter` HOC in order to access URL parameters.

Closes #2505