### PR TITLE
Handle table rows with incorrect number of columns

### DIFF
--- a/ui/src/viewers/TableViewer.jsx
+++ b/ui/src/viewers/TableViewer.jsx
@@ -30,10 +30,14 @@ class TableViewer extends Component {
   }
 
   renderCell(rowIndex, colIndex) {
-    const row = this.props.rows[rowIndex];
+    const { rows } = this.props;
+
+    const row = rows[rowIndex];
     const value = row ? row[colIndex] : undefined;
+    const loading = rowIndex >= rows.length;
+
     return (
-      <Cell loading={value === undefined}>
+      <Cell loading={loading}>
         <TruncatedFormat detectTruncation>{value || ''}</TruncatedFormat>
       </Cell>
     );


### PR DESCRIPTION
**This PR is based on https://github.com/alephdata/aleph/pull/2478 as it includes changes to components in react-ftm. Merge https://github.com/alephdata/aleph/pull/2478 first, then change the PR target to develop.**

***

When ingesting CSV files (and probably also other tabular file formats), the resulting CSV file that’s stored in the archive contains a new line file ending.

When we request and parse the CSV file in the frontend, the CSV parser we use emits only a single empty cell for the last row. When we were trying to render other cells in that row, the cell value would always be "undefined" and a skeleton loader would be displayed indefinitely.

Instead, we now compare the number of rows that have been already loaded with the row index of the cell to be rendered.

Closes #2377 