### PR TITLE
Prevent unbreakable title from causing overflow

### DIFF
--- a/ui/src/components/common/ItemOverview.scss
+++ b/ui/src/components/common/ItemOverview.scss
@@ -27,7 +27,7 @@
     &__subtitle,
     &__description {
       margin: 10px 0;
-      overflow-wrap: break-word;
+      overflow-wrap: anywhere;
     }
 
     &__title {


### PR DESCRIPTION
**This PR is based on https://github.com/alephdata/aleph/pull/2478 as it includes changes to components in react-ftm. Merge https://github.com/alephdata/aleph/pull/2478 first, then change the PR target to develop.**

***

`overflow-wrap: break-word` does break words if text is otherwise unbreakable, but those soft-break opportunities are not considered when calculating the intrinsic size of elements. If the title contains block/inline-block elements (e.g. the Transliterate component) this can result in overflows.

Using `overflow-wrap: anywhere` instead solves the issue. Fixes #2554.