### PR TITLE
Bookmarks MVP

### DIFF
--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -202,6 +202,12 @@ class Settings:
         self.XREF_MODEL = env.get("FTM_COMPARE_MODEL", None)
 
         ###############################################################################
+        # Feature flags
+        self.ENABLE_EXPERIMENTAL_BOOKMARKS_FEATURE = env.get(
+            "ALEPH_ENABLE_EXPERIMENTAL_BOOKMARKS_FEATURE", False
+        )
+
+        ###############################################################################
         # Additional configurations
         string_prefix = env.get("ALEPH_STRING_CONFIG_PREFIX")
         json_prefix = env.get("ALEPH_JSON_CONFIG_PREFIX")

--- a/aleph/validation/spec.py
+++ b/aleph/validation/spec.py
@@ -127,4 +127,9 @@ spec_tags = [
         "name": "System",
         "x-displayName": "System-wide API",
     },
+    {
+        "description": "Create and manage bookmarks",
+        "name": "Bookmarks",
+        "x-displayName": "Bookmarks API",
+    },
 ]

--- a/aleph/views/__init__.py
+++ b/aleph/views/__init__.py
@@ -18,6 +18,7 @@ from aleph.views.status_api import blueprint as status_api
 from aleph.views.mappings_api import blueprint as mappings_api
 from aleph.views.entitysets_api import blueprint as entitysets_api
 from aleph.views.exports_api import blueprint as exports_api
+from aleph.views.bookmarks_api import blueprint as bookmarks_api
 
 
 def mount_app_blueprints(app):
@@ -41,3 +42,4 @@ def mount_app_blueprints(app):
     app.register_blueprint(mappings_api, url_prefix="/api/2/collections")
     app.register_blueprint(entitysets_api)
     app.register_blueprint(exports_api)
+    app.register_blueprint(bookmarks_api)

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -7,6 +7,7 @@ from elasticsearch import TransportError
 from followthemoney import model
 from followthemoney.exc import InvalidData
 from jwt import ExpiredSignatureError, DecodeError
+from banal import as_bool
 
 from aleph import __version__
 from aleph.core import url_for, cache, archive
@@ -65,6 +66,9 @@ def _metadata_locale(locale):
         "model": model.to_dict(),
         "token": None,
         "auth": auth,
+        "feature_flags": {
+            "bookmarks": as_bool(SETTINGS.ENABLE_EXPERIMENTAL_BOOKMARKS_FEATURE),
+        },
     }
 
 

--- a/aleph/views/bookmarks_api.py
+++ b/aleph/views/bookmarks_api.py
@@ -1,0 +1,51 @@
+import logging
+from flask import Blueprint, request
+from aleph.views.util import jsonify, require
+
+
+log = logging.getLogger(__name__)
+blueprint = Blueprint("bookmarks_api", __name__)
+
+
+@blueprint.route("/api/2/bookmarks", methods=["POST"])
+def create():
+    """Creates a new bookmark for the user. This is currently a stub endpoint,
+    as the current version of the bookmarks features stores bookmarks client side.
+    ---
+    post:
+      summary: Create bookmark
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: OK
+      tags:
+        - Bookmarks
+    """
+    require(request.authz.logged_in)
+    log.info("User [%s]: Created bookmark", request.authz.role.id)
+    return jsonify({}, 200)
+
+
+@blueprint.route("/api/2/bookmarks/<bookmark_id>", methods=["DELETE"])
+def delete(bookmark_id):
+    """Delete a bookmark. This is currently a stub endpoint, as the current version
+    of the bookmarks features stores bookmarks client side.
+    ---
+    delete:
+      summary: Delete bookmark
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: object
+          description: OK
+      tags:
+        - Bookmarks
+    """
+    require(request.authz.logged_in)
+    log.info("User [%s]: Deleted bookmark", request.authz.role.id)
+    return jsonify({}, 200)

--- a/ui/src/actions/bookmarkActions.js
+++ b/ui/src/actions/bookmarkActions.js
@@ -1,0 +1,9 @@
+import asyncActionCreator from './asyncActionCreator';
+
+export const createBookmark = asyncActionCreator((id) => async () => id, {
+  name: 'CREATE_BOOKMARK',
+});
+
+export const deleteBookmark = asyncActionCreator((id) => async () => id, {
+  name: 'DELETE_BOOKMARK',
+});

--- a/ui/src/actions/bookmarkActions.js
+++ b/ui/src/actions/bookmarkActions.js
@@ -1,15 +1,18 @@
+import { endpoint } from 'app/api';
 import asyncActionCreator from './asyncActionCreator';
 
 export const createBookmark = asyncActionCreator(
-  (entity) => async () => entity,
-  {
-    name: 'CREATE_BOOKMARK',
-  }
+  (entity) => async () => {
+    await endpoint.post('bookmarks');
+    return entity;
+  },
+  { name: 'CREATE_BOOKMARK' }
 );
 
 export const deleteBookmark = asyncActionCreator(
-  (entity) => async () => entity,
-  {
-    name: 'DELETE_BOOKMARK',
-  }
+  (entity) => async () => {
+    await endpoint.delete('bookmarks/123');
+    return entity;
+  },
+  { name: 'DELETE_BOOKMARK' }
 );

--- a/ui/src/actions/bookmarkActions.js
+++ b/ui/src/actions/bookmarkActions.js
@@ -1,9 +1,15 @@
 import asyncActionCreator from './asyncActionCreator';
 
-export const createBookmark = asyncActionCreator((id) => async () => id, {
-  name: 'CREATE_BOOKMARK',
-});
+export const createBookmark = asyncActionCreator(
+  (entity) => async () => entity,
+  {
+    name: 'CREATE_BOOKMARK',
+  }
+);
 
-export const deleteBookmark = asyncActionCreator((id) => async () => id, {
-  name: 'DELETE_BOOKMARK',
-});
+export const deleteBookmark = asyncActionCreator(
+  (entity) => async () => entity,
+  {
+    name: 'DELETE_BOOKMARK',
+  }
+);

--- a/ui/src/actions/index.js
+++ b/ui/src/actions/index.js
@@ -66,6 +66,7 @@ export {
 } from './metadataActions';
 export { loginWithToken, loginWithPassword, logout } from './sessionActions';
 export { fetchExports, triggerQueryExport } from './exportActions';
+export { createBookmark, deleteBookmark } from './bookmarkActions';
 
 export { createAction };
 export const setLocale = createAction('SET_LOCALE');

--- a/ui/src/app/store.js
+++ b/ui/src/app/store.js
@@ -21,13 +21,15 @@ const store = createStore(
 
 store.subscribe(
   throttle(() => {
-    const state = store.getState();
+    const { session, config, messages, bookmarks } = store.getState();
+
     saveState({
-      session: state.session,
-      config: state.config,
+      session,
+      config,
+      bookmarks,
 
       // Do not persist the actual messages, only the dismissed message IDs.
-      messages: { ...state.messages, messages: [] },
+      messages: { ...messages, messages: [] },
     });
   })
 );

--- a/ui/src/components/Entity/EntityToolbar.jsx
+++ b/ui/src/components/Entity/EntityToolbar.jsx
@@ -37,7 +37,7 @@ class EntityToolbar extends React.Component {
             </Link>
           )}
           {showDownloadButton && <DownloadButton document={entity} />}
-          <BookmarkButton entityId={entity.id} />
+          <BookmarkButton entity={entity} />
         </ButtonGroup>
       </div>
     );

--- a/ui/src/components/Entity/EntityToolbar.jsx
+++ b/ui/src/components/Entity/EntityToolbar.jsx
@@ -4,6 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { ButtonGroup, Classes, Icon } from '@blueprintjs/core';
 import c from 'classnames';
 
+import { BookmarkButton } from 'components/common';
 import { DownloadButton } from 'components/Toolbar';
 import getEntityLink from 'util/getEntityLink';
 
@@ -36,6 +37,7 @@ class EntityToolbar extends React.Component {
             </Link>
           )}
           {showDownloadButton && <DownloadButton document={entity} />}
+          <BookmarkButton entityId={entity.id} />
         </ButtonGroup>
       </div>
     );

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -204,7 +204,12 @@ export class Navbar extends React.Component {
                   )}
                   <DialogToggleButton
                     buttonProps={{
-                      text: 'Bookmarks',
+                      text: (
+                        <FormattedMessage
+                          id="nav.bookmarks"
+                          defaultMessage="Bookmarks"
+                        />
+                      ),
                       icon: 'star',
                       minimal: true,
                     }}

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -202,19 +202,21 @@ export class Navbar extends React.Component {
                       />
                     </LinkButton>
                   )}
-                  <DialogToggleButton
-                    buttonProps={{
-                      text: (
-                        <FormattedMessage
-                          id="nav.bookmarks"
-                          defaultMessage="Bookmarks"
-                        />
-                      ),
-                      icon: 'star',
-                      minimal: true,
-                    }}
-                    Dialog={BookmarksDrawer}
-                  />
+                  {session.loggedIn && (
+                    <DialogToggleButton
+                      buttonProps={{
+                        text: (
+                          <FormattedMessage
+                            id="nav.bookmarks"
+                            defaultMessage="Bookmarks"
+                          />
+                        ),
+                        icon: 'star',
+                        minimal: true,
+                      }}
+                      Dialog={BookmarksDrawer}
+                    />
+                  )}
                   {menuPages.map((page) => (
                     <LinkButton
                       key={page.name}

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -20,6 +20,7 @@ import {
   selectSession,
   selectPages,
   selectEntitiesResult,
+  selectExperimentalBookmarksFeatureEnabled,
 } from 'selectors';
 import SearchAlert from 'components/SearchAlert/SearchAlert';
 import { DialogToggleButton } from 'components/Toolbar';
@@ -88,8 +89,16 @@ export class Navbar extends React.Component {
   }
 
   render() {
-    const { metadata, pages, session, query, result, isHomepage, intl } =
-      this.props;
+    const {
+      metadata,
+      pages,
+      session,
+      query,
+      result,
+      isHomepage,
+      bookmarksEnabled,
+      intl,
+    } = this.props;
     const { advancedSearchOpen, mobileSearchOpen } = this.state;
 
     const queryText = query?.getString('q');
@@ -202,7 +211,7 @@ export class Navbar extends React.Component {
                       />
                     </LinkButton>
                   )}
-                  {session.loggedIn && (
+                  {bookmarksEnabled && (
                     <DialogToggleButton
                       buttonProps={{
                         text: (
@@ -269,6 +278,7 @@ const mapStateToProps = (state, ownProps) => {
     metadata: selectMetadata(state),
     session: selectSession(state),
     pages: selectPages(state),
+    bookmarksEnabled: selectExperimentalBookmarksFeatureEnabled(state),
   };
 };
 

--- a/ui/src/components/Navbar/Navbar.jsx
+++ b/ui/src/components/Navbar/Navbar.jsx
@@ -22,7 +22,13 @@ import {
   selectEntitiesResult,
 } from 'selectors';
 import SearchAlert from 'components/SearchAlert/SearchAlert';
-import { HotkeysContainer, SearchBox, LinkButton } from 'components/common';
+import { DialogToggleButton } from 'components/Toolbar';
+import {
+  HotkeysContainer,
+  SearchBox,
+  LinkButton,
+  BookmarksDrawer,
+} from 'components/common';
 import getPageLink from 'util/getPageLink';
 import { entitiesQuery } from 'queries';
 
@@ -196,6 +202,14 @@ export class Navbar extends React.Component {
                       />
                     </LinkButton>
                   )}
+                  <DialogToggleButton
+                    buttonProps={{
+                      text: 'Bookmarks',
+                      icon: 'star',
+                      minimal: true,
+                    }}
+                    Dialog={BookmarksDrawer}
+                  />
                   {menuPages.map((page) => (
                     <LinkButton
                       key={page.name}

--- a/ui/src/components/common/BookmarkButton.tsx
+++ b/ui/src/components/common/BookmarkButton.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { injectIntl } from 'react-intl';
+import { injectIntl, FormattedMessage } from 'react-intl';
 import { Button, ButtonProps } from '@blueprintjs/core';
 import { Entity } from '@alephdata/followthemoney';
 
@@ -23,7 +23,11 @@ const BookmarkButton: FC<BookmarkButtonProps> = ({
   ...props
 }) => {
   const icon = bookmarked ? 'star' : 'star-empty';
-  const label = bookmarked ? 'Bookmarked' : 'Bookmark';
+  const label = bookmarked ? (
+    <FormattedMessage id="bookmarks.bookmarked" defaultMessage="Bookmarked" />
+  ) : (
+    <FormattedMessage id="bookmarks.bookmark" defaultMessage="Bookmark" />
+  );
 
   const toggle = async () => {
     const action = bookmarked ? deleteBookmark : createBookmark;

--- a/ui/src/components/common/BookmarkButton.tsx
+++ b/ui/src/components/common/BookmarkButton.tsx
@@ -5,23 +5,32 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 import { Button, ButtonProps } from '@blueprintjs/core';
 import { Entity } from '@alephdata/followthemoney';
 
-import { selectEntityBookmarked } from 'selectors';
+import { selectEntityBookmarked, selectSession } from 'selectors';
 import { createBookmark, deleteBookmark } from 'actions/bookmarkActions';
 
 type BookmarkButtonProps = ButtonProps & {
   bookmarked: boolean;
+  entity: Entity;
+  session: {
+    loggedIn?: boolean;
+    [key: string]: unknown;
+  };
   createBookmark: (entity: Entity) => Promise<any>;
   deleteBookmark: (entity: Entity) => Promise<any>;
-  entity: Entity;
 };
 
 const BookmarkButton: FC<BookmarkButtonProps> = ({
   entity,
   bookmarked,
+  session,
   createBookmark,
   deleteBookmark,
   ...props
 }) => {
+  if (!session.loggedIn) {
+    return null;
+  }
+
   const icon = bookmarked ? 'star' : 'star-empty';
   const label = bookmarked ? (
     <FormattedMessage id="bookmarks.bookmarked" defaultMessage="Bookmarked" />
@@ -44,11 +53,11 @@ const BookmarkButton: FC<BookmarkButtonProps> = ({
 const mapStateToProps = (state: any, ownProps: BookmarkButtonProps) => {
   const { entity } = ownProps;
   const bookmarked = selectEntityBookmarked(state, entity);
+  const session = selectSession(state);
 
   return {
     bookmarked,
-    createBookmark,
-    deleteBookmark,
+    session,
   };
 };
 

--- a/ui/src/components/common/BookmarkButton.tsx
+++ b/ui/src/components/common/BookmarkButton.tsx
@@ -3,19 +3,20 @@ import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { injectIntl } from 'react-intl';
 import { Button, ButtonProps } from '@blueprintjs/core';
+import { Entity } from '@alephdata/followthemoney';
 
 import { selectEntityBookmarked } from 'selectors';
 import { createBookmark, deleteBookmark } from 'actions/bookmarkActions';
 
 type BookmarkButtonProps = ButtonProps & {
   bookmarked: boolean;
-  createBookmark: (entityId: string) => Promise<any>;
-  deleteBookmark: (entityId: string) => Promise<any>;
-  entityId: string;
+  createBookmark: (entity: Entity) => Promise<any>;
+  deleteBookmark: (entity: Entity) => Promise<any>;
+  entity: Entity;
 };
 
 const BookmarkButton: FC<BookmarkButtonProps> = ({
-  entityId,
+  entity,
   bookmarked,
   createBookmark,
   deleteBookmark,
@@ -26,7 +27,7 @@ const BookmarkButton: FC<BookmarkButtonProps> = ({
 
   const toggle = async () => {
     const action = bookmarked ? deleteBookmark : createBookmark;
-    await action(entityId);
+    await action(entity);
   };
 
   return (
@@ -37,8 +38,8 @@ const BookmarkButton: FC<BookmarkButtonProps> = ({
 };
 
 const mapStateToProps = (state: any, ownProps: BookmarkButtonProps) => {
-  const { entityId } = ownProps;
-  const bookmarked = selectEntityBookmarked(state, entityId);
+  const { entity } = ownProps;
+  const bookmarked = selectEntityBookmarked(state, entity);
 
   return {
     bookmarked,

--- a/ui/src/components/common/BookmarkButton.tsx
+++ b/ui/src/components/common/BookmarkButton.tsx
@@ -1,0 +1,53 @@
+import { FC } from 'react';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
+import { Button, ButtonProps } from '@blueprintjs/core';
+
+import { selectEntityBookmarked } from 'selectors';
+import { createBookmark, deleteBookmark } from 'actions/bookmarkActions';
+
+type BookmarkButtonProps = ButtonProps & {
+  bookmarked: boolean;
+  createBookmark: (entityId: string) => Promise<any>;
+  deleteBookmark: (entityId: string) => Promise<any>;
+  entityId: string;
+};
+
+const BookmarkButton: FC<BookmarkButtonProps> = ({
+  entityId,
+  bookmarked,
+  createBookmark,
+  deleteBookmark,
+  ...props
+}) => {
+  const icon = bookmarked ? 'star' : 'star-empty';
+  const label = bookmarked ? 'Remove bookmark' : 'Bookmark';
+
+  const toggle = async () => {
+    const action = bookmarked ? deleteBookmark : createBookmark;
+    await action(entityId);
+  };
+
+  return (
+    <Button icon={icon} onClick={toggle} {...props}>
+      {label}
+    </Button>
+  );
+};
+
+const mapStateToProps = (state: any, ownProps: BookmarkButtonProps) => {
+  const { entityId } = ownProps;
+  const bookmarked = selectEntityBookmarked(state, entityId);
+
+  return {
+    bookmarked,
+    createBookmark,
+    deleteBookmark,
+  };
+};
+
+export default compose(
+  connect(mapStateToProps, { createBookmark, deleteBookmark }),
+  injectIntl
+)(BookmarkButton);

--- a/ui/src/components/common/BookmarkButton.tsx
+++ b/ui/src/components/common/BookmarkButton.tsx
@@ -5,16 +5,16 @@ import { injectIntl, FormattedMessage } from 'react-intl';
 import { Button, ButtonProps } from '@blueprintjs/core';
 import { Entity } from '@alephdata/followthemoney';
 
-import { selectEntityBookmarked, selectSession } from 'selectors';
+import {
+  selectEntityBookmarked,
+  selectExperimentalBookmarksFeatureEnabled,
+} from 'selectors';
 import { createBookmark, deleteBookmark } from 'actions/bookmarkActions';
 
 type BookmarkButtonProps = ButtonProps & {
   bookmarked: boolean;
   entity: Entity;
-  session: {
-    loggedIn?: boolean;
-    [key: string]: unknown;
-  };
+  enabled: boolean;
   createBookmark: (entity: Entity) => Promise<any>;
   deleteBookmark: (entity: Entity) => Promise<any>;
 };
@@ -22,12 +22,12 @@ type BookmarkButtonProps = ButtonProps & {
 const BookmarkButton: FC<BookmarkButtonProps> = ({
   entity,
   bookmarked,
-  session,
+  enabled,
   createBookmark,
   deleteBookmark,
   ...props
 }) => {
-  if (!session.loggedIn) {
+  if (!enabled) {
     return null;
   }
 
@@ -53,11 +53,11 @@ const BookmarkButton: FC<BookmarkButtonProps> = ({
 const mapStateToProps = (state: any, ownProps: BookmarkButtonProps) => {
   const { entity } = ownProps;
   const bookmarked = selectEntityBookmarked(state, entity);
-  const session = selectSession(state);
+  const enabled = selectExperimentalBookmarksFeatureEnabled(state);
 
   return {
     bookmarked,
-    session,
+    enabled,
   };
 };
 

--- a/ui/src/components/common/BookmarkButton.tsx
+++ b/ui/src/components/common/BookmarkButton.tsx
@@ -23,7 +23,7 @@ const BookmarkButton: FC<BookmarkButtonProps> = ({
   ...props
 }) => {
   const icon = bookmarked ? 'star' : 'star-empty';
-  const label = bookmarked ? 'Remove bookmark' : 'Bookmark';
+  const label = bookmarked ? 'Bookmarked' : 'Bookmark';
 
   const toggle = async () => {
     const action = bookmarked ? deleteBookmark : createBookmark;

--- a/ui/src/components/common/BookmarksDrawer.scss
+++ b/ui/src/components/common/BookmarksDrawer.scss
@@ -1,0 +1,5 @@
+@import 'app/variables.scss';
+
+.BookmarksDrawer__content {
+  padding: 2 * $aleph-grid-size;
+}

--- a/ui/src/components/common/BookmarksDrawer.scss
+++ b/ui/src/components/common/BookmarksDrawer.scss
@@ -3,3 +3,7 @@
 .BookmarksDrawer__content {
   padding: 2 * $aleph-grid-size;
 }
+
+.BookmarksDrawer__content > * + * {
+  margin-top: 2 * $aleph-grid-size;
+}

--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -1,8 +1,14 @@
 import { FC } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { FormattedMessage, injectIntl } from 'react-intl';
-import { Drawer, DrawerSize } from '@blueprintjs/core';
+import downloadFile from 'js-file-download';
+import {
+  FormattedMessage,
+  injectIntl,
+  useIntl,
+  defineMessage,
+} from 'react-intl';
+import { Button, Drawer, DrawerSize } from '@blueprintjs/core';
 
 import { selectBookmarks } from 'selectors';
 import BookmarksList from './BookmarksList';
@@ -19,6 +25,45 @@ type BookmarksDrawerProps = {
   isOpen: boolean;
   toggleDialog: () => void;
   bookmarks: Array<Bookmark>;
+};
+
+type DownloadButtonProps = Button['props'] & {
+  bookmarks: Array<Bookmark>;
+};
+
+const downloadHeading = defineMessage({
+  id: 'bookmarks.download.heading',
+  defaultMessage: 'Your bookmarks',
+});
+
+const DownloadButton: FC<DownloadButtonProps> = ({
+  bookmarks,
+  ...buttonProps
+}) => {
+  const { formatDate, formatTime, formatMessage } = useIntl();
+
+  const download = () => {
+    const items = bookmarks.map(({ caption, bookmarkedAt, id }) =>
+      [
+        caption,
+        `${formatDate(bookmarkedAt)} ${formatTime(bookmarkedAt)}`,
+        new URL(`/entities/${id}`, window.location.href),
+      ].join('\n')
+    );
+
+    const heading = formatMessage(downloadHeading).toUpperCase();
+    const contents = `${heading}\n\n${items.join('\n\n')}`;
+    downloadFile(contents, 'bookmarks.txt');
+  };
+
+  return (
+    <Button onClick={download} {...buttonProps}>
+      <FormattedMessage
+        id="bookmarks.download"
+        defaultMessage="Download your bookmarks"
+      />
+    </Button>
+  );
 };
 
 const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
@@ -53,6 +98,7 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
             />
           </p>
         )}
+        <DownloadButton icon="archive" bookmarks={bookmarks} />
       </div>
     </Drawer>
   );

--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -37,7 +37,9 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
       canOutsideClickClose={true}
     >
       <div className="BookmarksDrawer__content">
-        {bookmarks.length > 0 && <BookmarksList bookmarks={bookmarks} />}
+        {bookmarks.length > 0 && (
+          <BookmarksList bookmarks={bookmarks} onNavigate={toggleDialog} />
+        )}
 
         {bookmarks.length <= 0 && (
           <p>

--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -1,0 +1,50 @@
+import { FC } from 'react';
+import { compose } from 'redux';
+import { connect } from 'react-redux';
+import { injectIntl } from 'react-intl';
+import { Drawer, DrawerSize } from '@blueprintjs/core';
+
+import { selectBookmarks } from 'selectors';
+import BookmarksList from './BookmarksList';
+
+import './BookmarksDrawer.scss';
+
+type Bookmark = {
+  id: string;
+  caption: string;
+  bookmarkedAt: number;
+};
+
+type BookmarksDrawerProps = {
+  isOpen: boolean;
+  toggleDialog: () => void;
+  bookmarks: Array<Bookmark>;
+};
+
+const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
+  isOpen,
+  toggleDialog,
+  bookmarks,
+}) => {
+  return (
+    <Drawer
+      className="BookmarksDrawer"
+      title="Your Bookmarks"
+      size={DrawerSize.SMALL}
+      onClose={toggleDialog}
+      isOpen={isOpen}
+      hasBackdrop={false}
+      canOutsideClickClose={true}
+    >
+      <div className="BookmarksDrawer__content">
+        <BookmarksList bookmarks={bookmarks} />
+      </div>
+    </Drawer>
+  );
+};
+
+const mapStateToProps = (state: any) => {
+  return { bookmarks: selectBookmarks(state) };
+};
+
+export default compose(connect(mapStateToProps), injectIntl)(BookmarksDrawer);

--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -37,7 +37,14 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
       canOutsideClickClose={true}
     >
       <div className="BookmarksDrawer__content">
-        <BookmarksList bookmarks={bookmarks} />
+        {bookmarks.length > 0 && <BookmarksList bookmarks={bookmarks} />}
+
+        {bookmarks.length <= 0 && (
+          <p>
+            You haven’t bookmarked anything yet. Add any entity to your
+            bookmarks to get started.
+          </p>
+        )}
       </div>
     </Drawer>
   );

--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { injectIntl } from 'react-intl';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import { Drawer, DrawerSize } from '@blueprintjs/core';
 
 import { selectBookmarks } from 'selectors';
@@ -26,10 +26,14 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
   toggleDialog,
   bookmarks,
 }) => {
+  const title = (
+    <FormattedMessage id="bookmarks.title" defaultMessage="Your bookmarks" />
+  );
+
   return (
     <Drawer
       className="BookmarksDrawer"
-      title="Your Bookmarks"
+      title={title}
       size={DrawerSize.SMALL}
       onClose={toggleDialog}
       isOpen={isOpen}
@@ -43,8 +47,10 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
 
         {bookmarks.length <= 0 && (
           <p>
-            You haven’t bookmarked anything yet. Add any entity to your
-            bookmarks to get started.
+            <FormattedMessage
+              id="bookmarks.empty"
+              defaultMessage="You haven’t bookmarked anything yet. Add any entity to your bookmarks to get started."
+            />
           </p>
         )}
       </div>

--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -8,7 +8,7 @@ import {
   useIntl,
   defineMessage,
 } from 'react-intl';
-import { Button, Drawer, DrawerSize } from '@blueprintjs/core';
+import { Button, Drawer, DrawerSize, Callout, Intent } from '@blueprintjs/core';
 
 import { selectBookmarks } from 'selectors';
 import BookmarksList from './BookmarksList';
@@ -60,7 +60,7 @@ const DownloadButton: FC<DownloadButtonProps> = ({
     <Button onClick={download} {...buttonProps}>
       <FormattedMessage
         id="bookmarks.download"
-        defaultMessage="Download your bookmarks"
+        defaultMessage="Download bookmarks"
       />
     </Button>
   );
@@ -86,19 +86,38 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
       canOutsideClickClose={true}
     >
       <div className="BookmarksDrawer__content">
+        <Callout intent={Intent.WARNING} icon={null}>
+          <p>
+            <strong>
+              <FormattedMessage
+                id="bookmarks.warning.heading"
+                defaultMessage="Bookmarks are an experimental feature."
+              />
+            </strong>
+          </p>
+          <p>
+            <FormattedMessage
+              id="bookmarks.warning.text"
+              defaultMessage="Your bookmarks don’t sync to other devices and we may remove this feature in the future. You can download your bookmarks at any time:"
+            />
+          </p>
+        </Callout>
+
         {bookmarks.length > 0 && (
-          <BookmarksList bookmarks={bookmarks} onNavigate={toggleDialog} />
+          <>
+            <DownloadButton icon="archive" fill bookmarks={bookmarks} />
+            <BookmarksList bookmarks={bookmarks} onNavigate={toggleDialog} />
+          </>
         )}
 
         {bookmarks.length <= 0 && (
-          <p>
+          <Callout intent={Intent.PRIMARY} icon={null}>
             <FormattedMessage
               id="bookmarks.empty"
-              defaultMessage="You haven’t bookmarked anything yet. Add any entity to your bookmarks to get started."
+              defaultMessage="You haven’t bookmarked anything yet. Add documents or entities such as people or companies to your bookmarks to easily get back to them later."
             />
-          </p>
+          </Callout>
         )}
-        <DownloadButton icon="archive" bookmarks={bookmarks} />
       </div>
     </Drawer>
   );

--- a/ui/src/components/common/BookmarksList.scss
+++ b/ui/src/components/common/BookmarksList.scss
@@ -7,7 +7,7 @@
 }
 
 .BookmarksList > li + li {
-  margin-top: 2 * $aleph-grid-size;
+  margin-top: $aleph-grid-size;
 }
 
 .BookmarksList__caption {

--- a/ui/src/components/common/BookmarksList.scss
+++ b/ui/src/components/common/BookmarksList.scss
@@ -1,0 +1,28 @@
+@import 'app/variables.scss';
+
+.BookmarksList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.BookmarksList > li + li {
+  margin-top: 2 * $aleph-grid-size;
+}
+
+.BookmarksList__caption {
+  display: inline-block;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-weight: bold;
+}
+
+.BookmarksList__caption:hover {
+  text-decoration: underline;
+}
+
+.BookmarksList__meta {
+  color: $aleph-greyed-text;
+}

--- a/ui/src/components/common/BookmarksList.tsx
+++ b/ui/src/components/common/BookmarksList.tsx
@@ -12,9 +12,10 @@ type Bookmark = {
 
 type BookmarksListProps = {
   bookmarks: Array<Bookmark>;
+  onNavigate: () => void;
 };
 
-const BookmarksList: FC<BookmarksListProps> = ({ bookmarks }) => {
+const BookmarksList: FC<BookmarksListProps> = ({ bookmarks, onNavigate }) => {
   return (
     <ul className="BookmarksList">
       {bookmarks.map((bookmark) => (
@@ -22,6 +23,7 @@ const BookmarksList: FC<BookmarksListProps> = ({ bookmarks }) => {
           <Link
             className="BookmarksList__caption"
             to={`/entities/${bookmark.id}`}
+            onClick={onNavigate}
           >
             {bookmark.caption}
           </Link>

--- a/ui/src/components/common/BookmarksList.tsx
+++ b/ui/src/components/common/BookmarksList.tsx
@@ -1,0 +1,41 @@
+import { FC } from 'react';
+import { Link } from 'react-router-dom';
+import RelativeTime from './RelativeTime';
+
+import './BookmarksList.scss';
+
+type Bookmark = {
+  id: string;
+  caption: string;
+  bookmarkedAt: number;
+};
+
+type BookmarksListProps = {
+  bookmarks: Array<Bookmark>;
+};
+
+const BookmarksList: FC<BookmarksListProps> = ({ bookmarks }) => {
+  return (
+    <ul className="BookmarksList">
+      {bookmarks.map((bookmark) => (
+        <li key={bookmark.id}>
+          <Link
+            className="BookmarksList__caption"
+            to={`/entities/${bookmark.id}`}
+          >
+            {bookmark.caption}
+          </Link>
+          <div className="BookmarksList__meta">
+            {'bookmarked '}
+            <RelativeTime
+              date={new Date(bookmark.bookmarkedAt)}
+              utcDate={null}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default BookmarksList;

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -1,5 +1,6 @@
 import AnimatedCount from './AnimatedCount';
 import BookmarkButton from './BookmarkButton';
+import BookmarksDrawer from './BookmarksDrawer';
 import Breadcrumbs from './Breadcrumbs';
 import SignInCallout from './SignInCallout';
 import ClipboardInput from './ClipboardInput';
@@ -52,6 +53,7 @@ import LinkButton from './LinkButton';
 export {
   AnimatedCount,
   BookmarkButton,
+  BookmarksDrawer,
   Breadcrumbs,
   SignInCallout,
   ClipboardInput,

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -1,4 +1,5 @@
 import AnimatedCount from './AnimatedCount';
+import BookmarkButton from './BookmarkButton';
 import Breadcrumbs from './Breadcrumbs';
 import SignInCallout from './SignInCallout';
 import ClipboardInput from './ClipboardInput';
@@ -50,6 +51,7 @@ import LinkButton from './LinkButton';
 
 export {
   AnimatedCount,
+  BookmarkButton,
   Breadcrumbs,
   SignInCallout,
   ClipboardInput,

--- a/ui/src/reducers/bookmarks.js
+++ b/ui/src/reducers/bookmarks.js
@@ -1,0 +1,34 @@
+import { createReducer } from 'redux-act';
+
+import { createBookmark, deleteBookmark } from 'actions';
+
+const initialState = {
+  entities: [],
+};
+
+export default createReducer(
+  {
+    [createBookmark.COMPLETE]: (state, entityId) => {
+      if (state.entities.includes(entityId)) {
+        return state;
+      }
+
+      return {
+        ...state,
+        entities: [...state.entities, entityId],
+      };
+    },
+
+    [deleteBookmark.COMPLETE]: (state, entityId) => {
+      if (!state.entities.includes(entityId)) {
+        return state;
+      }
+
+      return {
+        ...state,
+        entities: state.entities.filter((id) => id !== entityId),
+      };
+    },
+  },
+  initialState
+);

--- a/ui/src/reducers/bookmarks.js
+++ b/ui/src/reducers/bookmarks.js
@@ -1,33 +1,34 @@
 import { createReducer } from 'redux-act';
 
+import timestamp from 'util/timestamp';
 import { createBookmark, deleteBookmark } from 'actions';
 
-const initialState = {
-  entities: [],
-};
+const initialState = [];
 
 export default createReducer(
   {
-    [createBookmark.COMPLETE]: (state, entityId) => {
-      if (state.entities.includes(entityId)) {
+    [createBookmark.COMPLETE]: (state, entity) => {
+      if (state.find(({ id }) => id === entity.id)) {
         return state;
       }
 
-      return {
+      return [
         ...state,
-        entities: [...state.entities, entityId],
-      };
+        {
+          id: entity.id,
+          bookmarkedAt: timestamp(),
+          caption: entity.getCaption(),
+          collection: {
+            id: entity.collection.id,
+            label: entity.collection.label,
+            category: entity.collection.category,
+          },
+        },
+      ];
     },
 
-    [deleteBookmark.COMPLETE]: (state, entityId) => {
-      if (!state.entities.includes(entityId)) {
-        return state;
-      }
-
-      return {
-        ...state,
-        entities: state.entities.filter((id) => id !== entityId),
-      };
+    [deleteBookmark.COMPLETE]: (state, entity) => {
+      return state.filter(({ id }) => id !== entity.id);
     },
   },
   initialState

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -19,6 +19,7 @@ import roles from './roles';
 import notifications from './notifications';
 import systemStatus from './systemStatus';
 import exports from './exports';
+import bookmarks from './bookmarks';
 
 const rootReducer = combineReducers({
   messages,
@@ -40,6 +41,7 @@ const rootReducer = combineReducers({
   results,
   systemStatus,
   exports,
+  bookmarks,
 });
 
 export default rootReducer;

--- a/ui/src/screens/EntityScreen/EntityScreen.jsx
+++ b/ui/src/screens/EntityScreen/EntityScreen.jsx
@@ -17,7 +17,12 @@ import ErrorScreen from 'components/Screen/ErrorScreen';
 import EntitySetSelector from 'components/EntitySet/EntitySetSelector';
 import CollectionWrapper from 'components/Collection/CollectionWrapper';
 import ProfileCallout from 'components/Profile/ProfileCallout';
-import { Breadcrumbs, DualPane, Schema } from 'components/common';
+import {
+  BookmarkButton,
+  Breadcrumbs,
+  DualPane,
+  Schema,
+} from 'components/common';
 import { DialogToggleButton } from 'components/Toolbar';
 import { DownloadButton } from 'components/Toolbar';
 import { deleteEntity } from 'actions';
@@ -101,6 +106,7 @@ class EntityScreen extends Component {
 
     const operation = (
       <ButtonGroup>
+        <BookmarkButton entityId={entityId} />
         <DownloadButton document={entity} />
         {entity?.collection?.writeable && (
           <>

--- a/ui/src/screens/EntityScreen/EntityScreen.jsx
+++ b/ui/src/screens/EntityScreen/EntityScreen.jsx
@@ -106,7 +106,7 @@ class EntityScreen extends Component {
 
     const operation = (
       <ButtonGroup>
-        <BookmarkButton entityId={entityId} />
+        <BookmarkButton entity={entity} />
         <DownloadButton document={entity} />
         {entity?.collection?.writeable && (
           <>

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -441,3 +441,12 @@ export function selectQueryLogsLimited(state, limit = 9) {
     results,
   };
 }
+
+export function selectBookmarks(state) {
+  return selectObject(state, state, 'bookmarks');
+}
+
+export function selectEntityBookmarked(state, entityId) {
+  const { entities } = selectBookmarks(state);
+  return entities.includes(entityId);
+}

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -446,7 +446,12 @@ export function selectBookmarks(state) {
   return selectObject(state, state, 'bookmarks');
 }
 
-export function selectEntityBookmarked(state, entityId) {
-  const { entities } = selectBookmarks(state);
-  return entities.includes(entityId);
+export function selectBookmark(state, entity) {
+  const bookmarks = selectBookmarks(state);
+  return bookmarks.find(({ id }) => id === entity.id);
+}
+
+export function selectEntityBookmarked(state, entity) {
+  const bookmark = selectBookmark(state, entity);
+  return bookmark !== undefined;
 }

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -75,6 +75,17 @@ export function selectMetadata(state) {
   return metadata;
 }
 
+export function selectFeatureFlags(state) {
+  return selectMetadata(state).feature_flags;
+}
+
+export function selectExperimentalBookmarksFeatureEnabled(state) {
+  const loggedIn = !!selectSession(state).loggedIn;
+  const featureFlag = !!selectFeatureFlags(state).bookmarks;
+
+  return loggedIn && featureFlag;
+}
+
 export function selectMessages(state) {
   return selectObject(state, state, 'messages');
 }

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -443,7 +443,8 @@ export function selectQueryLogsLimited(state, limit = 9) {
 }
 
 export function selectBookmarks(state) {
-  return selectObject(state, state, 'bookmarks');
+  const bookmarks = selectObject(state, state, 'bookmarks');
+  return bookmarks.sort((a, b) => b.bookmarkedAt - a.bookmarkedAt);
 }
 
 export function selectBookmark(state, entity) {


### PR DESCRIPTION
A very simple, client-side only implementation of a bookmarks feature for Aleph. Allows users to bookmark entities and quickly view a list of all bookmarks anywhere in the app.

**To consider:**

* Bookmarks may not be a perfect/flexible-enough solution for some cases. For example, some users want to mark/tag entities as sighted so they know they don’t have to look at the entities again when it appears e.g. in the results for another search.
* Some users would like to add a list of relevant entities from *other* datasets to an investigation.
* Some users would like to add tags/bookmark entities/mark entities as sighted in a way that can be shared across everyone who works on an investigation.

**To do:**

- [x] Improve empty state wording to let users know what they can bookmark
- [x] Add feature flag/env variable to enable experimental features
- [x] Only show bookmarks if user is authenticated
- [x] Add placeholder API endpoints `POST /bookmarks`, `DELETE /bookmarks/:id` that emit logs containing the user ID.
- [x] Download/backup bookmarks as plaintext file

**Possible future improvements:**

- [ ] Add indicator in search results/entity listings ("in your bookmarks")