### PR TITLE
Dismissible message banner

### DIFF
--- a/ui/src/actions/index.js
+++ b/ui/src/actions/index.js
@@ -58,7 +58,7 @@ export {
   fetchProfileTags,
   pairwiseJudgement,
 } from './profileActions';
-export { fetchMessages } from './messagesActions';
+export { fetchMessages, dismissMessage } from './messagesActions';
 export {
   fetchMetadata,
   fetchStatistics,

--- a/ui/src/actions/messagesActions.js
+++ b/ui/src/actions/messagesActions.js
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import asyncActionCreator from 'actions/asyncActionCreator';
+import { createAction } from 'redux-act';
 
 export const fetchMessages = asyncActionCreator(
   (endpoint) => async () => {
@@ -8,3 +9,5 @@ export const fetchMessages = asyncActionCreator(
   },
   { name: 'FETCH_MESSAGES' }
 );
+
+export const dismissMessage = createAction('DISMISS_MESSAGE');

--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -3,7 +3,7 @@ import { Route, Navigate, Routes } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { Spinner } from '@blueprintjs/core';
 
-import { fetchMetadata, fetchMessages } from 'actions';
+import { fetchMetadata, fetchMessages, dismissMessage } from 'actions';
 import {
   selectSession,
   selectMetadata,
@@ -88,7 +88,7 @@ class Router extends Component {
   }
 
   render() {
-    const { metadata, session, pinnedMessage } = this.props;
+    const { metadata, session, pinnedMessage, dismissMessage } = this.props;
     const isLoaded = metadata && metadata.app && session;
 
     const Loading = (
@@ -106,7 +106,7 @@ class Router extends Component {
     return (
       <>
         <Navbar />
-        <MessageBanner message={pinnedMessage} />
+        <MessageBanner message={pinnedMessage} onDismiss={dismissMessage} />
         <Suspense fallback={Loading}>
           <Routes>
             <Route path="oauth" element={<OAuthScreen />} />
@@ -207,4 +207,5 @@ const mapStateToProps = (state) => ({
 export default connect(mapStateToProps, {
   fetchMetadata,
   fetchMessages,
+  dismissMessage,
 })(Router);

--- a/ui/src/app/store.js
+++ b/ui/src/app/store.js
@@ -25,6 +25,9 @@ store.subscribe(
     saveState({
       session: state.session,
       config: state.config,
+
+      // Do not persist the actual messages, only the dismissed message IDs.
+      messages: { ...state.messages, messages: [] },
     });
   })
 );

--- a/ui/src/components/MessageBanner/MessageBanner.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.jsx
@@ -1,5 +1,5 @@
-import { Callout, Intent, Classes } from '@blueprintjs/core';
-import { injectIntl } from 'react-intl';
+import { Callout, Intent, Classes, Button } from '@blueprintjs/core';
+import { injectIntl, FormattedMessage } from 'react-intl';
 import { RelativeTime } from 'components/common';
 
 import './MessageBanner.scss';
@@ -19,16 +19,19 @@ function Wrapper({ children }) {
   );
 }
 
-function MessageBanner({ message }) {
+function MessageBanner({ message, onDismiss }) {
   if (!message) {
     return <Wrapper />;
   }
 
   const intent = MESSAGE_INTENTS[message.level] || Intent.WARNING;
   const updates = message.updates || [];
+  const dismissible = message.dismissible || false;
 
   const latestUpdate =
     updates.length > 0 ? updates[updates.length - 1] : message;
+
+  const onDismissButtonClick = () => onDismiss(message);
 
   return (
     <Wrapper>
@@ -51,6 +54,19 @@ function MessageBanner({ message }) {
             </span>
           )}
         </p>
+        {dismissible && (
+          <Button
+            minimal
+            rightIcon="cross"
+            intent={intent}
+            onClick={onDismissButtonClick}
+          >
+            <FormattedMessage
+              id="messages.banner.dismiss"
+              defaultMessage="Dismiss"
+            />
+          </Button>
+        )}
       </Callout>
     </Wrapper>
   );

--- a/ui/src/components/MessageBanner/MessageBanner.scss
+++ b/ui/src/components/MessageBanner/MessageBanner.scss
@@ -1,11 +1,15 @@
 @import '../../app/variables.scss';
 
 .MessageBanner__callout.MessageBanner__callout {
+  display: flex;
+  align-items: center;
   padding: 0.5 * $aleph-content-padding $aleph-content-padding;
 }
 
 .MessageBanner p {
   margin: 0;
+  flex-grow: 1;
+  flex-shrink: 1;
 }
 
 .MessageBanner a,

--- a/ui/src/components/MessageBanner/MessageBanner.test.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.test.jsx
@@ -29,6 +29,7 @@ it('renders level, title, body, date', () => {
   render(<MessageBanner message={message} />);
   expect(screen.getByText('Degraded ingest performance')).toBeInTheDocument();
   expect(screen.getByText(message.safeHtmlBody)).toBeInTheDocument();
+  expect(screen.queryByRole('button')).not.toBeInTheDocument();
 });
 
 it('renders HTML body', () => {
@@ -84,4 +85,19 @@ it('renders latest update', () => {
   const { container } = render(<MessageBanner message={message} />);
   expect(screen.getByRole('status')).toHaveTextContent('We’re back online!');
   expect(getTime(container, message.createdAt));
+});
+
+it('has dismiss button', () => {
+  const onDismiss = jest.fn();
+  const message = {
+    safeHtmlBody: 'You can dismiss me!',
+    dismissible: true,
+  };
+
+  render(<MessageBanner message={message} onDismiss={onDismiss} />);
+
+  const button = screen.getByRole('button', { name: 'Dismiss' });
+  expect(button).toBeInTheDocument();
+  button.click();
+  expect(onDismiss).toHaveBeenCalledTimes(1);
 });

--- a/ui/src/reducers/messages.js
+++ b/ui/src/reducers/messages.js
@@ -1,14 +1,37 @@
 import { createReducer } from 'redux-act';
-import { fetchMessages } from 'actions';
+import { fetchMessages, dismissMessage } from 'actions';
 import { loadState, loadStart, loadError, loadComplete } from 'reducers/util';
 
-const initialState = loadState();
+// The IDs of dismissed messages are persisted in local storage. Storing only
+// the ID of the most recently dismissed message is not enough, as there could
+// be multiple messages active at the same time and users wouldn’t be able to
+// dismiss both. However, storing all the IDs a user has ever dismissed isn't
+// necessary as well.
+const DISMISSED_MESSAGES_LIMIT = 5;
+
+const initialState = loadState({
+  messages: [],
+  dismissed: [],
+});
 
 export default createReducer(
   {
     [fetchMessages.START]: (state) => loadStart(state),
     [fetchMessages.ERROR]: (state, { error }) => loadError(state, error),
-    [fetchMessages.COMPLETE]: (state, messages) => loadComplete(messages),
+    [fetchMessages.COMPLETE]: (state, messages) =>
+      loadComplete({ ...state, ...messages }),
+    [dismissMessage]: (state, message) => {
+      if (state.dismissed.includes(message.id)) {
+        return state;
+      }
+
+      const dismissed = [
+        message.id,
+        ...state.dismissed.slice(0, DISMISSED_MESSAGES_LIMIT - 1),
+      ];
+
+      return { ...state, dismissed };
+    },
   },
   initialState
 );

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -81,7 +81,7 @@ export function selectMessages(state) {
 
 export function selectPinnedMessage(state) {
   const metadata = selectMetadata(state);
-  const { messages } = selectMessages(state);
+  const { messages, dismissed } = selectMessages(state);
 
   if (metadata?.app?.banner) {
     return { body: metadata.app.banner };
@@ -91,9 +91,11 @@ export function selectPinnedMessage(state) {
     return null;
   }
 
-  const activeMessages = messages.filter(({ displayUntil }) => {
-    return !displayUntil || Date.now() <= new Date(displayUntil);
-  });
+  const activeMessages = messages
+    .filter(({ id }) => !dismissed.includes(id))
+    .filter(({ displayUntil }) => {
+      return !displayUntil || Date.now() <= new Date(displayUntil);
+    });
 
   if (activeMessages.length <= 0) {
     return null;


### PR DESCRIPTION
Currently, there’s no way to close/dismiss the message banner. This can be annoying, especially when displaying less important information for a long time, as it takes up vertical screen estate.

This adds the ability to optionally let users dismiss a message.

https://user-images.githubusercontent.com/1512805/196056539-0bc914be-a889-48e4-988c-53653044e6e1.mov

In order to implement this, the IDs of the five most recently dismissed messages are persisted in local storage. Storing all messages a user has ever dismissed is probably unnecessary and could potentially bloat the local storage.