### PR TITLE
Fix error when rendering bezier curve in network diagrams

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -28,7 +28,7 @@
         "@types/react": "^17.0.1",
         "@types/react-dom": "^17.0.1",
         "axios": "^0.27.2",
-        "bezier-js": "^4.1.1",
+        "bezier-js": "^6.1.0",
         "buffer": "^6.0.3",
         "classnames": "^2.3.2",
         "crypto": "npm:crypto-browserify@^3.12.0",
@@ -5994,9 +5994,9 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
     },
     "node_modules/bezier-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-4.1.1.tgz",
-      "integrity": "sha512-oVOS6SSFFFlfnZdzC+lsfvhs/RRcbxJ47U04M4s5QIBaJmr3YWmTIL3qmrOK9uW+nUUcl9Jccmo/xpTrG+bBoQ==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.0.tgz",
+      "integrity": "sha512-oc8fkHqG0R+dQuNiXVbPMB0cc8iDqkLAjbA2gq26QmV8tZqW9GGI7iNEX1ioRWlZperQS7v5BX03+9FLVWZbSw==",
       "funding": {
         "type": "individual",
         "url": "https://github.com/Pomax/bezierjs/blob/master/FUNDING.md"
@@ -24566,9 +24566,9 @@
       "integrity": "sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw=="
     },
     "bezier-js": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-4.1.1.tgz",
-      "integrity": "sha512-oVOS6SSFFFlfnZdzC+lsfvhs/RRcbxJ47U04M4s5QIBaJmr3YWmTIL3qmrOK9uW+nUUcl9Jccmo/xpTrG+bBoQ=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/bezier-js/-/bezier-js-6.1.0.tgz",
+      "integrity": "sha512-oc8fkHqG0R+dQuNiXVbPMB0cc8iDqkLAjbA2gq26QmV8tZqW9GGI7iNEX1ioRWlZperQS7v5BX03+9FLVWZbSw=="
     },
     "bfj": {
       "version": "7.0.2",

--- a/ui/package.json
+++ b/ui/package.json
@@ -23,7 +23,7 @@
     "@types/react": "^17.0.1",
     "@types/react-dom": "^17.0.1",
     "axios": "^0.27.2",
-    "bezier-js": "^4.1.1",
+    "bezier-js": "^6.1.0",
     "buffer": "^6.0.3",
     "classnames": "^2.3.2",
     "crypto": "npm:crypto-browserify@^3.12.0",

--- a/ui/src/bezier-js.d.ts
+++ b/ui/src/bezier-js.d.ts
@@ -1,0 +1,3 @@
+declare module 'bezier-js' {
+  export const Bezier: any;
+}

--- a/ui/src/react-ftm/components/NetworkDiagram/renderer/EdgeRenderer.tsx
+++ b/ui/src/react-ftm/components/NetworkDiagram/renderer/EdgeRenderer.tsx
@@ -6,7 +6,7 @@ import {
   Point,
 } from 'react-ftm/components/NetworkDiagram/layout';
 import { EdgeLabelRenderer } from './EdgeLabelRenderer';
-const { Bezier } = require('bezier-js');
+import { Bezier } from 'bezier-js';
 
 interface IEdgeRendererProps {
   edge: Edge;


### PR DESCRIPTION
The way we import `bezier-js` was incompatible with out build setup, resulting in `Bezier` being `undefined`. Due to this, adding a curved/bezier line in a network diagram would raise an error.

This fixes the import and also updates `bezier-js` to the latest version.

You can verify that this solves the issue by creating a curved line in a network diagram:

https://user-images.githubusercontent.com/1512805/196520937-1497275a-d814-43cf-8107-f3a576174969.mov
