### PR TITLE
Run UI and Backend jobs only when necessary

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -1,0 +1,56 @@
+name: Build UI
+
+on:
+  push:
+    paths-ignore:
+      - "aleph/**"
+      - "contrib/**"
+      - "helm/**"
+      - "mappings/**"
+      - "site/**"
+
+permissions:
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup
+        run: echo "ALEPH_SECRET=batman\n" >> aleph.env
+
+      - name: Build development image
+        run: |
+          docker build -t alephdata/aleph-ui:${GITHUB_SHA} ui
+          docker tag alephdata/aleph-ui:${GITHUB_SHA} alephdata/aleph-ui:latest
+
+      - name: Check code formatting
+        run: make format-check-ui
+
+      - name: Run linter
+        run: make lint-ui
+
+      - name: Run tests
+        run: make test-ui
+
+      - name: Build production image
+        run: docker build -t alephdata/aleph-ui-production:${GITHUB_SHA} -f ui/Dockerfile.production ui
+
+      - name: Push docker image (hash)
+        env:
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+        if: env.DOCKER_PASSWORD != null
+        run: |
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin 
+          docker push alephdata/aleph-ui-production:${GITHUB_SHA}
+
+      - name: Push docker image (tagged)
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        run: |
+          export ALEPH_TAG=${GITHUB_REF/refs\/tags\//}
+          docker tag alephdata/aleph-ui-production:${GITHUB_SHA} alephdata/aleph-ui-production:${ALEPH_TAG};
+          docker push alephdata/aleph-ui-production:${ALEPH_TAG};
+          docker tag alephdata/aleph-ui-production:${GITHUB_SHA} alephdata/aleph-ui-production:latest;
+          docker push alephdata/aleph-ui-production:latest;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,54 +1,15 @@
-name: package
+name: Build
 
-on: [push]
+on:
+  push:
+    paths-ignore:
+      - "ui/**"
 
 permissions:
   packages: write
 
 jobs:
-  ui:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup
-        run: echo "ALEPH_SECRET=batman\n" >> aleph.env
-
-      - name: Build development image
-        run: |
-          docker build -t alephdata/aleph-ui:${GITHUB_SHA} ui
-          docker tag alephdata/aleph-ui:${GITHUB_SHA} alephdata/aleph-ui:latest
-
-      - name: Check code formatting
-        run: make format-check-ui
-
-      - name: Run linter
-        run: make lint-ui
-
-      - name: Run tests
-        run: make test-ui
-
-      - name: Build production image
-        run: docker build -t alephdata/aleph-ui-production:${GITHUB_SHA} -f ui/Dockerfile.production ui
-
-      - name: Push docker image (hash)
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-        if: env.DOCKER_PASSWORD != null
-        run: |
-          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin 
-          docker push alephdata/aleph-ui-production:${GITHUB_SHA}
-
-      - name: Push docker image (tagged)
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-        run: |
-          export ALEPH_TAG=${GITHUB_REF/refs\/tags\//}
-          docker tag alephdata/aleph-ui-production:${GITHUB_SHA} alephdata/aleph-ui-production:${ALEPH_TAG};
-          docker push alephdata/aleph-ui-production:${ALEPH_TAG};
-          docker tag alephdata/aleph-ui-production:${GITHUB_SHA} alephdata/aleph-ui-production:latest;
-          docker push alephdata/aleph-ui-production:latest;
-
-  backend:
+  build:
     runs-on: ubuntu-latest
 
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ balkhashdb
 
 TODO.md
 
-build*
-
 ui/node_modules
 ui/build
 ui/i18n/messages.json


### PR DESCRIPTION
Right now, we always run the backend/UI job even if only files related to the UI/backend have changed.

This is annoying and can block work, because GitHub Actions limits the number of concurrent jobs. In some cases (e.g. after Dependabot has opened a lot of PRs) this can lead to jobs being queued for quite some time.

Limiting the number of jobs that are triggered based on the files changed can help speed up CI runs.

Closes #2485

***

This is how I tested the changes.

1. Committed and pushed a new file in `/ui`. This commit triggered only the `build-ui.yml` workflow.
   
   <img width="868" alt="Screen Shot 2022-10-18 at 23 38 09" src="https://user-images.githubusercontent.com/1512805/196549984-d046bc26-488e-45d3-a284-17ed6045d25b.png">

2. Committed and pushed a new file in `/aleph`. This commit triggered only the `build.yml` workflow.

   <img width="818" alt="Screen Shot 2022-10-18 at 23 38 40" src="https://user-images.githubusercontent.com/1512805/196550162-562432b7-3fe9-4f35-a0a2-b91466352172.png">

4. Committed and pushed a new file in the root directory. This commit triggered both workflows.

   <img width="856" alt="Screen Shot 2022-10-18 at 23 41 59" src="https://user-images.githubusercontent.com/1512805/196550277-61c1edc3-d76d-4742-8a4a-22fa5e8edc47.png">