### PR TITLE
Fix icon color and alignment in auth popover

### DIFF
--- a/ui/src/components/AuthButtons/AuthButtons.jsx
+++ b/ui/src/components/AuthButtons/AuthButtons.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import { defineMessages, injectIntl } from 'react-intl';
-import { Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import Truncate from 'react-truncate';
 import {
@@ -22,7 +21,7 @@ import {
 } from 'selectors';
 import AuthenticationDialog from 'dialogs/AuthenticationDialog/AuthenticationDialog';
 import { DialogToggleButton } from 'components/Toolbar';
-import { Skeleton } from 'components/common';
+import { Skeleton, LinkMenuItem } from 'components/common';
 
 import './AuthButtons.scss';
 
@@ -105,94 +104,64 @@ export class AuthButtons extends Component {
         <span className="AuthButtons">
           <Popover
             popoverClassName="AuthButtons__popover"
+            placement="bottom-end"
+            fill
             content={
               <Menu className="AuthButtons__popover__menu">
-                <Link to="/notifications" className={Classes.MENU_ITEM}>
-                  <Icon icon="notifications" />{' '}
-                  <div
-                    className={c(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}
-                  >
-                    {intl.formatMessage(messages.notifications)}
-                  </div>
-                </Link>
-                <Link to="/alerts" className={Classes.MENU_ITEM}>
-                  <Icon icon="feed" />
-                  <div
-                    className={c(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}
-                  >
-                    {intl.formatMessage(messages.alerts)}
-                  </div>
-                </Link>
-                <Link to="/exports" className={Classes.MENU_ITEM}>
-                  <Icon icon="export" />
-                  <div
-                    className={c(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}
-                  >
-                    {intl.formatMessage(messages.exports)}
-                  </div>
-                </Link>
+                <LinkMenuItem
+                  to="/notifications"
+                  icon="notifications"
+                  text={intl.formatMessage(messages.notifications)}
+                />
+                <LinkMenuItem
+                  to="/alerts"
+                  icon="feed"
+                  text={intl.formatMessage(messages.alerts)}
+                />
+                <LinkMenuItem
+                  to="/exports"
+                  icon="export"
+                  text={intl.formatMessage(messages.exports)}
+                />
                 <MenuDivider />
-                <Link
+                <LinkMenuItem
                   to="/investigations"
-                  className={c(Classes.MENU_ITEM, 'mobile-show')}
-                >
-                  <Icon icon="briefcase" />
-                  <div
-                    className={c(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}
-                  >
-                    {intl.formatMessage(messages.cases)}
-                  </div>
-                </Link>
-                <Link to="/diagrams" className={Classes.MENU_ITEM}>
-                  <Icon icon="graph" />
-                  <div
-                    className={c(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}
-                  >
-                    {intl.formatMessage(messages.diagrams)}
-                  </div>
-                </Link>
-                <Link to="/timelines" className={Classes.MENU_ITEM}>
-                  <Icon icon="gantt-chart" />
-                  <div
-                    className={c(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}
-                  >
-                    {intl.formatMessage(messages.timelines)}
-                  </div>
-                </Link>
-                <Link to="/lists" className={Classes.MENU_ITEM}>
-                  <Icon icon="list" />
-                  <div
-                    className={c(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}
-                  >
-                    {intl.formatMessage(messages.lists)}
-                  </div>
-                </Link>
+                  icon="briefcase"
+                  text={intl.formatMessage(messages.cases)}
+                />
+                <LinkMenuItem
+                  to="/diagrams"
+                  icon="graph"
+                  text={intl.formatMessage(messages.diagrams)}
+                />
+                <LinkMenuItem
+                  to="/timelines"
+                  icon="gantt-chart"
+                  text={intl.formatMessage(messages.timelines)}
+                />
+                <LinkMenuItem
+                  to="/lists"
+                  icon="list"
+                  text={intl.formatMessage(messages.lists)}
+                />
                 <MenuDivider />
-                <Link to="/settings" className={Classes.MENU_ITEM}>
-                  <Icon icon="cog" />{' '}
-                  <div
-                    className={c(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}
-                  >
-                    {intl.formatMessage(messages.settings)}
-                  </div>
-                </Link>
-                <Link to="/status" className={Classes.MENU_ITEM}>
-                  <Icon icon="dashboard" />
-                  <div
-                    className={c(Classes.TEXT_OVERFLOW_ELLIPSIS, Classes.FILL)}
-                  >
-                    {intl.formatMessage(messages.status)}
-                  </div>
-                </Link>
-                <MenuItem
+                <LinkMenuItem
+                  to="/settings"
+                  icon="cog"
+                  text={intl.formatMessage(messages.settings)}
+                />
+                <LinkMenuItem
+                  to="/status"
+                  icon="dashboard"
+                  text={intl.formatMessage(messages.status)}
+                />
+                <LinkMenuItem
+                  to="/logout"
                   icon="log-out"
-                  href="/logout"
                   text={intl.formatMessage(messages.signout)}
                 />
               </Menu>
             }
-            placement="bottom-end"
-            fill
           >
             <Button icon="user" minimal rightIcon="caret-down">
               <Truncate lines={2} width={120}>


### PR DESCRIPTION
We didn’t used well structured markup for the auth button popover that resulted in the color and alignment being slightly off.

| Before | After |
| - | - |
| <img width="210" alt="Screen Shot 2022-10-19 at 11 39 17" src="https://user-images.githubusercontent.com/1512805/196658147-e240b83c-b2cf-46f6-befc-222bcf815848.png"> | <img width="218" alt="Screen Shot 2022-10-19 at 11 46 30" src="https://user-images.githubusercontent.com/1512805/196658175-016b4e50-b4f7-493b-8fc9-7e29cf8e4415.png"> |

