### PR TITLE
Pin ingest-file version in development environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -39,7 +39,7 @@ services:
     tmpfs: /tmp
 
   ingest-file:
-    image: ghcr.io/alephdata/ingest-file:latest
+    image: ghcr.io/alephdata/ingest-file:3.16.4
     hostname: ingest
     tmpfs: /tmp
     volumes:


### PR DESCRIPTION
The latest version of ingest-file (4.x) already contains changes to use RabbitMQ as the tasks queue which is incompatible with the current version of Aleph.