### PR TITLE
Do not reset select scroll position on rerender

### DIFF
--- a/ui/src/react-ftm/editors/PropertySelect.tsx
+++ b/ui/src/react-ftm/editors/PropertySelect.tsx
@@ -65,6 +65,7 @@ class PropertySelect extends React.PureComponent<IPropertySelectProps> {
         resetOnSelect={true}
         onItemSelect={this.props.onSelected}
         items={properties}
+        scrollToActiveItem={false}
       >
         <Button
           icon="add"

--- a/ui/src/react-ftm/editors/SchemaSelect.tsx
+++ b/ui/src/react-ftm/editors/SchemaSelect.tsx
@@ -46,6 +46,7 @@ class SchemaSelect extends React.PureComponent<ISelectSchemaProps> {
         popoverProps={{ minimal: true, matchTargetWidth: true }}
         className="SchemaSelect"
         fill
+        scrollToActiveItem={false}
       >
         {this.props.children}
       </TypedSelect>


### PR DESCRIPTION
This fix should have originally been included in [a previous PR](https://github.com/alephdata/aleph/pull/2481), but probably got lost while rebasing the PR.

Blueprint’s Select2 component will try to scroll the active option into view every time the component rerenders. If no option is selected, it tries to scroll the first option into view. Setting the scrollToActiveItem property to false solves this.