### PR TITLE
Fix interpunctuation

### DIFF
--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -98,7 +98,7 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
           <p>
             <FormattedMessage
               id="bookmarks.warning.text"
-              defaultMessage="Your bookmarks don’t sync to other devices and we may remove this feature in the future. You can download your bookmarks at any time:"
+              defaultMessage="Your bookmarks don’t sync to other devices and we may remove this feature in the future. You can download your bookmarks at any time."
             />
           </p>
         </Callout>


### PR DESCRIPTION
The download button is only displayed if a user has bookmarked at least one entity. In case a user has no bookmarks, the colon "leads to nowhere".