### PR TITLE
Fix visual quirk when displaying long, dismissible messages

### DIFF
--- a/ui/src/components/MessageBanner/MessageBanner.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.jsx
@@ -55,17 +55,19 @@ function MessageBanner({ message, onDismiss }) {
           )}
         </p>
         {dismissible && (
-          <Button
-            minimal
-            rightIcon="cross"
-            intent={intent}
-            onClick={onDismissButtonClick}
-          >
-            <FormattedMessage
-              id="messages.banner.dismiss"
-              defaultMessage="Dismiss"
-            />
-          </Button>
+          <div class="MessageBanner__actions">
+            <Button
+              minimal
+              rightIcon="cross"
+              intent={intent}
+              onClick={onDismissButtonClick}
+            >
+              <FormattedMessage
+                id="messages.banner.dismiss"
+                defaultMessage="Dismiss"
+              />
+            </Button>
+          </div>
         )}
       </Callout>
     </Wrapper>

--- a/ui/src/components/MessageBanner/MessageBanner.scss
+++ b/ui/src/components/MessageBanner/MessageBanner.scss
@@ -2,6 +2,7 @@
 
 .MessageBanner__callout.MessageBanner__callout {
   display: flex;
+  gap: $aleph-grid-size;
   align-items: center;
   padding: 0.5 * $aleph-content-padding $aleph-content-padding;
 }
@@ -25,4 +26,8 @@
 
 .MessageBanner__meta::before {
   content: ' — ';
+}
+
+.MessageBanner__actions {
+  flex-shrink: 0;
 }


### PR DESCRIPTION
In some cases, this may cause the button to shrink and the button text overlaying the message text.

**Before:**
<img width="1004" alt="Screen Shot 2022-11-10 at 11 08 20" src="https://user-images.githubusercontent.com/1512805/201064289-ed80be7e-d040-4a33-be58-723663a59715.png">

This adds some whitespace between the button and the message text and also ensures that the button is wide enough for the label text.

**After:**
<img width="1005" alt="Screen Shot 2022-11-10 at 11 07 15" src="https://user-images.githubusercontent.com/1512805/201064583-e35a51b0-fb72-467a-a55f-22e50a62d6ab.png">
