### PR TITLE
Use className instead of class, enable linter rule 🤦‍♂️

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -84,7 +84,8 @@
     "extends": "react-app",
     "rules": {
       "no-console": "error",
-      "no-debugger": "error"
+      "no-debugger": "error",
+      "react/no-unknown-property": "error"
     }
   },
   "jest": {

--- a/ui/src/components/MessageBanner/MessageBanner.jsx
+++ b/ui/src/components/MessageBanner/MessageBanner.jsx
@@ -55,7 +55,7 @@ function MessageBanner({ message, onDismiss }) {
           )}
         </p>
         {dismissible && (
-          <div class="MessageBanner__actions">
+          <div className="MessageBanner__actions">
             <Button
               minimal
               rightIcon="cross"


### PR DESCRIPTION
I forgot about this so often it's embarrassing. Enabling the linter rule will ensure our CI fails when we use props for HTML elements that are named differently in JSX/React.