### PR TITLE
Migrate different legacy colors to the new Blueprint 4 color palette

### DIFF
--- a/ui/src/react-ftm/components/NetworkDiagram/GraphConfig.ts
+++ b/ui/src/react-ftm/components/NetworkDiagram/GraphConfig.ts
@@ -10,7 +10,7 @@ export interface IGraphConfig {
 }
 
 export class GraphConfig {
-  public DEFAULT_VERTEX_COLOR: string = Colors.BLUE1;
+  public DEFAULT_VERTEX_COLOR: string = Colors.BLUE2;
   public EDGE_COLOR: string = Colors.GRAY2;
   public UNSELECTED_COLOR: string = Colors.GRAY5;
   public DEFAULT_VERTEX_RADIUS = 1;

--- a/ui/src/react-ftm/components/NetworkDiagram/renderer/VertexRenderer.tsx
+++ b/ui/src/react-ftm/components/NetworkDiagram/renderer/VertexRenderer.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Colors } from '@blueprintjs/core';
 import { DraggableCore, DraggableEvent, DraggableData } from 'react-draggable';
 import { GraphContext } from 'react-ftm/components/NetworkDiagram/GraphContext';
 import { Point } from 'react-ftm/components/NetworkDiagram/layout/Point';
@@ -23,6 +24,38 @@ interface IVertexRendererProps {
 interface IVertexRendererState {
   hovered: boolean;
 }
+
+// Blueprint 4 comes with an updated color palette that has been
+// improved for better accessibility. As a result, the darkest shades
+// (e.g. Blue 1) are darker in BP4 compared to BP3. That makes them look
+// kinda dull when used in network diagram, so we’re now using the second
+// darkest shade (e.g. Blue 2).
+//
+// This mapping ensures that we render vertices using the new colors,
+// even if they have been created when we still used Blueprint 3 colors
+// or the darkest shade of the Blueprint 4 colors.
+
+const COLOR_MAPPING: {
+  [key: string]: string;
+} = {
+  // Map Blueprint 3 colors to Blueprint 4 colors
+  // Example: BP3 Blue 1 => BP4 Blue 2
+  '#0E5A8A': Colors.BLUE2,
+  '#A82A2A': Colors.RED2,
+  '#0A6640': Colors.GREEN2,
+  '#A66321': Colors.ORANGE2,
+  '#5C255C': Colors.VIOLET2,
+  '#008075': Colors.TURQUOISE2,
+
+  // Map Blueprint 4 colors to lighter shade
+  // Example: BP4 Blue 1 => BP Blue 2
+  '#184A90': Colors.BLUE2,
+  '#8E292C': Colors.RED2,
+  '#77450D': Colors.ORANGE2,
+  '#165A36': Colors.GREEN2,
+  // Violet colors haven’t changed from BP3 to BP4
+  '#004D46': Colors.TURQUOISE2,
+};
 
 export class VertexRenderer extends React.PureComponent<
   IVertexRendererProps,
@@ -143,7 +176,11 @@ export class VertexRenderer extends React.PureComponent<
     const highlighted =
       layout.isElementSelected(vertex) || layout.selection.length === 0;
 
-    const color = vertex.color || layout.config.DEFAULT_VERTEX_COLOR;
+    let color = vertex.color || layout.config.DEFAULT_VERTEX_COLOR;
+
+    if (typeof color === 'string') {
+      color = COLOR_MAPPING[color] || color;
+    }
 
     if (highlighted || hovered) {
       return color;

--- a/ui/src/react-ftm/components/NetworkDiagram/renderer/VertexRenderer.tsx
+++ b/ui/src/react-ftm/components/NetworkDiagram/renderer/VertexRenderer.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { Colors } from '@blueprintjs/core';
 import { DraggableCore, DraggableEvent, DraggableData } from 'react-draggable';
 import { GraphContext } from 'react-ftm/components/NetworkDiagram/GraphContext';
 import { Point } from 'react-ftm/components/NetworkDiagram/layout/Point';
@@ -11,7 +10,7 @@ import {
 import { VertexLabelRenderer } from './VertexLabelRenderer';
 import { IconRenderer } from './IconRenderer';
 import { modes } from 'react-ftm/components/NetworkDiagram/utils';
-import { reduceTranslucentColor } from 'react-ftm/utils/reduceTranslucentColor';
+import { reduceTranslucentColor, mapColor } from 'react-ftm/utils';
 
 interface IVertexRendererProps {
   vertex: Vertex;
@@ -24,38 +23,6 @@ interface IVertexRendererProps {
 interface IVertexRendererState {
   hovered: boolean;
 }
-
-// Blueprint 4 comes with an updated color palette that has been
-// improved for better accessibility. As a result, the darkest shades
-// (e.g. Blue 1) are darker in BP4 compared to BP3. That makes them look
-// kinda dull when used in network diagram, so we’re now using the second
-// darkest shade (e.g. Blue 2).
-//
-// This mapping ensures that we render vertices using the new colors,
-// even if they have been created when we still used Blueprint 3 colors
-// or the darkest shade of the Blueprint 4 colors.
-
-const COLOR_MAPPING: {
-  [key: string]: string;
-} = {
-  // Map Blueprint 3 colors to Blueprint 4 colors
-  // Example: BP3 Blue 1 => BP4 Blue 2
-  '#0E5A8A': Colors.BLUE2,
-  '#A82A2A': Colors.RED2,
-  '#0A6640': Colors.GREEN2,
-  '#A66321': Colors.ORANGE2,
-  '#5C255C': Colors.VIOLET2,
-  '#008075': Colors.TURQUOISE2,
-
-  // Map Blueprint 4 colors to lighter shade
-  // Example: BP4 Blue 1 => BP Blue 2
-  '#184A90': Colors.BLUE2,
-  '#8E292C': Colors.RED2,
-  '#77450D': Colors.ORANGE2,
-  '#165A36': Colors.GREEN2,
-  // Violet colors haven’t changed from BP3 to BP4
-  '#004D46': Colors.TURQUOISE2,
-};
 
 export class VertexRenderer extends React.PureComponent<
   IVertexRendererProps,
@@ -177,11 +144,7 @@ export class VertexRenderer extends React.PureComponent<
     const highlighted =
       layout.isElementSelected(vertex) || layout.selection.length === 0;
 
-    let color = vertex.color || layout.config.DEFAULT_VERTEX_COLOR;
-
-    if (typeof color === 'string') {
-      color = COLOR_MAPPING[color] || color;
-    }
+    const color = mapColor(vertex.color || layout.config.DEFAULT_VERTEX_COLOR);
 
     if (highlighted || hovered) {
       return color;
@@ -262,12 +225,7 @@ export class VertexRenderer extends React.PureComponent<
             onClick={this.onClick}
             color={vertexColor}
           />
-          {entity && (
-            <IconRenderer
-              entity={entity}
-              radius={vertexRadius}
-            />
-          )}
+          {entity && <IconRenderer entity={entity} radius={vertexRadius} />}
         </g>
       </DraggableCore>
     );

--- a/ui/src/react-ftm/components/NetworkDiagram/renderer/VertexRenderer.tsx
+++ b/ui/src/react-ftm/components/NetworkDiagram/renderer/VertexRenderer.tsx
@@ -62,6 +62,7 @@ export class VertexRenderer extends React.PureComponent<
   IVertexRendererState
 > {
   static contextType = GraphContext;
+  context: React.ContextType<typeof GraphContext>;
   gRef: React.RefObject<SVGGElement>;
 
   constructor(props: Readonly<IVertexRendererProps>) {
@@ -79,7 +80,7 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   componentDidMount() {
-    const { writeable } = this.context;
+    const { writeable } = this.context!;
     const g = this.gRef.current;
     if (writeable && g !== null) {
       g.addEventListener('dblclick', this.onDoubleClick);
@@ -87,7 +88,7 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   componentWillUnmount() {
-    const { writeable } = this.context;
+    const { writeable } = this.context!;
     const g = this.gRef.current;
     if (writeable && g !== null) {
       g.removeEventListener('dblclick', this.onDoubleClick);
@@ -95,7 +96,7 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   private onDragMove(e: DraggableEvent, data: DraggableData) {
-    const { interactionMode, layout } = this.context;
+    const { interactionMode, layout } = this.context!;
     const { actions, dragSelection } = this.props;
     const matrix = getRefMatrix(this.gRef);
     const current = applyMatrix(matrix, data.x, data.y);
@@ -111,7 +112,7 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   onDragEnd() {
-    const { interactionMode } = this.context;
+    const { interactionMode } = this.context!;
     const { actions, dropSelection } = this.props;
 
     if (interactionMode === modes.ITEM_DRAG) {
@@ -125,7 +126,7 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   onClick(e: any) {
-    const { interactionMode, layout } = this.context;
+    const { interactionMode, layout } = this.context!;
     const { vertex, selectVertex, actions } = this.props;
     if (interactionMode === modes.EDGE_DRAW) {
       // can't draw link to self
@@ -142,7 +143,7 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   onDoubleClick(e: MouseEvent) {
-    const { entityManager } = this.context;
+    const { entityManager } = this.context!;
     const { actions, vertex } = this.props;
     e.preventDefault();
     e.stopPropagation();
@@ -156,7 +157,7 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   onMouseOver() {
-    const { interactionMode } = this.context;
+    const { interactionMode } = this.context!;
     const { vertex } = this.props;
 
     if (interactionMode === modes.EDGE_DRAW && vertex.isEntity()) {
@@ -169,7 +170,7 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   getColor() {
-    const { layout } = this.context;
+    const { layout } = this.context!;
     const { vertex } = this.props;
     const { hovered } = this.state;
 
@@ -190,7 +191,7 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   allowPointerEvents() {
-    const { interactionMode } = this.context;
+    const { interactionMode } = this.context!;
     const { vertex } = this.props;
 
     // sets pointer events to none while dragging in order to detect mouseover on other elements
@@ -205,11 +206,15 @@ export class VertexRenderer extends React.PureComponent<
   }
 
   render() {
-    const { entityManager, layout, writeable } = this.context;
+    const { entityManager, layout, writeable } = this.context!;
     const { vertex } = this.props;
     const { x, y } = layout.config.gridToPixel(vertex.position);
     const selected = layout.isElementSelected(vertex);
+
     const isEntity = vertex.isEntity();
+    const entityId = vertex.entityId;
+    const entity = entityId && entityManager.getEntity(vertex.entityId);
+
     const defaultRadius = isEntity
       ? layout.config.DEFAULT_VERTEX_RADIUS
       : layout.config.DEFAULT_VERTEX_RADIUS / 2;
@@ -257,10 +262,12 @@ export class VertexRenderer extends React.PureComponent<
             onClick={this.onClick}
             color={vertexColor}
           />
-          <IconRenderer
-            entity={entityManager.getEntity(vertex.entityId)}
-            radius={vertexRadius}
-          />
+          {entity && (
+            <IconRenderer
+              entity={entity}
+              radius={vertexRadius}
+            />
+          )}
         </g>
       </DraggableCore>
     );

--- a/ui/src/react-ftm/components/NetworkDiagram/toolbox/EntityViewer.tsx
+++ b/ui/src/react-ftm/components/NetworkDiagram/toolbox/EntityViewer.tsx
@@ -11,6 +11,7 @@ import {
   FTMEntityExtended as FTMEntity,
   Schema,
 } from 'react-ftm/types';
+import { mapColor } from 'react-ftm/utils';
 import { Vertex } from 'react-ftm/components/NetworkDiagram/layout';
 import { GraphContext } from 'react-ftm/components/NetworkDiagram/GraphContext';
 import { EditableProperty } from 'react-ftm/components/common';
@@ -148,7 +149,7 @@ export class EntityViewer extends React.PureComponent<
           {vertexRef && writeable && (
             <div className="EntityViewer__title__settings">
               <ColorPicker
-                currSelected={vertexRef.color}
+                currSelected={mapColor(vertexRef.color)}
                 onSelect={(color: string) =>
                   this.props.onVertexColorSelected(vertexRef, color)
                 }

--- a/ui/src/react-ftm/editors/ColorPicker.tsx
+++ b/ui/src/react-ftm/editors/ColorPicker.tsx
@@ -44,12 +44,12 @@ const messages = defineMessages({
 type ColorName = 'blue' | 'green' | 'orange' | 'red' | 'violet' | 'turquoise';
 
 const colorOptions = new Map<ColorName, string>([
-  ['blue', Colors.BLUE1],
-  ['green', Colors.GREEN1],
-  ['orange', Colors.ORANGE1],
-  ['red', Colors.RED1],
-  ['violet', Colors.VIOLET1],
-  ['turquoise', Colors.TURQUOISE1],
+  ['blue', Colors.BLUE2],
+  ['green', Colors.GREEN2],
+  ['orange', Colors.ORANGE2],
+  ['red', Colors.RED2],
+  ['violet', Colors.VIOLET2],
+  ['turquoise', Colors.TURQUOISE2],
 ]);
 
 interface IColorPickerProps extends WrappedComponentProps {

--- a/ui/src/react-ftm/utils/index.ts
+++ b/ui/src/react-ftm/utils/index.ts
@@ -10,3 +10,5 @@ export * from './toaster';
 export * from './wordList';
 export * from './validate';
 export * from './sortEntities';
+export * from './reduceTranslucentColor';
+export * from './mapColor';

--- a/ui/src/react-ftm/utils/mapColor.ts
+++ b/ui/src/react-ftm/utils/mapColor.ts
@@ -1,0 +1,37 @@
+import { Colors } from '@blueprintjs/core';
+
+// Blueprint 4 comes with an updated color palette that has been
+// improved for better accessibility. As a result, the darkest shades
+// (e.g. Blue 1) are darker in BP4 compared to BP3. That makes them look
+// kinda dull when used in network diagram, so we’re now using the second
+// darkest shade (e.g. Blue 2).
+//
+// This mapping ensures that we render vertices using the new colors,
+// even if they have been created when we still used Blueprint 3 colors
+// or the darkest shade of the Blueprint 4 colors.
+
+const COLOR_MAPPING: {
+  [key: string]: string;
+} = {
+  // Map Blueprint 3 colors to Blueprint 4 colors
+  // Example: BP3 Blue 1 => BP4 Blue 2
+  '#0E5A8A': Colors.BLUE2,
+  '#A82A2A': Colors.RED2,
+  '#0A6640': Colors.GREEN2,
+  '#A66321': Colors.ORANGE2,
+  '#5C255C': Colors.VIOLET2,
+  '#008075': Colors.TURQUOISE2,
+
+  // Map Blueprint 4 colors to lighter shade
+  // Example: BP4 Blue 1 => BP Blue 2
+  '#184A90': Colors.BLUE2,
+  '#8E292C': Colors.RED2,
+  '#77450D': Colors.ORANGE2,
+  '#165A36': Colors.GREEN2,
+  // Violet colors haven’t changed from BP3 to BP4
+  '#004D46': Colors.TURQUOISE2,
+};
+
+export function mapColor(color: string) {
+  return COLOR_MAPPING[color] || color;
+}

--- a/ui/src/react-ftm/utils/reduceTranslucentColor.test.ts
+++ b/ui/src/react-ftm/utils/reduceTranslucentColor.test.ts
@@ -6,5 +6,5 @@ it('returns HEX representation of color on white background', () => {
 });
 
 it('handles invalid HEX strings', () => {
-  expect(reduceTranslucentColor('#gghhii', 0.5)).toBeNull();
+  expect(reduceTranslucentColor('#gghhii', 0.5)).toBeUndefined();
 });

--- a/ui/src/react-ftm/utils/reduceTranslucentColor.ts
+++ b/ui/src/react-ftm/utils/reduceTranslucentColor.ts
@@ -24,15 +24,12 @@ function rgbToHex(rgb: RgbColor): string {
 
 // Calculate the HEX representation for a color as if
 // it was rendered on a white background
-export function reduceTranslucentColor(
-  hex: string,
-  opacity: number
-): null | string {
+export function reduceTranslucentColor(hex: string, opacity: number) {
   const color = hexToRgb(hex);
   const white = { r: 255, g: 255, b: 255 };
 
   if (!color) {
-    return null;
+    return undefined;
   }
 
   const reducedRgb = {


### PR DESCRIPTION
This updates the default colors that can be selected using the color pickers to a lighter shade. With the Blueprint 4 update, the darkest shade that we’re currently using looks a bit too dull and grayish for use in a visualization.

Depending on when the the vertices in a network diagram were created, colors will be slightly different. So this also ensures that all colors are consistent across different network diagrams and – more importantly – within network diagrams.

In the screenshots below, the vertices in the left column have been created before we rolled out the BP4 upgrade, the vertices in the middle column have been created using the current 3.13.0 RC, and the vertices in the right column have been created after changing the default colors to a lighter shade.

Closes #2657

| Before | After |
| - | - |
| <img width="283" alt="Screen Shot 2022-11-11 at 16 01 21" src="https://user-images.githubusercontent.com/1512805/201367582-f88b1aff-f549-4ca0-a941-943f935dca68.png"> | <img width="286" alt="Screen Shot 2022-11-11 at 16 01 48" src="https://user-images.githubusercontent.com/1512805/201367628-a6373be8-3656-4952-8b4c-40ab86881584.png"> |