### PR TITLE
Fix native click behavior search results

### DIFF
--- a/ui/src/components/common/Entity.jsx
+++ b/ui/src/components/common/Entity.jsx
@@ -21,10 +21,15 @@ class EntityLink extends PureComponent {
 
   onClick(event) {
     const { entity, navigate, location, preview, profile = true } = this.props;
-    if (preview) {
-      event.preventDefault();
-      togglePreview(navigate, location, entity, profile);
+    const modifierPressed =
+      event.altKey || event.ctrlKey || event.metaKey || event.shiftKey;
+
+    if (!preview || modifierPressed) {
+      return;
     }
+
+    event.preventDefault();
+    togglePreview(navigate, location, entity, profile);
   }
 
   render() {


### PR DESCRIPTION
I observed this issue in a recent user research session. The user wanted to view search results in a separate window or tab.

Right now, we always prevent the default browser behavior and open the preview drawer, even if the user has pressed a modifier key while clicking a link. This prevents users from opening entity links in a new tab or window.

This PR only prevent the native browser behavior if no modifier keys (Cmd, Ctrl, Alt, Shift) are pressed while clicking on the link. That means that users can now:

* Cmd+Click to open a search result in a new tab, in the background.
* Cmd+Shift+Click to open a search result in a new tab, in the foreground.

Fix #2713