### PR TITLE
Enable CORS for Elasticsearch API in development environment

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,6 +20,10 @@ services:
     environment:
       - discovery.type=single-node
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      - "http.cors.enabled=true"
+      - "http.cors.allow-origin=*"
+      - "http.cors.allow-headers=*"
+      - "http.cors.allow-credentials=true"
     ports:
       - "127.0.0.1:19200:9200"
     volumes:


### PR DESCRIPTION
This allows us to use tools like dejavue [1] to inspect index contents which is slightly more convenient than sending requests directly to the ES API.

I’ll eventually add this to the technical documentation or the Readme. For now, here’s what’s worked well for me:

1. Run `docker run -p 1358:1358 -d appbaseio/dejavu` to start dejavue
2. Open the web interface at http://localgost:1358
3. Enter the ES endpoint (`http://localhost:19200`) and the name of the ES index. Entity indices follow the follow the pattern `aleph-entity-schema-v1`. For example the index for the `LegalEntity` schema would be `aleph-entity-legalentity-v1`.
4. Click "Connect".

[1] https://github.com/appbaseio/dejavu