### PR TITLE
Upgrade to the latest LTS Node.js version

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16-slim
+FROM node:18-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 


### PR DESCRIPTION
Fixes #2695

We’re currently using Node.js 16 which will reach EOL in Sep 2023. The current LTS version is 18 (see [release schedule](https://github.com/nodejs/release#release-schedule)).

This upgrades only the base image used in development and when building the UI (`Dockerfile`). 

The base image used to serve the static UI assets in production is `nginx:alpine` (as specified in `Dockerfile.production`) and stays untouched.