### PR TITLE
Run docs workflow only if docs directory as changes

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,10 @@
 name: Docs
 
 on: 
-  - push
-  - workflow_dispatch
+  push:
+    paths:
+      - "docs/**"
+  workflow_dispatch: {}
 
 concurrency:
   group: pages


### PR DESCRIPTION
Right now, the docs workflow is triggered every time a commit is pushed. This is unnecessary, can delay execution of other workflows, and can cause notification spam.

The `/docs` directory is completely self-contained (at least at the moment), i.e. it is fine to only run the docs workflow if the diff affects files in this directory.