### PR TITLE
Integrate dejavu as an ES UI into dev workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: build upgrade web
 services:
 	$(COMPOSE) up -d --remove-orphans \
 		postgres elasticsearch ingest-file \
-		convert-document
+		convert-document dejavu
 
 shell: services
 	$(APPDOCKER) /bin/bash

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,6 +29,14 @@ services:
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
 
+  dejavu:
+    image: appbaseio/dejavu:3.6.0
+    container_name: dejavu
+    ports:
+        - '1358:1358'
+    links:
+        - elasticsearch
+
   redis:
     image: redis:alpine
     command: ["redis-server", "--save", "3600", "10"]

--- a/docs/src/pages/developers/installation.mdx
+++ b/docs/src/pages/developers/installation.mdx
@@ -152,6 +152,10 @@ You can also build the Aleph images locally. This could be useful while working 
 
 To build the image you can run `make build`, which will build the `alephdata/aleph` image (this will generate a production ready image).
 
+### Inspecting ElasticSearch
+
+At times it can be useful to inspect the contents of the ElasticSearch indices. The developer setup includes [dejavu](https://github.com/appbaseio/dejavu/stargazers), a web-based UI for ElasticSearch. In a local environment brought up as described above you should see dejavu under [http://localhost:1358](http://localhost:1358). You will need to pass it the local ES cluster URL (`http://localhost:19200`) and you can either inspect an individual index or use `*` to see the whole content.
+
 ## Production deployment
 
 <Callout>


### PR DESCRIPTION
Building on https://github.com/alephdata/aleph/commit/33df4c4638caf309eb5e2d45f15adaf9918fd998 this adds `dejavu` to the dev docker-compose setup and briefly documents it.