### PR TITLE
Remove pdflib mention from docs

### DIFF
--- a/docs/src/pages/developers/developer-tools.mdx
+++ b/docs/src/pages/developers/developer-tools.mdx
@@ -13,8 +13,6 @@ All of the tools below are packaged as releases regularly and can be installed v
 
 [`fingerprints`](https://github.com/alephdata/fingerprints) is a Python library that heavily normalises names of companies and people before comparison. This includes transliteration, word order, and the normalisation of company type suffixes like Limited \(Ltd\) or Aktiengesellschaft \(AG\). `fingerprints` depends on `normality` and works best when `pyicu` is installed.
 
-[`pdflib`](https://github.com/alephdata/pdflib) is a Python to C binding for the `poppler` PDF parser. It's used to extract text and images from PDF files with a high level of error tolerance.
-
 [`msglite`](https://github.com/alephdata/msglite) is a fork of `msg-extractor`, a parser for Microsoft Outlook MSG files. These binary email files are OLE containers \(like old-style Word or Excel documents\) and require some tickling before they will confess details about the contained email message.
 
 [`countrynames`](https://github.com/alephdata/countrynames) helps to turn country names into two-letter ISO codes representing that country. For example, `United States` or `Delaware` become `us`, `England` becomes `gb`. Due to the work area of the OCCRP, this includes some exotic country designations, such as Yugoslavia, Transnistria and the Soviet Union \(now deceased\).


### PR DESCRIPTION
After the migration away from pdflib we are going to deprecate it, so there is no need to mention it.