### PR TITLE
Reset signin modal state after closing or when switching between signin and signup

### DIFF
--- a/ui/src/app/blueprint-overrides.scss
+++ b/ui/src/app/blueprint-overrides.scss
@@ -1,3 +1,4 @@
+@import 'app/variables.scss';
 @import 'app/mixins.scss';
 
 // Add spacing before tag pill
@@ -245,7 +246,13 @@ table {
 // Add RTL support for dialogs
 .#{$bp-ns}-dialog {
   .#{$bp-ns}-dialog-header {
-    @include rtlSupportInvertedProp(padding, left, 20px, 5px);
+    // See https://github.com/palantir/blueprint/blob/develop/packages/core/src/components/dialog/_dialog.scss
+    @include rtlSupportInvertedProp(
+      padding,
+      left,
+      1.5 * $pt-grid-size,
+      0.5 * $pt-grid-size
+    );
     .#{$bp-ns}-icon-large,
     .#{$bp-ns}-icon {
       @include rtlSupportInvertedProp(margin, right, 10px, 0);

--- a/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.jsx
+++ b/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.jsx
@@ -38,17 +38,20 @@ export class AuthenticationDialog extends Component {
   constructor(props) {
     super(props);
 
-    this.state = {
+    this.initialState = {
       submitted: false,
       firstSection: '',
       secondSection: 'hide',
     };
+
+    this.state = this.initialState;
 
     this.onLogin = this.onLogin.bind(this);
     this.onSignup = this.onSignup.bind(this);
     this.onRegisterClick = this.onRegisterClick.bind(this);
     this.onSignInClick = this.onSignInClick.bind(this);
     this.onOAuthLogin = this.onOAuthLogin.bind(this);
+    this.resetState = this.resetState.bind(this);
   }
 
   onOAuthLogin() {
@@ -86,12 +89,24 @@ export class AuthenticationDialog extends Component {
 
   onRegisterClick(e) {
     e.preventDefault();
-    this.setState({ firstSection: 'hide', secondSection: '' });
+    this.setState({
+      firstSection: 'hide',
+      secondSection: '',
+      submitted: false,
+    });
   }
 
   onSignInClick(e) {
     e.preventDefault();
-    this.setState({ firstSection: '', secondSection: 'hide' });
+    this.setState({
+      firstSection: '',
+      secondSection: 'hide',
+      submitted: false,
+    });
+  }
+
+  resetState() {
+    this.setState(this.initialState);
   }
 
   render() {
@@ -115,6 +130,7 @@ export class AuthenticationDialog extends Component {
         className="AuthenticationScreen"
         isOpen={isOpen}
         onClose={toggleDialog}
+        onOpening={this.resetState}
         title={
           firstSection === ''
             ? intl.formatMessage(messages.title)
@@ -160,16 +176,16 @@ export class AuthenticationDialog extends Component {
                   buttonClassName="signin-button"
                   onSubmit={this.onSignup}
                 />
-                <div className="link-box">
-                  <a key="oauth" href="/" onClick={this.onSignInClick}>
-                    <FormattedMessage
-                      id="signup.login"
-                      defaultMessage="Already have account? Sign in!"
-                    />
-                  </a>
-                </div>
               </span>
             )}
+            <div className="link-box">
+              <a key="oauth" href="/" onClick={this.onSignInClick}>
+                <FormattedMessage
+                  id="signup.login"
+                  defaultMessage="Already have account? Sign in!"
+                />
+              </a>
+            </div>
           </section>
           {auth.oauth_uri && (
             <>

--- a/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.jsx
+++ b/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.jsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import {
+  Classes,
   Callout,
   Intent,
   Dialog,
@@ -126,7 +127,6 @@ export class AuthenticationDialog extends Component {
 
     return (
       <Dialog
-        icon="authentication"
         className="AuthenticationScreen"
         isOpen={isOpen}
         onClose={toggleDialog}
@@ -137,7 +137,7 @@ export class AuthenticationDialog extends Component {
             : intl.formatMessage(messages.registration_title)
         }
       >
-        <div className="inner">
+        <div className={Classes.DIALOG_BODY}>
           <section className={firstSection}>
             {passwordLogin && (
               <PasswordAuthLogin
@@ -158,13 +158,16 @@ export class AuthenticationDialog extends Component {
           </section>
           <section className={secondSection}>
             {submitted ? (
-              <Callout intent={Intent.SUCCESS} icon="tick">
-                <h5>
+              <Callout
+                intent={Intent.SUCCESS}
+                icon="tick"
+                title={
                   <FormattedMessage
                     id="signup.inbox.title"
                     defaultMessage="Check your inbox"
                   />
-                </h5>
+                }
+              >
                 <FormattedMessage
                   id="signup.inbox.desc"
                   defaultMessage="We've sent you an email, please follow the link to complete your registration"

--- a/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.scss
+++ b/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.scss
@@ -1,12 +1,8 @@
 @import 'app/mixins.scss';
 
-.AuthenticationScreen {
+.AuthenticationScreen.AuthenticationScreen {
   width: 28em !important;
-
-  .inner {
-    margin-top: 1em;
-    @include rtlSupportInvertedProp(margin, right, 1em, 1em);
-  }
+  padding-bottom: 0;
 
   .menu-divider {
     margin-top: 1em;
@@ -22,8 +18,8 @@
   }
 
   .link-box {
-    margin-top: 2em;
-    margin-bottom: 2em;
-    // margin-left: 8.5em;
+    // TODO: This is a hacky way to center the link horizontally. We should
+    // refactor this and use flexbox to achieve that.
+    margin-top: 1.75em;
   }
 }


### PR DESCRIPTION
Closes #2806. This allows users to switch between signin/signup any time and always resets the dialog state when closing and reopening it.

In addition to fixing the referenced bug, I’ve also sneaked in a few minor styling fixes.


https://user-images.githubusercontent.com/1512805/212868415-9c4b5080-5d09-45ce-add7-e5843ec0fb32.mov