### PR TITLE
Improve bookmarks warning messages

### DIFF
--- a/ui/src/components/common/BookmarkButton.tsx
+++ b/ui/src/components/common/BookmarkButton.tsx
@@ -1,8 +1,9 @@
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage } from 'react-intl';
-import { Button, ButtonProps } from '@blueprintjs/core';
+import { Intent, Button, ButtonProps } from '@blueprintjs/core';
+import { Popover2 as Popover, Classes } from '@blueprintjs/popover2';
 import { Entity } from '@alephdata/followthemoney';
 
 import {
@@ -10,23 +11,30 @@ import {
   selectExperimentalBookmarksFeatureEnabled,
 } from 'selectors';
 import { createBookmark, deleteBookmark } from 'actions/bookmarkActions';
+import { setConfigValue } from 'actions/configActions';
 
 type BookmarkButtonProps = ButtonProps & {
   bookmarked: boolean;
   entity: Entity;
   enabled: boolean;
+  showWarning: boolean;
   createBookmark: (entity: Entity) => Promise<any>;
   deleteBookmark: (entity: Entity) => Promise<any>;
+  setConfigValue: (payload: object) => any;
 };
 
 const BookmarkButton: FC<BookmarkButtonProps> = ({
   entity,
   bookmarked,
   enabled,
+  showWarning,
   createBookmark,
   deleteBookmark,
+  setConfigValue,
   ...props
 }) => {
+  const [showPopover, setShowPopover] = useState(false);
+
   if (!enabled) {
     return null;
   }
@@ -40,13 +48,56 @@ const BookmarkButton: FC<BookmarkButtonProps> = ({
 
   const toggle = async () => {
     const action = bookmarked ? deleteBookmark : createBookmark;
+
+    if (!bookmarked && showWarning) {
+      setShowPopover(true);
+    }
+
     await action(entity);
   };
 
+  const popoverContent = (
+    <>
+      <p>
+        <FormattedMessage
+          id="bookmarks.popover.line1"
+          defaultMessage="Yay, you found the new bookmark button! 🎉"
+        />
+      </p>
+      <p>
+        <FormattedMessage
+          id="bookmarks.popover.line2"
+          defaultMessage="This is still an <strong>experimental feature</strong>. Bookmarks are only stored in your browser. If you delete your browsing data or switch devices, you may lose access to your bookmarks."
+          values={{ strong: (chunks) => <strong>{chunks}</strong> }}
+        />
+      </p>
+      <Button
+        fill
+        intent={Intent.PRIMARY}
+        onClick={() => {
+          setConfigValue({ bookmarksWarningDismissed: true });
+          setShowPopover(false);
+        }}
+      >
+        <FormattedMessage
+          id="bookmarks.popover.confirm"
+          defaultMessage="Okay, I understand!"
+        />
+      </Button>
+    </>
+  );
+
   return (
-    <Button icon={icon} onClick={toggle} {...props}>
-      {label}
-    </Button>
+    <Popover
+      content={popoverContent}
+      placement="bottom"
+      isOpen={showPopover}
+      popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
+    >
+      <Button icon={icon} onClick={toggle} {...props}>
+        {label}
+      </Button>
+    </Popover>
   );
 };
 
@@ -54,14 +105,16 @@ const mapStateToProps = (state: any, ownProps: BookmarkButtonProps) => {
   const { entity } = ownProps;
   const bookmarked = selectEntityBookmarked(state, entity);
   const enabled = selectExperimentalBookmarksFeatureEnabled(state);
+  const showWarning = !state.config.bookmarksWarningDismissed;
 
   return {
     bookmarked,
     enabled,
+    showWarning,
   };
 };
 
 export default compose(
-  connect(mapStateToProps, { createBookmark, deleteBookmark }),
+  connect(mapStateToProps, { createBookmark, deleteBookmark, setConfigValue }),
   injectIntl
 )(BookmarkButton);

--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -98,7 +98,7 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
           <p>
             <FormattedMessage
               id="bookmarks.warning.text"
-              defaultMessage="Your bookmarks don’t sync to other devices and we may remove this feature in the future. You can download your bookmarks at any time."
+              defaultMessage="Bookmarks are only stored in your browser. If you delete your browsing data or switch devices, you may lose access to your bookmarks. You can download your bookmarks at any time."
             />
           </p>
         </Callout>

--- a/ui/src/reducers/config.js
+++ b/ui/src/reducers/config.js
@@ -5,7 +5,9 @@ const initialState = {};
 
 export default createReducer(
   {
-    [setConfigValue]: (state, newVal) => ({ ...state.config, ...newVal }),
+    [setConfigValue]: (state, newVal) => {
+      return { ...state, ...newVal };
+    },
     [setLocale]: (state, { locale }) => ({ locale }),
   },
   initialState


### PR DESCRIPTION
This PR…

1. improves the wording of the existing warning message to clarify that clearing browsing data or switching devices can cause bookmarks to get deleted,
2. adds a separate warning message popover when bookmarking something for the first time.

https://user-images.githubusercontent.com/1512805/215151100-a3802ed6-aec9-4792-937b-e9818b5043d5.mov

