### PR TITLE
Implement server-side bookmarks

### DIFF
--- a/aleph/logic/entities.py
+++ b/aleph/logic/entities.py
@@ -7,7 +7,7 @@ from followthemoney.types import registry
 from followthemoney.exc import InvalidData
 
 from aleph.core import db, cache
-from aleph.model import Entity, Document, EntitySetItem, Mapping
+from aleph.model import Entity, Document, EntitySetItem, Mapping, Bookmark
 from aleph.index import entities as index
 from aleph.queues import pipeline_entity, queue_task
 from aleph.queues import OP_UPDATE_ENTITY, OP_PRUNE_ENTITY
@@ -165,6 +165,7 @@ def prune_entity(collection, entity_id=None, job_id=None):
     if doc is not None:
         doc.delete()
     EntitySetItem.delete_by_entity(entity_id)
+    Bookmark.delete_by_entity(entity_id)
     Mapping.delete_by_table(entity_id)
     xref_index.delete_xref(collection, entity_id=entity_id)
     aggregator = get_aggregator(collection)

--- a/aleph/migrate/versions/c52a1f469ac7_create_bookmark_table.py
+++ b/aleph/migrate/versions/c52a1f469ac7_create_bookmark_table.py
@@ -1,0 +1,41 @@
+"""create bookmark table
+
+Revision ID: c52a1f469ac7
+Revises: 274270e01613
+Create Date: 2023-01-30 08:53:59.370110
+
+"""
+
+# revision identifiers, used by Alembic.
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c52a1f469ac7"
+down_revision = "274270e01613"
+
+
+def upgrade():
+    op.create_table(
+        "bookmark",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("role_id", sa.Integer(), sa.ForeignKey("role.id"), nullable=False),
+        sa.Column("entity_id", sa.String(length=128), nullable=False),
+        sa.Column(
+            "collection_id",
+            sa.Integer(),
+            sa.ForeignKey("collection.id"),
+            nullable=False,
+        ),
+        sa.UniqueConstraint("role_id", "entity_id"),
+    )
+
+    op.create_index(
+        op.f("ix_bookmark_role_id_collection_id_created_at"),
+        "bookmark",
+        ["role_id", "collection_id", "created_at"],
+    )
+
+
+def downgrade():
+    op.drop_table("bookmark")

--- a/aleph/model/__init__.py
+++ b/aleph/model/__init__.py
@@ -9,4 +9,5 @@ from aleph.model.event import Event, Events  # noqa
 from aleph.model.mapping import Mapping  # noqa
 from aleph.model.entityset import EntitySet, EntitySetItem, Judgement  # noqa
 from aleph.model.export import Export  # noqa
+from aleph.model.bookmark import Bookmark  # noqa
 from aleph.model.common import Status, make_token  # noqa

--- a/aleph/model/bookmark.py
+++ b/aleph/model/bookmark.py
@@ -19,3 +19,9 @@ class Bookmark(db.Model, IdModel):
             "entity_id": self.entity_id,
             "collection_id": self.collection_id,
         }
+
+    @classmethod
+    def delete_by_entity(cls, entity_id):
+        query = db.session.query(Bookmark)
+        query = query.filter(Bookmark.entity_id == entity_id)
+        query.delete(synchronize_session=False)

--- a/aleph/model/bookmark.py
+++ b/aleph/model/bookmark.py
@@ -1,0 +1,21 @@
+from datetime import datetime
+from normality import stringify
+from aleph.core import db
+from aleph.model.common import ENTITY_ID_LEN, IdModel
+
+
+class Bookmark(db.Model, IdModel):
+    """A bookmark of an entity created by a user."""
+
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    role_id = db.Column(db.Integer, db.ForeignKey("role.id"))
+    collection_id = db.Column(db.Integer, db.ForeignKey("collection.id"))
+    entity_id = db.Column(db.String(ENTITY_ID_LEN))
+
+    def to_dict(self):
+        return {
+            "id": stringify(self.id),
+            "created_at": self.created_at,
+            "entity_id": self.entity_id,
+            "collection_id": self.collection_id,
+        }

--- a/aleph/tests/test_bookmarks_api.py
+++ b/aleph/tests/test_bookmarks_api.py
@@ -1,0 +1,224 @@
+import json
+import datetime
+from aleph.index.entities import index_entity
+from aleph.tests.util import TestCase, JSON
+from aleph.model import Bookmark
+from aleph.core import db
+
+
+class BookmarksApiTestCase(TestCase):
+    def setUp(self):
+        super(BookmarksApiTestCase, self).setUp()
+
+        self.role, self.headers = self.login()
+        self.collection = self.create_collection(self.role, label="Politicians")
+
+        data = {"schema": "Person", "properties": {"name": "Angela Merkel"}}
+        self.entity = self.create_entity(data=data, collection=self.collection)
+        index_entity(self.entity)
+
+    def test_bookmarks_index_auth(self):
+        res = self.client.get("/api/2/bookmarks")
+        assert res.status_code == 403, res
+
+        res = self.client.get("/api/2/bookmarks", headers=self.headers)
+        assert res.status_code == 200, res
+        assert res.json["total"] == 0, res.json
+
+    def test_bookmarks_index_results(self):
+        other_role, _ = self.login("tester2")
+        other_entity = self.create_entity(
+            data={"schema": "Person", "properties": {"name": "Barack Obama"}},
+            collection=self.collection,
+        )
+        index_entity(other_entity)
+
+        bookmarks = [
+            Bookmark(
+                entity_id=self.entity.id,
+                collection_id=self.entity.collection_id,
+                role_id=self.role.id,
+            ),
+            Bookmark(
+                entity_id=other_entity.id,
+                collection_id=self.entity.collection_id,
+                role_id=other_role.id,
+            ),
+        ]
+        db.session.add_all(bookmarks)
+        db.session.commit()
+
+        res = self.client.get("/api/2/bookmarks", headers=self.headers)
+        assert res.status_code == 200, res
+        assert res.json["total"] == 1, res.json
+        entity = res.json["results"][0]["entity"]
+        assert entity["properties"]["name"][0] == "Angela Merkel", res.json
+
+    def test_bookmarks_index_order(self):
+        other_entity = self.create_entity(
+            data={"schema": "Person", "properties": {"name": "Barack Obama"}},
+            collection=self.collection,
+        )
+        index_entity(other_entity)
+
+        old_bookmark = Bookmark(
+            entity_id=self.entity.id,
+            collection_id=self.entity.collection_id,
+            role_id=self.role.id,
+            created_at=datetime.date(2005, 11, 22),
+        )
+        new_bookmark = Bookmark(
+            entity_id=other_entity.id,
+            collection_id=other_entity.collection_id,
+            role_id=self.role.id,
+            created_at=datetime.date(2009, 1, 20),
+        )
+        db.session.add_all([old_bookmark, new_bookmark])
+        db.session.commit()
+
+        res = self.client.get("/api/2/bookmarks", headers=self.headers)
+        assert res.status_code == 200, res
+        assert res.json["total"] == 2, res.json
+        first = res.json["results"][0]["entity"]
+        second = res.json["results"][1]["entity"]
+        assert first["properties"]["name"][0] == "Barack Obama", first
+        assert second["properties"]["name"][0] == "Angela Merkel", second
+
+    def test_bookmarks_index_access(self):
+        other_role = self.create_user(foreign_id="other")
+        secret_collection = self.create_collection(other_role, label="Top Secret")
+
+        data = {"schema": "Person", "properties": {"name": ["Mister X"]}}
+        secret_entity = self.create_entity(data, secret_collection)
+        index_entity(secret_entity)
+
+        bookmark = Bookmark(
+            entity_id=secret_entity.id,
+            collection_id=secret_entity.collection_id,
+            role_id=self.role.id,
+        )
+        db.session.add(bookmark)
+        db.session.commit()
+
+        res = self.client.get("/api/2/bookmarks", headers=self.headers)
+
+        assert res.status_code == 200, res
+        assert res.json["total"] == 0, res.json
+        assert len(res.json["results"]) == 0, res.json
+
+    def test_bookmarks_create(self):
+        count = Bookmark.query.count()
+        assert count == 0, count
+
+        res = self.client.post(
+            "/api/2/bookmarks",
+            headers=self.headers,
+            data=json.dumps({"entity_id": self.entity.id}),
+            content_type=JSON,
+        )
+        assert res.status_code == 201, res
+        entity = res.json.get("entity")
+        assert entity["properties"]["name"][0] == "Angela Merkel", res.json
+
+        count = Bookmark.query.count()
+        assert count == 1, count
+        bookmark = Bookmark.query.first()
+        assert bookmark.entity_id == self.entity.id, bookmark.entity_id
+        assert bookmark.role_id == self.role.id, bookmark.role_id
+
+    def test_bookmarks_create_validate_access(self):
+        other_role = self.create_user(foreign_id="other")
+        secret_collection = self.create_collection(other_role, label="Top Secret")
+
+        data = {"schema": "Person", "properties": {"name": ["Mister X"]}}
+        secret_entity = self.create_entity(data, secret_collection)
+        index_entity(secret_entity)
+
+        res = self.client.post(
+            "/api/2/bookmarks",
+            headers=self.headers,
+            data=json.dumps({"entity_id": secret_entity.id}),
+            content_type=JSON,
+        )
+        assert res.status_code == 400, res
+        message = res.json["message"]
+        assert message.startswith("Could not bookmark the given entity"), message
+
+        count = Bookmark.query.count()
+        assert count == 0, count
+
+    def test_bookmarks_create_validate_exists(self):
+        invalid_entity_id = self.create_entity(
+            {"schema": "Company"}, self.collection
+        ).id
+
+        res = self.client.post(
+            "/api/2/bookmarks",
+            headers=self.headers,
+            data=json.dumps({"entity_id": invalid_entity_id}),
+            content_type=JSON,
+        )
+        assert res.status_code == 400, res
+        message = res.json["message"]
+        assert message.startswith("Could not bookmark the given entity"), message
+
+        count = Bookmark.query.count()
+        assert count == 0, count
+
+    def test_bookmarks_create_idempotent(self):
+        count = Bookmark.query.count()
+        assert count == 0, count
+
+        res = self.client.post(
+            "/api/2/bookmarks",
+            headers=self.headers,
+            data=json.dumps({"entity_id": self.entity.id}),
+            content_type=JSON,
+        )
+        assert res.status_code == 201
+
+        count = Bookmark.query.count()
+        assert count == 1, count
+
+        res = self.client.post(
+            "/api/2/bookmarks",
+            headers=self.headers,
+            data=json.dumps({"entity_id": self.entity.id}),
+            content_type=JSON,
+        )
+        assert res.status_code == 201
+
+        count = Bookmark.query.count()
+        assert count == 1, count
+
+    def test_bookmarks_delete(self):
+        bookmark = Bookmark(
+            entity_id=self.entity.id,
+            collection_id=self.entity.collection_id,
+            role_id=self.role.id,
+        )
+        db.session.add(bookmark)
+        db.session.commit()
+
+        count = Bookmark.query.count()
+        assert count == 1, count
+
+        res = self.client.delete(
+            f"/api/2/bookmarks/{self.entity.id}", headers=self.headers
+        )
+        assert res.status_code == 204, res
+
+        count = Bookmark.query.count()
+        assert count == 0, count
+
+    def test_bookmarks_delete_idempotent(self):
+        count = Bookmark.query.count()
+        assert count == 0, count
+
+        res = self.client.delete(
+            f"/api/2/bookmarks/{self.entity.id}", headers=self.headers
+        )
+        assert res.status_code == 204, res
+
+        count = Bookmark.query.count()
+        assert count == 0, count

--- a/aleph/tests/util.py
+++ b/aleph/tests/util.py
@@ -5,6 +5,7 @@ import logging
 import unittest
 import tempfile
 from flask import json
+import flask_migrate
 from pathlib import Path
 from tempfile import mkdtemp
 from datetime import datetime
@@ -223,7 +224,7 @@ class TestCase(unittest.TestCase):
         if not hasattr(SETTINGS, "_global_test_state"):
             SETTINGS._global_test_state = True
             destroy_db()
-            db.create_all()
+            flask_migrate.upgrade()
             delete_index()
             upgrade_search()
         else:

--- a/aleph/validation/schema/bookmark.yml
+++ b/aleph/validation/schema/bookmark.yml
@@ -1,0 +1,27 @@
+BookmarksResponse:
+  type: object
+  allOf:
+    - $ref: "#/components/schemas/QueryResponse"
+  properties:
+    results:
+      type: array
+      items:
+        $ref: "#/components/schemas/Bookmark"
+
+Bookmark:
+  type: object
+  properties:
+    created_at:
+      type: string
+      format: date-time
+    entity:
+      $ref: "#/components/schemas/Entity"
+
+BookmarkCreate:
+  type: object
+  properties:
+    entity_id:
+      type: string
+      format: entity-id
+  required:
+    - entity_id

--- a/aleph/validation/schema/bookmark.yml
+++ b/aleph/validation/schema/bookmark.yml
@@ -25,3 +25,18 @@ BookmarkCreate:
       format: entity-id
   required:
     - entity_id
+
+BookmarkMigrate:
+  type: array
+  items:
+    type: object
+    properties:
+      entity_id:
+        type: string
+        format: entity-id
+      created_at:
+        type: string
+        format: date-time
+    required:
+      - entity_id
+      - created_at

--- a/aleph/validation/schema/entity.yml
+++ b/aleph/validation/schema/entity.yml
@@ -79,6 +79,8 @@ Entity:
     writeable:
       type: boolean
       example: false
+    bookmarked:
+      type: boolean
 
 EntityUpdate:
   required: ["schema"]

--- a/aleph/views/bookmarks_api.py
+++ b/aleph/views/bookmarks_api.py
@@ -1,51 +1,125 @@
 import logging
 from flask import Blueprint, request
-from aleph.views.util import jsonify, require
+from werkzeug.exceptions import NotFound, Forbidden, BadRequest
+
+from aleph.core import db
+from aleph.search import DatabaseQueryResult
+from aleph.views.util import jsonify, require, parse_request, get_index_entity
+from aleph.views.serializers import BookmarkSerializer
+from aleph.model import Bookmark
 
 
 log = logging.getLogger(__name__)
 blueprint = Blueprint("bookmarks_api", __name__)
 
 
+@blueprint.route("/api/2/bookmarks", methods=["GET"])
+def index():
+    """Get a list of bookmarks created by the current role
+    ---
+    get:
+      summary: Get bookmarks
+      tags: [Bookmarks]
+      parameters:
+        - in: query
+          name: limit
+          description: Number of bookmarks to return
+          schema:
+            type: number
+        - in: query
+          name: offset
+          description: Number of bookmarks to skip
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BookmarksResponse'
+    """
+    authz = request.authz
+    require(authz.logged_in)
+    collection_ids = authz.collections(authz.READ)
+
+    query = Bookmark.query.filter(
+        Bookmark.role_id == request.authz.id,
+        Bookmark.collection_id.in_(collection_ids),
+    ).order_by(Bookmark.created_at.desc())
+    result = DatabaseQueryResult(request, query)
+    return BookmarkSerializer.jsonify_result(result)
+
+
 @blueprint.route("/api/2/bookmarks", methods=["POST"])
 def create():
-    """Creates a new bookmark for the user. This is currently a stub endpoint,
-    as the current version of the bookmarks features stores bookmarks client side.
+    """Bookmark one or more entities.
     ---
     post:
       summary: Create bookmark
+      tags: [Bookmarks]
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BookmarkCreate'
       responses:
         '200':
+          description: OK
           content:
             application/json:
               schema:
-                type: object
-          description: OK
-      tags:
-        - Bookmarks
+                $ref: '#/components/schemas/Bookmark'
     """
-    require(request.authz.logged_in)
-    log.info("User [%s]: Created bookmark", request.authz.role.id)
-    return jsonify({}, 200)
+    require(request.authz.session_write)
+    data = parse_request("BookmarkCreate")
+    entity_id = data.get("entity_id")
+
+    try:
+        entity = get_index_entity(entity_id, request.authz.READ)
+    except (NotFound, Forbidden):
+        raise BadRequest(
+            "Could not bookmark the given entity as the entity does not exist or you do not have access."
+        )
+
+    query = Bookmark.query.filter_by(entity_id=entity_id, role_id=request.authz.id)
+    bookmark = query.first()
+
+    if not bookmark:
+        bookmark = Bookmark(
+            entity_id=entity_id,
+            collection_id=entity.get("collection_id"),
+            role_id=request.authz.id,
+        )
+
+        db.session.add(bookmark)
+        db.session.commit()
+
+    serializer = BookmarkSerializer()
+    response = serializer.serialize(bookmark)
+    return jsonify(response, status=201)
 
 
-@blueprint.route("/api/2/bookmarks/<bookmark_id>", methods=["DELETE"])
-def delete(bookmark_id):
-    """Delete a bookmark. This is currently a stub endpoint, as the current version
-    of the bookmarks features stores bookmarks client side.
+@blueprint.route("/api/2/bookmarks/<entity_id>", methods=["DELETE"])
+def delete(entity_id):
+    """Delete a bookmark.
     ---
     delete:
       summary: Delete bookmark
+      tags: [Bookmarks]
+      parameters:
+        - in: path
+          name: entity_id
+          description: ID of the bookmarked entitiy
+          required: true
+          schema:
+            type: string
       responses:
-        '200':
-          content:
-            application/json:
-              schema:
-                type: object
-          description: OK
-      tags:
-        - Bookmarks
+        '204':
+          description: No content
     """
-    require(request.authz.logged_in)
-    log.info("User [%s]: Deleted bookmark", request.authz.role.id)
-    return jsonify({}, 200)
+    require(request.authz.session_write)
+
+    query = Bookmark.query.filter_by(entity_id=entity_id, role_id=request.authz.id)
+    query.delete()
+    db.session.commit()
+
+    return "", 204

--- a/aleph/views/bookmarks_api.py
+++ b/aleph/views/bookmarks_api.py
@@ -176,5 +176,6 @@ def migrate():
         index_elements=[Bookmark.role_id, Bookmark.entity_id],
     )
     db.session.execute(stmt)
+    db.session.commit()
 
     return jsonify({"errors": errors}, 201)

--- a/aleph/views/entities_api.py
+++ b/aleph/views/entities_api.py
@@ -16,6 +16,7 @@ from aleph.logic.expand import entity_tags, expand_proxies
 from aleph.logic.html import sanitize_html
 from aleph.logic.export import create_export
 from aleph.model.entityset import EntitySet, Judgement
+from aleph.model.bookmark import Bookmark
 from aleph.index.util import MAX_PAGE
 from aleph.views.util import get_index_entity, get_db_collection
 from aleph.views.util import jsonify, parse_request, get_flag
@@ -309,6 +310,15 @@ def view(entity_id):
     encoding = proxy.first("encoding", quiet=True)
     entity["safeHtml"] = sanitize_html(html, source_url, encoding=encoding)
     entity["shallow"] = False
+
+    if request.authz.logged_in:
+        bookmark = Bookmark.query.filter_by(
+            role_id=request.authz.id,
+            collection_id=entity.get("collection_id"),
+            entity_id=entity_id,
+        ).first()
+        entity["bookmarked"] = True if bookmark else False
+
     return EntitySerializer.jsonify(entity)
 
 

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -400,3 +400,22 @@ class MappingSerializer(Serializer):
         obj["entityset"] = self.resolve(EntitySet, entityset_id, EntitySetSerializer)
         obj["table"] = self.resolve(Entity, obj.get("table_id", None), EntitySerializer)
         return obj
+
+
+class BookmarkSerializer(Serializer):
+    def collect(self, obj):
+        self.queue(Entity, obj.get("entity_id"))
+
+    def _serialize(self, obj):
+        obj["entity"] = self.resolve(Entity, obj.get("entity_id"), EntitySerializer)
+
+        # Entity could not be resolved, for example because it has been
+        # removed or permissions have changed.
+        if not obj["entity"]:
+            return None
+
+        obj.pop("id", None)
+        obj.pop("entity_id", None)
+        obj.pop("collection_id", None)
+        obj.pop("writeable", None)
+        return obj

--- a/aleph/views/serializers.py
+++ b/aleph/views/serializers.py
@@ -414,7 +414,7 @@ class BookmarkSerializer(Serializer):
         if not obj["entity"]:
             return None
 
-        obj.pop("id", None)
+        obj["id"] = obj["entity"]["id"]
         obj.pop("entity_id", None)
         obj.pop("collection_id", None)
         obj.pop("writeable", None)

--- a/ui/src/actions/bookmarkActions.js
+++ b/ui/src/actions/bookmarkActions.js
@@ -1,5 +1,11 @@
 import { endpoint } from 'app/api';
 import asyncActionCreator from './asyncActionCreator';
+import { queryEndpoint } from './util';
+
+export const queryBookmarks = asyncActionCreator(
+  (payload) => async () => queryEndpoint(payload),
+  { name: 'QUERY_BOOKMARKS' }
+);
 
 export const createBookmark = asyncActionCreator(
   (entity) => async () =>

--- a/ui/src/actions/bookmarkActions.js
+++ b/ui/src/actions/bookmarkActions.js
@@ -17,3 +17,15 @@ export const deleteBookmark = asyncActionCreator(
   (entity) => async () => await endpoint.delete(`bookmarks/${entity.id}`),
   { name: 'DELETE_BOOKMARK' }
 );
+
+export const migrateLocalBookmarks = asyncActionCreator(
+  (bookmarks) => async () => {
+    const body = bookmarks.map((bookmark) => ({
+      entity_id: bookmark.id,
+      created_at: new Date(bookmark.bookmarkedAt).toISOString(),
+    }));
+    const response = await endpoint.post('bookmarks/migrate', body);
+    return { bookmarks, response };
+  },
+  { name: 'MIGRATE_BOOKMARKS' }
+);

--- a/ui/src/actions/bookmarkActions.js
+++ b/ui/src/actions/bookmarkActions.js
@@ -2,17 +2,12 @@ import { endpoint } from 'app/api';
 import asyncActionCreator from './asyncActionCreator';
 
 export const createBookmark = asyncActionCreator(
-  (entity) => async () => {
-    await endpoint.post('bookmarks');
-    return entity;
-  },
+  (entity) => async () =>
+    await endpoint.post('bookmarks', { entity_id: entity.id }),
   { name: 'CREATE_BOOKMARK' }
 );
 
 export const deleteBookmark = asyncActionCreator(
-  (entity) => async () => {
-    await endpoint.delete('bookmarks/123');
-    return entity;
-  },
+  (entity) => async () => await endpoint.delete(`bookmarks/${entity.id}`),
   { name: 'DELETE_BOOKMARK' }
 );

--- a/ui/src/actions/index.js
+++ b/ui/src/actions/index.js
@@ -70,6 +70,7 @@ export {
   queryBookmarks,
   createBookmark,
   deleteBookmark,
+  migrateLocalBookmarks,
 } from './bookmarkActions';
 
 export { createAction };

--- a/ui/src/actions/index.js
+++ b/ui/src/actions/index.js
@@ -66,7 +66,11 @@ export {
 } from './metadataActions';
 export { loginWithToken, loginWithPassword, logout } from './sessionActions';
 export { fetchExports, triggerQueryExport } from './exportActions';
-export { createBookmark, deleteBookmark } from './bookmarkActions';
+export {
+  queryBookmarks,
+  createBookmark,
+  deleteBookmark,
+} from './bookmarkActions';
 
 export { createAction };
 export const setLocale = createAction('SET_LOCALE');

--- a/ui/src/app/storage.js
+++ b/ui/src/app/storage.js
@@ -1,7 +1,19 @@
 export const loadState = () => {
   try {
-    const storedState = localStorage.getItem('state');
-    return storedState ? JSON.parse(storedState) : {};
+    const json = localStorage.getItem('state');
+
+    if (!json) {
+      return {};
+    }
+
+    const storedState = JSON.parse(json);
+
+    // TODO: Remove after deadline
+    // See https://github.com/alephdata/aleph/issues/2864
+    storedState.localBookmarks = storedState.bookmarks;
+    delete storedState.bookmarks;
+
+    return storedState;
   } catch (e) {
     // eslint-disable-next-line
     console.error('could not load state', e);

--- a/ui/src/app/store.js
+++ b/ui/src/app/store.js
@@ -21,12 +21,15 @@ const store = createStore(
 
 store.subscribe(
   throttle(() => {
-    const { session, config, messages, bookmarks } = store.getState();
+    const { session, config, messages, localBookmarks } = store.getState();
 
     saveState({
       session,
       config,
-      bookmarks,
+
+      // TODO: Remove after deadline
+      // See https://github.com/alephdata/aleph/issues/2864
+      bookmarks: localBookmarks,
 
       // Do not persist the actual messages, only the dismissed message IDs.
       messages: { ...messages, messages: [] },

--- a/ui/src/components/common/BookmarkButton.tsx
+++ b/ui/src/components/common/BookmarkButton.tsx
@@ -1,9 +1,8 @@
-import { FC, useState } from 'react';
+import { FC } from 'react';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { injectIntl, FormattedMessage } from 'react-intl';
-import { Intent, Button, ButtonProps } from '@blueprintjs/core';
-import { Popover2 as Popover, Classes } from '@blueprintjs/popover2';
+import { Button, ButtonProps } from '@blueprintjs/core';
 import { Entity } from '@alephdata/followthemoney';
 
 import {
@@ -11,30 +10,23 @@ import {
   selectExperimentalBookmarksFeatureEnabled,
 } from 'selectors';
 import { createBookmark, deleteBookmark } from 'actions/bookmarkActions';
-import { setConfigValue } from 'actions/configActions';
 
 type BookmarkButtonProps = ButtonProps & {
   bookmarked: boolean;
   entity: Entity;
   enabled: boolean;
-  showWarning: boolean;
   createBookmark: (entity: Entity) => Promise<any>;
   deleteBookmark: (entity: Entity) => Promise<any>;
-  setConfigValue: (payload: object) => any;
 };
 
 const BookmarkButton: FC<BookmarkButtonProps> = ({
   entity,
   bookmarked,
   enabled,
-  showWarning,
   createBookmark,
   deleteBookmark,
-  setConfigValue,
   ...props
 }) => {
-  const [showPopover, setShowPopover] = useState(false);
-
   if (!enabled) {
     return null;
   }
@@ -48,56 +40,13 @@ const BookmarkButton: FC<BookmarkButtonProps> = ({
 
   const toggle = async () => {
     const action = bookmarked ? deleteBookmark : createBookmark;
-
-    if (!bookmarked && showWarning) {
-      setShowPopover(true);
-    }
-
     await action(entity);
   };
 
-  const popoverContent = (
-    <>
-      <p>
-        <FormattedMessage
-          id="bookmarks.popover.line1"
-          defaultMessage="Yay, you found the new bookmark button! 🎉"
-        />
-      </p>
-      <p>
-        <FormattedMessage
-          id="bookmarks.popover.line2"
-          defaultMessage="This is still an <strong>experimental feature</strong>. Bookmarks are only stored in your browser. If you delete your browsing data or switch devices, you may lose access to your bookmarks."
-          values={{ strong: (chunks) => <strong>{chunks}</strong> }}
-        />
-      </p>
-      <Button
-        fill
-        intent={Intent.PRIMARY}
-        onClick={() => {
-          setConfigValue({ bookmarksWarningDismissed: true });
-          setShowPopover(false);
-        }}
-      >
-        <FormattedMessage
-          id="bookmarks.popover.confirm"
-          defaultMessage="Okay, I understand!"
-        />
-      </Button>
-    </>
-  );
-
   return (
-    <Popover
-      content={popoverContent}
-      placement="bottom"
-      isOpen={showPopover}
-      popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
-    >
-      <Button icon={icon} onClick={toggle} {...props}>
-        {label}
-      </Button>
-    </Popover>
+    <Button icon={icon} onClick={toggle} {...props}>
+      {label}
+    </Button>
   );
 };
 
@@ -105,16 +54,11 @@ const mapStateToProps = (state: any, ownProps: BookmarkButtonProps) => {
   const { entity } = ownProps;
   const bookmarked = selectEntityBookmarked(state, entity);
   const enabled = selectExperimentalBookmarksFeatureEnabled(state);
-  const showWarning = !state.config.bookmarksWarningDismissed;
 
-  return {
-    bookmarked,
-    enabled,
-    showWarning,
-  };
+  return { bookmarked, enabled };
 };
 
 export default compose(
-  connect(mapStateToProps, { createBookmark, deleteBookmark, setConfigValue }),
+  connect(mapStateToProps, { createBookmark, deleteBookmark }),
   injectIntl
 )(BookmarkButton);

--- a/ui/src/components/common/BookmarksDrawer.scss
+++ b/ui/src/components/common/BookmarksDrawer.scss
@@ -1,6 +1,10 @@
 @import 'app/variables.scss';
 
 .BookmarksDrawer__content {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  min-height: 100%;
   padding: 2 * $aleph-grid-size;
 }
 

--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -1,6 +1,9 @@
 import { FC } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { useSelector } from 'react-redux';
 import { Classes, Drawer, DrawerSize } from '@blueprintjs/core';
+import { selectLocalBookmarks, selectConfigValue } from 'selectors';
+import BookmarksMigration from './BookmarksMigration';
 import BookmarksList from './BookmarksList';
 
 import './BookmarksDrawer.scss';
@@ -14,6 +17,12 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
   isOpen,
   toggleDialog,
 }) => {
+  const localBookmarks = useSelector(selectLocalBookmarks);
+  const migrationCompleted = useSelector((state) =>
+    selectConfigValue(state, 'bookmarksMigrationCompleted')
+  );
+  const showMigration = localBookmarks.length > 0 && !migrationCompleted;
+
   const title = (
     <FormattedMessage id="bookmarks.title" defaultMessage="Your bookmarks" />
   );
@@ -30,7 +39,11 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
     >
       <div className={Classes.DRAWER_BODY}>
         <div className="BookmarksDrawer__content">
-          <BookmarksList onNavigate={toggleDialog} />
+          {showMigration ? (
+            <BookmarksMigration />
+          ) : (
+            <BookmarksList onNavigate={toggleDialog} />
+          )}
         </div>
       </div>
     </Drawer>

--- a/ui/src/components/common/BookmarksDrawer.tsx
+++ b/ui/src/components/common/BookmarksDrawer.tsx
@@ -1,75 +1,18 @@
 import { FC } from 'react';
-import { compose } from 'redux';
-import { connect } from 'react-redux';
-import downloadFile from 'js-file-download';
-import {
-  FormattedMessage,
-  injectIntl,
-  useIntl,
-  defineMessage,
-} from 'react-intl';
-import { Button, Drawer, DrawerSize, Callout, Intent } from '@blueprintjs/core';
-
-import { selectBookmarks } from 'selectors';
+import { FormattedMessage } from 'react-intl';
+import { Classes, Drawer, DrawerSize } from '@blueprintjs/core';
 import BookmarksList from './BookmarksList';
 
 import './BookmarksDrawer.scss';
 
-type Bookmark = {
-  id: string;
-  caption: string;
-  bookmarkedAt: number;
-};
-
 type BookmarksDrawerProps = {
   isOpen: boolean;
   toggleDialog: () => void;
-  bookmarks: Array<Bookmark>;
-};
-
-type DownloadButtonProps = Button['props'] & {
-  bookmarks: Array<Bookmark>;
-};
-
-const downloadHeading = defineMessage({
-  id: 'bookmarks.download.heading',
-  defaultMessage: 'Your bookmarks',
-});
-
-const DownloadButton: FC<DownloadButtonProps> = ({
-  bookmarks,
-  ...buttonProps
-}) => {
-  const { formatDate, formatTime, formatMessage } = useIntl();
-
-  const download = () => {
-    const items = bookmarks.map(({ caption, bookmarkedAt, id }) =>
-      [
-        caption,
-        `${formatDate(bookmarkedAt)} ${formatTime(bookmarkedAt)}`,
-        new URL(`/entities/${id}`, window.location.href),
-      ].join('\n')
-    );
-
-    const heading = formatMessage(downloadHeading).toUpperCase();
-    const contents = `${heading}\n\n${items.join('\n\n')}`;
-    downloadFile(contents, 'bookmarks.txt');
-  };
-
-  return (
-    <Button onClick={download} {...buttonProps}>
-      <FormattedMessage
-        id="bookmarks.download"
-        defaultMessage="Download bookmarks"
-      />
-    </Button>
-  );
 };
 
 const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
   isOpen,
   toggleDialog,
-  bookmarks,
 }) => {
   const title = (
     <FormattedMessage id="bookmarks.title" defaultMessage="Your bookmarks" />
@@ -85,46 +28,13 @@ const BookmarksDrawer: FC<BookmarksDrawerProps> = ({
       hasBackdrop={false}
       canOutsideClickClose={true}
     >
-      <div className="BookmarksDrawer__content">
-        <Callout intent={Intent.WARNING} icon={null}>
-          <p>
-            <strong>
-              <FormattedMessage
-                id="bookmarks.warning.heading"
-                defaultMessage="Bookmarks are an experimental feature."
-              />
-            </strong>
-          </p>
-          <p>
-            <FormattedMessage
-              id="bookmarks.warning.text"
-              defaultMessage="Bookmarks are only stored in your browser. If you delete your browsing data or switch devices, you may lose access to your bookmarks. You can download your bookmarks at any time."
-            />
-          </p>
-        </Callout>
-
-        {bookmarks.length > 0 && (
-          <>
-            <DownloadButton icon="archive" fill bookmarks={bookmarks} />
-            <BookmarksList bookmarks={bookmarks} onNavigate={toggleDialog} />
-          </>
-        )}
-
-        {bookmarks.length <= 0 && (
-          <Callout intent={Intent.PRIMARY} icon={null}>
-            <FormattedMessage
-              id="bookmarks.empty"
-              defaultMessage="You haven’t bookmarked anything yet. Add documents or entities such as people or companies to your bookmarks to easily get back to them later."
-            />
-          </Callout>
-        )}
+      <div className={Classes.DRAWER_BODY}>
+        <div className="BookmarksDrawer__content">
+          <BookmarksList onNavigate={toggleDialog} />
+        </div>
       </div>
     </Drawer>
   );
 };
 
-const mapStateToProps = (state: any) => {
-  return { bookmarks: selectBookmarks(state) };
-};
-
-export default compose(connect(mapStateToProps), injectIntl)(BookmarksDrawer);
+export default BookmarksDrawer;

--- a/ui/src/components/common/BookmarksList.scss
+++ b/ui/src/components/common/BookmarksList.scss
@@ -26,3 +26,7 @@
 .BookmarksList__meta {
   color: $aleph-greyed-text;
 }
+
+.BookmarksList__spinner {
+  width: 100%;
+}

--- a/ui/src/components/common/BookmarksList.tsx
+++ b/ui/src/components/common/BookmarksList.tsx
@@ -1,42 +1,80 @@
-import { FC } from 'react';
+import { FC, useEffect, useMemo, useCallback } from 'react';
 import { Link } from 'react-router-dom';
+import { useSelector, useDispatch } from 'react-redux';
+import { Callout, Intent, Spinner } from '@blueprintjs/core';
+import { FormattedMessage } from 'react-intl';
 import RelativeTime from './RelativeTime';
+import { selectBookmarksResult } from 'selectors';
+import { queryBookmarks } from 'actions';
+import Query from 'app/Query';
+import { QueryInfiniteLoad } from 'components/common';
 
 import './BookmarksList.scss';
 
-type Bookmark = {
-  id: string;
-  caption: string;
-  bookmarkedAt: number;
-};
-
 type BookmarksListProps = {
-  bookmarks: Array<Bookmark>;
   onNavigate: () => void;
 };
 
-const BookmarksList: FC<BookmarksListProps> = ({ bookmarks, onNavigate }) => {
+const BookmarksList: FC<BookmarksListProps> = ({ onNavigate }) => {
+  const dispatch = useDispatch();
+  const query = useMemo(() => new Query('bookmarks', {}), []);
+  const result = useSelector((state) => selectBookmarksResult(state, query));
+  const loadBookmarks = useCallback(
+    (payload: any) => queryBookmarks(payload)(dispatch),
+    [dispatch]
+  );
+  const shouldLoad = result.shouldLoad;
+
+  useEffect(() => {
+    if (shouldLoad) {
+      loadBookmarks({ query });
+    }
+  }, [loadBookmarks, shouldLoad, query]);
+
+  if (!result.status && result.isPending) {
+    return <Spinner className="BookmarksList__spinner" size={100} />;
+  }
+
+  if (result.total <= 0) {
+    return (
+      <Callout intent={Intent.PRIMARY} icon={null}>
+        <FormattedMessage
+          id="bookmarks.empty"
+          defaultMessage="You haven’t bookmarked anything yet. Add documents or entities such as people or companies to your bookmarks to easily get back to them later."
+        />
+      </Callout>
+    );
+  }
+
   return (
-    <ul className="BookmarksList">
-      {bookmarks.map((bookmark) => (
-        <li key={bookmark.id}>
-          <Link
-            className="BookmarksList__caption"
-            to={`/entities/${bookmark.id}`}
-            onClick={onNavigate}
-          >
-            {bookmark.caption}
-          </Link>
-          <div className="BookmarksList__meta">
-            {'bookmarked '}
-            <RelativeTime
-              date={new Date(bookmark.bookmarkedAt)}
-              utcDate={null}
-            />
-          </div>
-        </li>
-      ))}
-    </ul>
+    <>
+      <ul className="BookmarksList">
+        {result.results.map((bookmark: any) => (
+          <li key={bookmark.entity.id}>
+            <Link
+              className="BookmarksList__caption"
+              to={`/entities/${bookmark.entity.id}`}
+              onClick={onNavigate}
+            >
+              {bookmark.entity.getCaption()}
+            </Link>
+            <div className="BookmarksList__meta">
+              {'bookmarked '}
+              <RelativeTime
+                date={new Date(bookmark.created_at)}
+                utcDate={null}
+              />
+            </div>
+          </li>
+        ))}
+      </ul>
+      <QueryInfiniteLoad
+        query={query}
+        result={result}
+        fetch={loadBookmarks}
+        scrollableAncestor={null}
+      />
+    </>
   );
 };
 

--- a/ui/src/components/common/BookmarksMigration.scss
+++ b/ui/src/components/common/BookmarksMigration.scss
@@ -1,0 +1,4 @@
+.BookmarksMigration__spinner {
+  align-self: center;
+  margin: auto;
+}

--- a/ui/src/components/common/BookmarksMigration.tsx
+++ b/ui/src/components/common/BookmarksMigration.tsx
@@ -62,8 +62,8 @@ const BookmarksMigration: FC = () => {
     return (
       <NonIdealState
         icon="star"
-        title="Changes to bookmarks"
-        description="We have recently rolled out enhancements for bookmarks! Bookmarks are now more reliable and sync across all your devices."
+        title="We’ve updated bookmarks"
+        description="Your bookmarks will now synchronize across all your devices."
         action={
           <Button
             onClick={() => {
@@ -82,23 +82,23 @@ const BookmarksMigration: FC = () => {
     return (
       <NonIdealState
         icon="warning-sign"
-        title="Changes to bookmarks"
+        title="We’ve updated bookmarks"
         description={
           <>
             <p>
-              We have recently rolled out enhancements for bookmarks! This
-              required updating bookmarks to a new storage format.
+              In order to synchronize bookmarks across all your devices, we’ve
+              updated the way your bookmarks are stored.
             </p>
             <p>
               <strong>
                 Unfortunately, {failed.length} out of {succeeded.length}{' '}
-                bookmarks could not be updated to the new format.
+                bookmarks that you had previously created could not be updated.
               </strong>
             </p>
             <p>
-              Most likely that’s because the data you bookmarked has been
-              removed from Aleph. Download a copy of the affected bookmarks
-              to proceed.
+              The most likely reason for this is that the data you bookmarked
+              has been removed from Aleph in the meantime. To proceed, download
+              a copy of the affected bookmarks.
             </p>
           </>
         }

--- a/ui/src/components/common/BookmarksMigration.tsx
+++ b/ui/src/components/common/BookmarksMigration.tsx
@@ -1,0 +1,130 @@
+import { FC, useEffect, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { NonIdealState, Button, Spinner } from '@blueprintjs/core';
+import downloadFile from 'js-file-download';
+import { migrateLocalBookmarks, setConfigValue } from 'actions';
+import { selectLocalBookmarks } from 'selectors';
+
+import './BookmarksMigration.scss';
+
+function downloadBookmarks(bookmarks: Array<any>) {
+  const items = bookmarks.map(({ caption, bookmarkedAt, id }, index) =>
+    [
+      `${index + 1}: ${caption}`,
+      new Date(bookmarkedAt).toISOString(),
+      new URL(`/entities/${id}`, window.location.href),
+    ].join('\n')
+  );
+
+  const heading = 'Bookmarks'.toUpperCase();
+  const contents = `${heading}\n\n${items.join('\n\n')}`;
+  downloadFile(contents, 'bookmarks.txt');
+}
+
+const BookmarksMigration: FC = () => {
+  const localBookmarks = useSelector(selectLocalBookmarks);
+
+  const failed = localBookmarks.filter(
+    (bookmark: any) =>
+      bookmark.migrationAttempted === true &&
+      bookmark.migrationSucceeded === false
+  );
+
+  const succeeded = localBookmarks.filter(
+    (bookmark: any) =>
+      bookmark.migrationAttempted === true &&
+      bookmark.migrationSucceeded === false
+  );
+
+  const migratable = localBookmarks.filter(
+    (bookmark: any) => bookmark.migrationAttempted !== true
+  );
+
+  const [state, setState] = useState<'LOADING' | 'ERROR' | 'DONE'>('DONE');
+  const dispatch = useDispatch();
+
+  useEffect(() => {
+    if (migratable.length <= 0) {
+      return;
+    }
+
+    setState('LOADING');
+    migrateLocalBookmarks(migratable)(dispatch)
+      .then(() => setState('DONE'))
+      .catch(() => setState('ERROR'));
+  }, [migratable, dispatch]);
+
+  if (state === 'LOADING') {
+    return <Spinner className="BookmarksMigration__spinner" size={100} />;
+  }
+
+  if (state === 'DONE' && failed.length <= 0) {
+    return (
+      <NonIdealState
+        icon="star"
+        title="Changes to bookmarks"
+        description="We have recently rolled out enhancements for bookmarks! Bookmarks are now more reliable and sync across all your devices."
+        action={
+          <Button
+            onClick={() => {
+              // @ts-ignore
+              dispatch(setConfigValue({ bookmarksMigrationCompleted: true }));
+            }}
+          >
+            Don’t show this message again
+          </Button>
+        }
+      />
+    );
+  }
+
+  if (state === 'DONE' && failed.length >= 0) {
+    return (
+      <NonIdealState
+        icon="warning-sign"
+        title="Changes to bookmarks"
+        description={
+          <>
+            <p>
+              We have recently rolled out enhancements for bookmarks! This
+              required updating bookmarks to a new storage format.
+            </p>
+            <p>
+              <strong>
+                Unfortunately, {failed.length} out of {succeeded.length}{' '}
+                bookmarks could not be updated to the new format.
+              </strong>
+            </p>
+            <p>
+              Most likely that’s because the data you bookmarked has been
+              removed from Aleph. Download a copy of the affected bookmarks
+              to proceed.
+            </p>
+          </>
+        }
+        action={
+          <Button
+            icon="archive"
+            onClick={() => {
+              downloadBookmarks(failed);
+              // @ts-ignore
+              dispatch(setConfigValue({ bookmarksMigrationCompleted: true }));
+            }}
+          >
+            Download bookmarks
+          </Button>
+        }
+      />
+    );
+  }
+
+  return (
+    <NonIdealState
+      icon="error"
+      title="Error"
+      description="There was an error loading your bookmarks."
+    />
+  );
+};
+
+export default BookmarksMigration;

--- a/ui/src/components/common/QueryInfiniteLoad.jsx
+++ b/ui/src/components/common/QueryInfiniteLoad.jsx
@@ -32,7 +32,11 @@ class QueryInfiniteLoad extends Component {
   }
 
   render() {
-    const { loadOnScroll = true, result } = this.props;
+    const {
+      loadOnScroll = true,
+      result,
+      scrollableAncestor = window,
+    } = this.props;
     const canLoadMore =
       result &&
       result.next &&
@@ -47,7 +51,7 @@ class QueryInfiniteLoad extends Component {
           <Waypoint
             onEnter={this.getMoreResults}
             bottomOffset="-100px"
-            scrollableAncestor={window}
+            scrollableAncestor={scrollableAncestor}
           />
         );
       } else {

--- a/ui/src/reducers/bookmarks.js
+++ b/ui/src/reducers/bookmarks.js
@@ -1,35 +1,13 @@
 import { createReducer } from 'redux-act';
+import { queryBookmarks } from 'actions';
+import { resultObjects } from './util';
 
-import timestamp from 'util/timestamp';
-import { createBookmark, deleteBookmark } from 'actions';
-
-const initialState = [];
+const initialState = {};
 
 export default createReducer(
   {
-    [createBookmark.COMPLETE]: (state, entity) => {
-      if (state.find(({ id }) => id === entity.id)) {
-        return state;
-      }
-
-      return [
-        ...state,
-        {
-          id: entity.id,
-          bookmarkedAt: timestamp(),
-          caption: entity.getCaption(),
-          collection: {
-            id: entity.collection.id,
-            label: entity.collection.label,
-            category: entity.collection.category,
-          },
-        },
-      ];
-    },
-
-    [deleteBookmark.COMPLETE]: (state, entity) => {
-      return state.filter(({ id }) => id !== entity.id);
-    },
+    [queryBookmarks.COMPLETE]: (state, { result }) =>
+      resultObjects(state, result),
   },
   initialState
 );

--- a/ui/src/reducers/entities.js
+++ b/ui/src/reducers/entities.js
@@ -11,6 +11,8 @@ import {
   updateEntity,
   deleteEntity,
   pairwiseJudgement,
+  createBookmark,
+  deleteBookmark,
 } from 'actions';
 import {
   objectLoadStart,
@@ -91,6 +93,16 @@ export default createReducer(
 
     [pairwiseJudgement.COMPLETE]: (state, { entityId, profileId }) =>
       updateEntityProfile(state, entityId, profileId),
+
+    [createBookmark.START]: (state, entity) => ({
+      ...state,
+      [entity.id]: { ...state[entity.id], bookmarked: true },
+    }),
+
+    [deleteBookmark.START]: (state, entity) => ({
+      ...state,
+      [entity.id]: { ...state[entity.id], bookmarked: false },
+    }),
   },
   initialState
 );

--- a/ui/src/reducers/index.js
+++ b/ui/src/reducers/index.js
@@ -20,6 +20,7 @@ import notifications from './notifications';
 import systemStatus from './systemStatus';
 import exports from './exports';
 import bookmarks from './bookmarks';
+import localBookmarks from './localBookmarks';
 
 const rootReducer = combineReducers({
   messages,
@@ -42,6 +43,10 @@ const rootReducer = combineReducers({
   systemStatus,
   exports,
   bookmarks,
+
+  // TODO: Remove after deadline
+  // See https://github.com/alephdata/aleph/issues/2864
+  localBookmarks,
 });
 
 export default rootReducer;

--- a/ui/src/reducers/localBookmarks.js
+++ b/ui/src/reducers/localBookmarks.js
@@ -1,0 +1,7 @@
+// TODO: Remove file after deadline
+// See https://github.com/alephdata/aleph/issues/2864
+
+import { createReducer } from 'redux-act';
+
+const initialState = [];
+export default createReducer({}, initialState);

--- a/ui/src/reducers/localBookmarks.js
+++ b/ui/src/reducers/localBookmarks.js
@@ -2,6 +2,33 @@
 // See https://github.com/alephdata/aleph/issues/2864
 
 import { createReducer } from 'redux-act';
+import { migrateLocalBookmarks } from 'actions';
 
 const initialState = [];
-export default createReducer({}, initialState);
+
+export default createReducer(
+  {
+    [migrateLocalBookmarks.COMPLETE]: (state, { bookmarks, response }) => {
+      const localBookmarks = new Map(
+        state.map((bookmark) => [bookmark.id, bookmark])
+      );
+      const errors = response.data.errors;
+
+      for (const bookmark of bookmarks) {
+        if (!localBookmarks.has(bookmark.id)) {
+          continue;
+        }
+
+        const localBookmark = localBookmarks.get(bookmark.id);
+        localBookmarks.set(bookmark.id, {
+          ...localBookmark,
+          migrationAttempted: true,
+          migrationSucceeded: !errors.includes(bookmark.id),
+        });
+      }
+
+      return [...localBookmarks.values()];
+    },
+  },
+  initialState
+);

--- a/ui/src/reducers/mutation.js
+++ b/ui/src/reducers/mutation.js
@@ -20,39 +20,48 @@ import {
   updateRole,
   deleteAlert,
   createAlert,
+  createBookmark,
+  deleteBookmark,
   loginWithToken,
   logout,
 } from 'actions';
 
-const initialState = timestamp();
+const initialState = {
+  global: timestamp(),
+};
 
-function update() {
-  return timestamp();
+function update(state, key = 'global') {
+  return {
+    ...state,
+    [key]: timestamp(),
+  };
 }
 
 export default createReducer(
   {
-    [forceMutate]: update,
-    [loginWithToken]: update,
-    [logout]: update,
+    [forceMutate]: () => update(),
+    [loginWithToken]: () => update(),
+    [logout]: () => update(),
     // Clear out the redux cache when operations are performed that
     // may affect the content of the results.
-    [createCollection.COMPLETE]: update,
-    [updateCollection.COMPLETE]: update,
-    [deleteCollection.COMPLETE]: update,
-    [createEntityMapping.COMPLETE]: update,
-    [updateEntityMapping.COMPLETE]: update,
-    [deleteEntityMapping.COMPLETE]: update,
-    [triggerCollectionCancel.COMPLETE]: update,
-    [updateCollectionPermissions.COMPLETE]: update,
-    [createEntity.COMPLETE]: update,
-    [createEntitySetMutate.COMPLETE]: update,
-    [updateEntitySetItemMutate.COMPLETE]: update,
-    [deleteEntity.COMPLETE]: update,
-    [deleteEntitySet.COMPLETE]: update,
-    [updateRole.COMPLETE]: update,
-    [createAlert.COMPLETE]: update,
-    [deleteAlert.COMPLETE]: update,
+    [createCollection.COMPLETE]: () => update(),
+    [updateCollection.COMPLETE]: () => update(),
+    [deleteCollection.COMPLETE]: () => update(),
+    [createEntityMapping.COMPLETE]: () => update(),
+    [updateEntityMapping.COMPLETE]: () => update(),
+    [deleteEntityMapping.COMPLETE]: () => update(),
+    [triggerCollectionCancel.COMPLETE]: () => update(),
+    [updateCollectionPermissions.COMPLETE]: () => update(),
+    [createEntity.COMPLETE]: () => update(),
+    [createEntitySetMutate.COMPLETE]: () => update(),
+    [updateEntitySetItemMutate.COMPLETE]: () => update(),
+    [deleteEntity.COMPLETE]: () => update(),
+    [deleteEntitySet.COMPLETE]: () => update(),
+    [updateRole.COMPLETE]: () => update(),
+    [createAlert.COMPLETE]: () => update(),
+    [deleteAlert.COMPLETE]: () => update(),
+    [createBookmark.COMPLETE]: (state) => update(state, 'bookmarks'),
+    [deleteBookmark.COMPLETE]: (state) => update(state, 'bookmarks'),
   },
   initialState
 );

--- a/ui/src/reducers/results.js
+++ b/ui/src/reducers/results.js
@@ -21,6 +21,7 @@ import {
   queryEntitySetItems,
   queryMappings,
   queryAlerts,
+  queryBookmarks,
 } from 'actions';
 
 const initialState = {};
@@ -99,6 +100,13 @@ export default createReducer(
     [queryMappings.START]: (state, { query }) => resultLoadStart(state, query),
     [queryMappings.ERROR]: (state, { error, args: { query } }) =>
       resultLoadError(state, query, error),
+
+    [queryBookmarks.START]: (state, { query }) => {
+      return resultLoadStart(state, query);
+    },
+    [queryBookmarks.ERROR]: (state, { error, args: { query } }) =>
+      resultLoadError(state, query, error),
+    [queryBookmarks.COMPLETE]: updateResultsKeyed,
   },
   initialState
 );

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -477,3 +477,7 @@ export function selectLocalBookmarks(state) {
     state?.localBookmarks?.sort((a, b) => b.bookmarkedAt - a.bookmarkedAt) || []
   );
 }
+
+export function selectConfigValue(state, name) {
+  return state?.config?.[name];
+}

--- a/ui/src/selectors.js
+++ b/ui/src/selectors.js
@@ -227,6 +227,7 @@ export function selectEntity(state, entityId) {
   result.profileId = entity.profile_id;
   result.lastViewed = lastViewed;
   result.writeable = entity.writeable;
+  result.bookmarked = entity.bookmarked;
 
   return result;
 }
@@ -453,17 +454,26 @@ export function selectQueryLogsLimited(state, limit = 9) {
   };
 }
 
-export function selectBookmarks(state) {
-  const bookmarks = selectObject(state, state, 'bookmarks');
-  return bookmarks.sort((a, b) => b.bookmarkedAt - a.bookmarkedAt);
+export function selectBookmarksResult(state, query) {
+  const model = selectModel(state);
+  const result = selectResult(
+    state,
+    query,
+    (stateInner, id) => stateInner.bookmarks[id]
+  );
+
+  result.results = result.results.map((bookmark) => ({
+    ...bookmark,
+    entity: model.getEntity(bookmark.entity),
+  }));
+
+  return result;
 }
 
-export function selectBookmark(state, entity) {
-  const bookmarks = selectBookmarks(state);
-  return bookmarks.find(({ id }) => id === entity.id);
-}
-
-export function selectEntityBookmarked(state, entity) {
-  const bookmark = selectBookmark(state, entity);
-  return bookmark !== undefined;
+// TODO: Remove after deadline
+// See https://github.com/alephdata/aleph/issues/2864
+export function selectLocalBookmarks(state) {
+  return (
+    state?.localBookmarks?.sort((a, b) => b.bookmarkedAt - a.bookmarkedAt) || []
+  );
 }


### PR DESCRIPTION
The current experimental bookmarks feature in Aleph stores bookmark in local storage in the browser. This PR extends the feature to store bookmarks on the server, preventing a few common issues (for example users losing their bookmarks after clearing the browsing data). Closes #2831.

Specifically, there are three primary changes:

1. **API**: A new `/bookmarks` API endpoint to retrieve, create, and delete bookmarks.
2. **Frontend:** Changes to frontend to use the API instead of storing bookmarks locally.
3. **Migration:** New logic in the frontend to migrate bookmarks from client-side storage to the server.

### API

* Data is stored in a new `bookmark` table in Postgres. This table stores the role ID, entity ID and (to support efficient querying based on users permissions) the collection ID.
* There are API method to list bookmarks makes use of existing abstractions to fetch data from the database (incl. flexible offsets and limits) using the `DatabaseQuery` class, and merging it with entity data from the ElasticSearch index using the `Serializer` class. So it’s actually quite simple.

### UI

* Uses our existing data fetching logic based on Redux to handle data fetching and mutations. I had to extend this to support partial data invalidation, for details see f5ac9d5.

### Migration

* There’s a separate endpoint to batch create bookmarks specifically for the purpose of migrating existing bookmarks stored client-side. The idea is to remove any code related to this migration after a couple of months.
* When a user opens the bookmarks drawer and has local bookmarks that haven’t yet been migrated, a request to the migration endpoint is sent. If there have been errors while migrating bookmarks, users can download a list of bookmarks that couldn’t be migrated.

***

### How to test the migration

**Testing the happy path:**

1. Check out the `develop` branch.
2. Start Aleph.
3. Create a few entities.
4. Bookmark a few entities.
5. Stop Aleph.
6. Check out this branch.
7. Start Aleph.
8. Open the bookmarks drawer.
9. You should see a message notifying you that bookmarks now sync across devices. Confirm the message and you should see your bookmarks.
10. Clear your local storage.
11. Reload the page.
12. Open the bookmarks drawer.
13. Your bookmarks should still be there.

**Testing migration errors:**

1. Check out the `develop` branch.
2. Start Aleph.
3. Create a few entities.
4. Bookmark a few entities.
5. Now delete one or two of the bookmarked entities, but not all of them.
6. Stop Aleph.
7. Check out this branch.
8. Start Aleph.
9. Open the bookmarks drawer.
10. You should see a message about recent changes to bookmarks and that there was an issue with some of your bookmarks prompting you to download a list of affected bookmarks.
11. Download and confirm.
12. You should now be presented with a list of bookmarks that could be migrated successfully.
13. Clear your local storage.
14. Reload the page.
15. Open the bookmarks drawer.
16. Your bookmarks should still be there.

***

**Backend:**
- [x] Decide whether we want to have single `POST /bookmarks` endpoint that handles both creating a single bookmark as well as bulk creation (see comment below).
  * **Decision:** We want to have a separate endpoint for the purpose of migrating client-side bookmarks only. This endpoint can include specifics only relevant to this particular use case and we expect to remove it after some time.
- [x] `GET /bookmarks`: Endpoint should return bookmarks sorted by creation date, in descending order.
- [x] `POST /bookmarks`: Endpoint should validate `entity_id` when creating a new bookmark.
- [x] `POST /bookmarks`: Creating a bookmark for an entity that is already bookmarked shouldn’t raise an exception, but silently ignore the request or return a semantic status code (see review comment below).
- [x] Adjust `GET /entities/:entity_id` to return whether the entity is bookmarked if the user is authenticated
- [x] Optional: We should consider using bulk operations when creating database records for new bookmarks (see review comment below).
- [x] ~Optional: Delete bookmarks if entity is deleted. (Check entity set implementation)~
  * ~**Update:** Entity sets are very similar to bookmarks. I checked the current implementation and right now, if you delete an entity, corresponding entity set items aren’t deleted. They are obviously not returned from API responses and not displayed in the UI, but we keep the records in the database. I think it’s sensible to keep the bookmarks implementation similar for now and don’t think it’s a huge issue.~
  * **Update 2:** Actually we do clean up related records after deleting an entity. This is now also implemented for bookmarks.
- [x] Optional: Add proper response schemata in docstrings for API routes

**Frontend:**
- [x] Fetch bookmarks from backend API
- [x] Implement infinite scrolling for bookmarks list to support users with 100+ bookmarks. (We should expect users to accumulate many bookmarks over time.)
- [x] Send a one-time bulk create requests for bookmarks stored in local storage.

**Other:**
- [x] Check whether we use a foreign key constraint on the `entity_id` column? This will also help us get a better understanding of Aleph’s architecture.
  * The answer is no -- and it makes sense as there can be situations where entity data does exist in the index only and there is no corresponding record in the Postgres database.