### PR TITLE
Allow add-to-project to fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,3 +17,4 @@ jobs:
           # to the issue
           project-url: https://github.com/orgs/alephdata/projects/10
           github-token: ${{ secrets.ALEPH_GITHUB_TOKEN }}
+        continue-on-error: true


### PR DESCRIPTION
The diff is weird because the file used to have DOS-style line endings, which I made consistent with all other files in the repo. The only change is in the last line, allowing us to skip this action if it fails (and not take down the whole build with it). See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepscontinue-on-error