### PR TITLE
Indicate optional fields when creating new timeline items

### DIFF
--- a/ui/src/components/Timeline/Timeline.test.tsx
+++ b/ui/src/components/Timeline/Timeline.test.tsx
@@ -255,7 +255,7 @@ it('allows creating new items', async () => {
   // 'Event' is the default schema
   expect(screen.getByRole('textbox', { name: 'Name' })).toBeInTheDocument();
   expect(screen.getByRole('textbox', { name: 'Start date' }));
-  expect(screen.getByRole('textbox', { name: 'End date' }));
+  expect(screen.getByRole('textbox', { name: 'End date (optional)' }));
 
   // Change schema to 'Company'
   await userEvent.click(screen.getByRole('button', { name: 'Type' }));
@@ -266,7 +266,9 @@ it('allows creating new items', async () => {
   const incorporation = screen.getByRole('textbox', {
     name: 'Incorporation date',
   });
-  const dissolution = screen.getByRole('textbox', { name: 'Dissolution date' });
+  const dissolution = screen.getByRole('textbox', {
+    name: 'Dissolution date (optional)',
+  });
 
   expect(name).toBeInTheDocument();
   expect(incorporation).toBeInTheDocument();

--- a/ui/src/components/Timeline/Timeline.test.tsx
+++ b/ui/src/components/Timeline/Timeline.test.tsx
@@ -250,7 +250,9 @@ it('allows creating new items', async () => {
   await userEvent.click(screen.getByRole('button', { name: 'Add item' }));
 
   const dialog = screen.getByRole('dialog', { name: /Add new item/ });
+  const submit = screen.getByRole('button', { name: 'Add' });
   expect(dialog).toBeVisible();
+  expect(submit).toBeDisabled();
 
   // 'Event' is the default schema
   expect(screen.getByRole('textbox', { name: 'Name' })).toBeInTheDocument();
@@ -276,7 +278,9 @@ it('allows creating new items', async () => {
 
   await userEvent.type(name, 'ACME, Inc.');
   await userEvent.type(incorporation, '2022-02-15');
-  await userEvent.click(screen.getByRole('button', { name: 'Add' }));
+
+  expect(submit).not.toBeDisabled();
+  await userEvent.click(submit);
 
   await waitFor(() => expect(dialog).not.toBeVisible());
 

--- a/ui/src/components/Timeline/TimelineItemCreateDialog.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateDialog.tsx
@@ -1,8 +1,9 @@
-import { FC, useState, useEffect } from 'react';
+import { FC, useState, useEffect, useRef } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { Button, Dialog, Intent, Classes } from '@blueprintjs/core';
 import { Model, Schema, Entity } from '@alephdata/followthemoney';
 import TimelineItemCreateForm from './TimelineItemCreateForm';
+import { useFormValidity } from './util';
 
 type TimelineItemCreateDialogProps = Dialog['props'] & {
   model: Model;
@@ -21,6 +22,8 @@ const TimelineItemCreateDialog: FC<TimelineItemCreateDialogProps> = ({
   fetchEntitySuggestions,
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const formRef = useRef<HTMLFormElement>(null);
+  const [isValid, onInput] = useFormValidity(formRef);
 
   // Reset the loading state when the dialog is closed
   useEffect(() => {
@@ -39,7 +42,12 @@ const TimelineItemCreateDialog: FC<TimelineItemCreateDialogProps> = ({
       <div className={Classes.DIALOG_BODY}>
         <TimelineItemCreateForm
           id="timeline-item-create-form"
+          ref={formRef}
           model={model}
+          onInput={onInput}
+          onKeyDown={(event) =>
+            event.key === 'Enter' && formRef.current?.reportValidity()
+          }
           onSubmit={(entity) => {
             setIsSubmitting(true);
             onCreate(entity);
@@ -54,6 +62,7 @@ const TimelineItemCreateDialog: FC<TimelineItemCreateDialogProps> = ({
             form="timeline-item-create-form"
             intent={Intent.PRIMARY}
             loading={isSubmitting}
+            disabled={!isValid}
           >
             <FormattedMessage
               id="timeline.create_entity.submit"

--- a/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
@@ -96,7 +96,7 @@ it('renders temporal extent fields', async () => {
     name: 'Start date',
   }) as HTMLInputElement;
   const endDate = screen.getByRole('textbox', {
-    name: 'End date',
+    name: 'End date (optional)',
   }) as HTMLInputElement;
   const date = screen.queryByRole('textbox', { name: 'Date' });
 
@@ -111,7 +111,9 @@ it('renders temporal extent fields', async () => {
   await selectSchema('Court case');
 
   const fileDate = screen.getByRole('textbox', { name: 'File date' });
-  const closeDate = screen.getByRole('textbox', { name: 'Close date' });
+  const closeDate = screen.getByRole('textbox', {
+    name: 'Close date (optional)',
+  });
 
   expect(fileDate).toBeInTheDocument();
   expect(closeDate).toBeInTheDocument();

--- a/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
@@ -10,6 +10,8 @@ const defaultProps = {
   model,
   fetchEntitySuggestions: async () => [],
   onSubmit: () => {},
+  onInput: () => {},
+  onKeyDown: () => {},
 };
 
 const selectSchema = async (name: string) => {

--- a/ui/src/components/Timeline/TimelineItemCreateForm.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.tsx
@@ -30,6 +30,7 @@ type PropertyFieldProps = {
   value?: string;
   required?: boolean;
   placeholder?: string;
+  pattern?: string;
   onChange: (property: Property, value: Value) => void;
 };
 
@@ -90,6 +91,7 @@ const PropertyField: FC<PropertyFieldProps> = ({
   value,
   required,
   placeholder,
+  pattern,
   onChange,
 }) => (
   <FormGroup
@@ -110,6 +112,7 @@ const PropertyField: FC<PropertyFieldProps> = ({
       value={value}
       required={required}
       placeholder={placeholder}
+      pattern={pattern}
       onChange={(event) => onChange(property, event.target.value)}
     />
   </FormGroup>
@@ -198,6 +201,7 @@ const TemporalExtentFields: FC<TemporalExtentFieldsProps> = ({
           value={typeof value === 'string' ? value : ''}
           onChange={onChange}
           placeholder="YYYY-MM-DD"
+          pattern="\d{4}-\d{1,2}-\d{1,2}"
           required={required}
         />
       ))}

--- a/ui/src/components/Timeline/TimelineItemCreateForm.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.tsx
@@ -1,4 +1,12 @@
-import { FC, FormEvent, useState } from 'react';
+import {
+  FC,
+  FormEvent,
+  useState,
+  forwardRef,
+  FormEventHandler,
+  KeyboardEventHandler,
+  ForwardedRef,
+} from 'react';
 import { FormattedMessage } from 'react-intl';
 import {
   Model,
@@ -63,6 +71,8 @@ type TemporalExtentFieldsProps = {
 type TimelineItemCreateFormProps = {
   model: Model;
   onSubmit: (entity: Entity) => void;
+  onInput: FormEventHandler;
+  onKeyDown: KeyboardEventHandler;
   id?: string;
   fetchEntitySuggestions: FetchEntitySuggestions;
 };
@@ -258,12 +268,13 @@ const CaptionField: FC<CaptionFieldProps> = ({
 
 const isEdge = (schema: Schema): schema is EdgeSchema => schema.isEdge;
 
-const TimelineItemCreateForm: FC<TimelineItemCreateFormProps> = ({
-  id,
-  model,
-  onSubmit,
-  fetchEntitySuggestions,
-}) => {
+const TimelineItemCreateForm = (
+  props: TimelineItemCreateFormProps,
+  formRef: ForwardedRef<HTMLFormElement>
+) => {
+  const { id, model, onSubmit, onInput, onKeyDown, fetchEntitySuggestions } =
+    props;
+
   const [entity, setEntity] = useState<Entity>(model.createEntity('Event'));
 
   const onFormSubmit = (event: FormEvent<HTMLFormElement>) => {
@@ -300,7 +311,13 @@ const TimelineItemCreateForm: FC<TimelineItemCreateFormProps> = ({
   );
 
   return (
-    <form id={id} onSubmit={onFormSubmit}>
+    <form
+      id={id}
+      onSubmit={onFormSubmit}
+      onInput={onInput}
+      onKeyDown={onKeyDown}
+      ref={formRef}
+    >
       <SchemaField
         model={model}
         value={entity.schema}
@@ -333,4 +350,6 @@ const TimelineItemCreateForm: FC<TimelineItemCreateFormProps> = ({
   );
 };
 
-export default TimelineItemCreateForm;
+export default forwardRef<HTMLFormElement, TimelineItemCreateFormProps>(
+  TimelineItemCreateForm
+);

--- a/ui/src/components/Timeline/util.ts
+++ b/ui/src/components/Timeline/util.ts
@@ -5,6 +5,7 @@ import {
   useState,
   createRef,
   KeyboardEvent,
+  RefObject,
 } from 'react';
 import { differenceInDays } from 'date-fns';
 import { throttle } from 'lodash';
@@ -254,4 +255,14 @@ export function useEntitySuggestions(
   }, [onQueryChange]);
 
   return [suggestions, isFetching, onQueryChange] as const;
+}
+
+export function useFormValidity(formRef: RefObject<HTMLFormElement>) {
+  const [isValid, setIsValid] = useState(false);
+
+  const onInput = () => {
+    setIsValid(!!formRef.current?.checkValidity());
+  };
+
+  return [isValid, onInput] as const;
 }


### PR DESCRIPTION
The end date of a timeline item is always optional. This adds "(optional)" after the respective form labels to make this clear for users. Additionally, this also adds proper validation to required fields (i.e. you can’t create a timeline item without a start date).

<img width="514" alt="Screen Shot 2023-03-06 at 07 41 06" src="https://user-images.githubusercontent.com/1512805/223037189-6c2f33d4-a86a-4f70-9aa3-b7a15b900775.png">
