### PR TITLE
Do not save timeline layout on initial load

### DIFF
--- a/ui/src/components/Timeline/Timeline.test.tsx
+++ b/ui/src/components/Timeline/Timeline.test.tsx
@@ -51,8 +51,17 @@ describe('Sidebar', () => {
   it('allows changing entity color', async () => {
     const entities = [event1];
     const layout = { vertices: [] };
+    const onLayoutUpdate = jest.fn();
 
-    render(<Timeline {...defaultProps} entities={entities} layout={layout} />);
+    render(
+      <Timeline
+        {...defaultProps}
+        entities={entities}
+        layout={layout}
+        onLayoutUpdate={onLayoutUpdate}
+      />
+    );
+
     const rows = screen.getAllByRole('row');
     await userEvent.click(rows[1]);
 
@@ -67,6 +76,7 @@ describe('Sidebar', () => {
     await userEvent.click(swatches[3]);
     color = rows[1].style.getPropertyValue('--timeline-item-color');
     expect(color).toEqual(Colors.RED2);
+    expect(onLayoutUpdate).toHaveBeenCalledTimes(1);
   });
 
   it('does not allow changing entity color if not writeable', async () => {

--- a/ui/src/components/Timeline/Timeline.tsx
+++ b/ui/src/components/Timeline/Timeline.tsx
@@ -5,7 +5,7 @@ import { Colors } from '@blueprintjs/colors';
 import { Schema, Entity, Model } from '@alephdata/followthemoney';
 import c from 'classnames';
 import { TimelineRenderer, Layout, Vertex } from './types';
-import { TimelineItem } from './util';
+import { TimelineItem, updateVertex } from './util';
 import {
   reducer,
   selectSortedEntities,
@@ -64,12 +64,8 @@ const Timeline: FC<TimelineProps> = ({
   const sortedEntities = selectSortedEntities(state);
 
   const items = sortedEntities.map(
-    (entity) => new TimelineItem(entity, layout)
+    (entity) => new TimelineItem(entity, state.layout)
   );
-
-  useEffect(() => {
-    onLayoutUpdate(state.layout);
-  }, [state.layout, onLayoutUpdate]);
 
   const createButton = (
     <Button intent={Intent.PRIMARY} icon="add" onClick={toggleCreateDialog}>
@@ -131,6 +127,9 @@ const Timeline: FC<TimelineProps> = ({
             writeable={writeable}
             onVertexChange={(vertex: Vertex) => {
               dispatch({ type: 'UPDATE_VERTEX', payload: { vertex } });
+              // State updates are executed asyncronously, so we need to compute the new layout explicitly
+              const newLayout = updateVertex(state.layout, vertex);
+              onLayoutUpdate(newLayout);
             }}
             onEntityChange={(entity: Entity) => {
               dispatch({ type: 'UPDATE_ENTITY', payload: { entity } });

--- a/ui/src/components/Timeline/state.ts
+++ b/ui/src/components/Timeline/state.ts
@@ -1,5 +1,6 @@
 import { Entity } from '@alephdata/followthemoney';
 import type { Vertex, Layout, TimelineEntity } from './types';
+import { updateVertex } from './util';
 
 type State = {
   entities: Array<Entity>;
@@ -70,18 +71,8 @@ const reducer = (state: State, action: Action): State => {
   }
 
   if (type === 'UPDATE_VERTEX') {
-    const vertices = state.layout.vertices;
-    const index = state.layout.vertices.findIndex(
-      (vertex) => vertex.entityId === action.payload.vertex.entityId
-    );
-
-    if (index < 0) {
-      vertices.push(action.payload.vertex);
-    } else {
-      vertices.splice(index, 1, action.payload.vertex);
-    }
-
-    return { ...state, layout: { vertices } };
+    const newLayout = updateVertex(state.layout, action.payload.vertex);
+    return { ...state, layout: newLayout };
   }
 
   if (type === 'UPDATE_ENTITY') {

--- a/ui/src/components/Timeline/util.ts
+++ b/ui/src/components/Timeline/util.ts
@@ -11,7 +11,7 @@ import { differenceInDays } from 'date-fns';
 import { throttle } from 'lodash';
 import { Entity, Schema } from '@alephdata/followthemoney';
 import { DEFAULT_COLOR } from './Timeline';
-import { FetchEntitySuggestions, Layout } from './types';
+import { FetchEntitySuggestions, Layout, Vertex } from './types';
 
 function endOfMonth(year: number, month: number): number {
   // Months in ECMAScript are zero-based:
@@ -265,4 +265,21 @@ export function useFormValidity(formRef: RefObject<HTMLFormElement>) {
   };
 
   return [isValid, onInput] as const;
+}
+
+export function updateVertex(layout: Layout, updatedVertex: Vertex): Layout {
+  const { vertices } = layout;
+  const index = layout.vertices.findIndex(
+    (vertex) => vertex.entityId === updatedVertex.entityId
+  );
+
+  const newVertices = [...vertices];
+
+  if (index < 0) {
+    newVertices.push(updatedVertex);
+  } else {
+    newVertices.splice(index, 1, updatedVertex);
+  }
+
+  return { vertices: newVertices };
 }


### PR DESCRIPTION
The current implementation was using `useEffect` to trigger an API request (via the `onLayoutUpdate` callback) whenever the layout state (for example the color of an entity set item) changes. As `useEffect` will also execute the side effect on initial render, this caused an undesired API request directly after opening a timeline.

Instead of relying on `useEffect` to persist the layout state, this now triggers the `onLayoutUpdate` callback explicitly when the user performs certain actions (like changing the color of an item).