### PR TITLE
Do not render delete and settings actions for read-only timelines, lists

### DIFF
--- a/ui/src/components/EntitySet/EntitySetManageMenu.jsx
+++ b/ui/src/components/EntitySet/EntitySetManageMenu.jsx
@@ -100,6 +100,10 @@ class EntitySetManageMenu extends Component {
       return this.renderExport();
     }
 
+    if (!entitySet.writeable) {
+      return null;
+    }
+
     if (isDiagram || isTimeline) {
       return (
         <ButtonGroup minimal>


### PR DESCRIPTION
Previously, we would display the settings and delete action buttons for read-only timelines and lists. This PR hides them and only displays them if the current user does actually have write access to a timelines or list.

| | Before | After |
| --- | --- | --- |
| Timelines | <img width="1003" alt="Screen Shot 2023-03-09 at 10 20 25" src="https://user-images.githubusercontent.com/1512805/223977569-7077a423-9187-4b42-a71f-c003903b4dc4.png"> | <img width="1006" alt="Screen Shot 2023-03-09 at 10 20 43" src="https://user-images.githubusercontent.com/1512805/223977613-f929c367-3fdd-47b0-8f03-e8bdc1174ddd.png"> |
| Lists | <img width="1005" alt="Screen Shot 2023-03-09 at 10 21 21" src="https://user-images.githubusercontent.com/1512805/223977401-40ad7d84-72e0-4125-8057-ff04678a27f2.png"> | <img width="1004" alt="Screen Shot 2023-03-09 at 10 21 03" src="https://user-images.githubusercontent.com/1512805/223977431-04b7de29-7f24-4db8-a71b-9322f8c88241.png"> |
