### PR TITLE
Allow users to switch between timeline day/month/year zoom levels

### DIFF
--- a/ui/src/components/Timeline/Timeline.scss
+++ b/ui/src/components/Timeline/Timeline.scss
@@ -14,6 +14,8 @@
 }
 
 .Timeline__actions {
+  display: flex;
+  gap: $aleph-grid-size;
   margin-bottom: 2.5 * $aleph-grid-size;
 }
 

--- a/ui/src/components/Timeline/Timeline.scss
+++ b/ui/src/components/Timeline/Timeline.scss
@@ -14,6 +14,8 @@
 }
 
 .Timeline__actions {
+  position: sticky;
+  left: 0;
   display: flex;
   gap: $aleph-grid-size;
   margin-bottom: 2.5 * $aleph-grid-size;

--- a/ui/src/components/Timeline/Timeline.tsx
+++ b/ui/src/components/Timeline/Timeline.tsx
@@ -1,8 +1,7 @@
 import { FC, useReducer, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Button, Intent, Menu, MenuItem } from '@blueprintjs/core';
+import { Button, ButtonGroup, Intent } from '@blueprintjs/core';
 import { Colors } from '@blueprintjs/colors';
-import { Classes, Popover2 as Popover } from '@blueprintjs/popover2';
 import { Schema, Entity, Model } from '@alephdata/followthemoney';
 import c from 'classnames';
 import {
@@ -80,50 +79,33 @@ const Timeline: FC<TimelineProps> = ({
     </Button>
   );
 
-  const zoomLevelDropdown = (
-    <Popover
-      placement="bottom"
-      content={
-        <div className={Classes.POPOVER2_CONTENT_SIZING}>
-          <Menu>
-            <MenuItem
-              active={zoomLevel === 'days'}
-              text={
-                <FormattedMessage
-                  id="timeline.zoom_level.days"
-                  defaultMessage="Days"
-                />
-              }
-              onClick={() => setZoomLevel('days')}
-            />
-            <MenuItem
-              active={zoomLevel === 'months'}
-              text={
-                <FormattedMessage
-                  id="timeline.zoom_level.months"
-                  defaultMessage="Months"
-                />
-              }
-              onClick={() => setZoomLevel('months')}
-            />
-            <MenuItem
-              active={zoomLevel === 'years'}
-              text={
-                <FormattedMessage
-                  id="timeline.zoom_level.years"
-                  defaultMessage="Years"
-                />
-              }
-              onClick={() => setZoomLevel('years')}
-            />
-          </Menu>
-        </div>
-      }
-    >
-      <Button icon="zoom-in" rightIcon="caret-down">
-        Zoom
+  const zoomLevelSwitch = (
+    <ButtonGroup>
+      <Button
+        active={zoomLevel === 'days'}
+        onClick={() => setZoomLevel('days')}
+      >
+        <FormattedMessage id="timeline.zoom_level.days" defaultMessage="Days" />
       </Button>
-    </Popover>
+      <Button
+        active={zoomLevel === 'months'}
+        onClick={() => setZoomLevel('months')}
+      >
+        <FormattedMessage
+          id="timeline.zoom_level.months"
+          defaultMessage="Months"
+        />
+      </Button>
+      <Button
+        active={zoomLevel === 'years'}
+        onClick={() => setZoomLevel('years')}
+      >
+        <FormattedMessage
+          id="timeline.zoom_level.years"
+          defaultMessage="Years"
+        />
+      </Button>
+    </ButtonGroup>
   );
 
   return (
@@ -153,7 +135,7 @@ const Timeline: FC<TimelineProps> = ({
             {writeable && (
               <div className="Timeline__actions">
                 {createButton}
-                {renderer === 'chart' && zoomLevelDropdown}
+                {renderer === 'chart' && zoomLevelSwitch}
               </div>
             )}
             <Renderer

--- a/ui/src/components/Timeline/Timeline.tsx
+++ b/ui/src/components/Timeline/Timeline.tsx
@@ -53,13 +53,13 @@ const Timeline: FC<TimelineProps> = ({
   onEntityRemove,
   onLayoutUpdate,
 }) => {
-  const [zoomLevel, setZoomLevel] = useState<TimelineChartZoomLevel>('months');
   const Renderer = renderer === 'chart' ? TimelineChart : TimelineList;
 
   const [state, dispatch] = useReducer(reducer, {
     entities,
     layout: layout || { vertices: [] },
     selectedId: null,
+    zoomLevel: 'months',
   });
 
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
@@ -82,14 +82,18 @@ const Timeline: FC<TimelineProps> = ({
   const zoomLevelSwitch = (
     <ButtonGroup>
       <Button
-        active={zoomLevel === 'days'}
-        onClick={() => setZoomLevel('days')}
+        active={state.zoomLevel === 'days'}
+        onClick={() =>
+          dispatch({ type: 'SET_ZOOM_LEVEL', payload: { zoomLevel: 'days' } })
+        }
       >
         <FormattedMessage id="timeline.zoom_level.days" defaultMessage="Days" />
       </Button>
       <Button
-        active={zoomLevel === 'months'}
-        onClick={() => setZoomLevel('months')}
+        active={state.zoomLevel === 'months'}
+        onClick={() =>
+          dispatch({ type: 'SET_ZOOM_LEVEL', payload: { zoomLevel: 'months' } })
+        }
       >
         <FormattedMessage
           id="timeline.zoom_level.months"
@@ -97,8 +101,10 @@ const Timeline: FC<TimelineProps> = ({
         />
       </Button>
       <Button
-        active={zoomLevel === 'years'}
-        onClick={() => setZoomLevel('years')}
+        active={state.zoomLevel === 'years'}
+        onClick={() =>
+          dispatch({ type: 'SET_ZOOM_LEVEL', payload: { zoomLevel: 'years' } })
+        }
       >
         <FormattedMessage
           id="timeline.zoom_level.years"
@@ -142,7 +148,7 @@ const Timeline: FC<TimelineProps> = ({
               items={items}
               selectedId={selectedEntity && selectedEntity.id}
               writeable={writeable}
-              zoomLevel={zoomLevel}
+              zoomLevel={state.zoomLevel}
               onSelect={(entity: Entity) =>
                 dispatch({ type: 'SELECT_ENTITY', payload: { entity } })
               }

--- a/ui/src/components/Timeline/Timeline.tsx
+++ b/ui/src/components/Timeline/Timeline.tsx
@@ -1,10 +1,16 @@
-import { FC, useReducer, useState, useEffect } from 'react';
+import { FC, useReducer, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Button, Intent } from '@blueprintjs/core';
+import { Button, Intent, Menu, MenuItem } from '@blueprintjs/core';
 import { Colors } from '@blueprintjs/colors';
+import { Classes, Popover2 as Popover } from '@blueprintjs/popover2';
 import { Schema, Entity, Model } from '@alephdata/followthemoney';
 import c from 'classnames';
-import { TimelineRenderer, Layout, Vertex } from './types';
+import {
+  TimelineRenderer,
+  Layout,
+  Vertex,
+  TimelineChartZoomLevel,
+} from './types';
 import { TimelineItem, updateVertex } from './util';
 import {
   reducer,
@@ -48,6 +54,7 @@ const Timeline: FC<TimelineProps> = ({
   onEntityRemove,
   onLayoutUpdate,
 }) => {
+  const [zoomLevel, setZoomLevel] = useState<TimelineChartZoomLevel>('months');
   const Renderer = renderer === 'chart' ? TimelineChart : TimelineList;
 
   const [state, dispatch] = useReducer(reducer, {
@@ -71,6 +78,52 @@ const Timeline: FC<TimelineProps> = ({
     <Button intent={Intent.PRIMARY} icon="add" onClick={toggleCreateDialog}>
       <FormattedMessage id="timeline.add_item" defaultMessage="Add item" />
     </Button>
+  );
+
+  const zoomLevelDropdown = (
+    <Popover
+      placement="bottom"
+      content={
+        <div className={Classes.POPOVER2_CONTENT_SIZING}>
+          <Menu>
+            <MenuItem
+              active={zoomLevel === 'days'}
+              text={
+                <FormattedMessage
+                  id="timeline.zoom_level.days"
+                  defaultMessage="Days"
+                />
+              }
+              onClick={() => setZoomLevel('days')}
+            />
+            <MenuItem
+              active={zoomLevel === 'months'}
+              text={
+                <FormattedMessage
+                  id="timeline.zoom_level.months"
+                  defaultMessage="Months"
+                />
+              }
+              onClick={() => setZoomLevel('months')}
+            />
+            <MenuItem
+              active={zoomLevel === 'years'}
+              text={
+                <FormattedMessage
+                  id="timeline.zoom_level.years"
+                  defaultMessage="Years"
+                />
+              }
+              onClick={() => setZoomLevel('years')}
+            />
+          </Menu>
+        </div>
+      }
+    >
+      <Button icon="zoom-in" rightIcon="caret-down">
+        Zoom
+      </Button>
+    </Popover>
   );
 
   return (
@@ -98,12 +151,16 @@ const Timeline: FC<TimelineProps> = ({
         {items.length > 0 && (
           <>
             {writeable && (
-              <div className="Timeline__actions">{createButton}</div>
+              <div className="Timeline__actions">
+                {createButton}
+                {renderer === 'chart' && zoomLevelDropdown}
+              </div>
             )}
             <Renderer
               items={items}
               selectedId={selectedEntity && selectedEntity.id}
               writeable={writeable}
+              zoomLevel={zoomLevel}
               onSelect={(entity: Entity) =>
                 dispatch({ type: 'SELECT_ENTITY', payload: { entity } })
               }

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.scss
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.scss
@@ -1,6 +1,20 @@
 @import 'app/variables.scss';
 
+@keyframes timeline-fadein {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
 .TimelineChart {
+  --timeline-chart-transition-duration: 0.33s;
+  --timeline-chart-transition-easing: cubic-bezier(0.65, 0, 0.35, 1);
+  --timeline-chart-labels-height: #{3 * $aleph-grid-size};
+
   position: relative;
   min-width: calc(var(--timeline-chart-days) * var(--timeline-chart-day-width));
   flex-grow: 1;
@@ -22,6 +36,7 @@
   list-style: none;
   margin: 0;
   padding: 0;
+  padding-top: $aleph-grid-size;
 }
 
 .TimelineChart__list > * + * {

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.scss
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.scss
@@ -1,11 +1,21 @@
 @import 'app/variables.scss';
 
 .TimelineChart {
-  --timeline-chart-day-width: 25px;
-
   position: relative;
   min-width: calc(var(--timeline-chart-days) * var(--timeline-chart-day-width));
   flex-grow: 1;
+}
+
+.TimelineChart--days {
+  --timeline-chart-day-width: 20px;
+}
+
+.TimelineChart--months {
+  --timeline-chart-day-width: 5px;
+}
+
+.TimelineChart--years {
+  --timeline-chart-day-width: 1px;
 }
 
 .TimelineChart__list {

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.test.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.test.tsx
@@ -48,6 +48,12 @@ const defaultProps = {
   onUnselect: () => {},
 };
 
+beforeEach(() => {
+  // jsdom doesn't actually calculate layouts or renders anything, so methods that
+  //  rely on this like `scrollIntoView` are not available and need to be stubbed.
+  window.Element.prototype.scrollIntoView = jest.fn();
+});
+
 it('supports navigating the list using arrow keys', async () => {
   render(<TimelineChart {...defaultProps} />);
 

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.test.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.test.tsx
@@ -39,16 +39,17 @@ const items = [
   new TimelineItem(event3),
 ];
 
+const defaultProps = {
+  items: items,
+  selectedId: null,
+  zoomLevel: 'months' as const,
+  onSelect: () => {},
+  onRemove: () => {},
+  onUnselect: () => {},
+};
+
 it('supports navigating the list using arrow keys', async () => {
-  render(
-    <TimelineChart
-      items={items}
-      selectedId={null}
-      onSelect={() => {}}
-      onRemove={() => {}}
-      onUnselect={() => {}}
-    />
-  );
+  render(<TimelineChart {...defaultProps} />);
 
   const listItems = screen.getAllByRole('listitem');
 
@@ -85,11 +86,10 @@ it('selects and unselects items on click', async () => {
 
   render(
     <TimelineChart
+      {...defaultProps}
       items={items}
-      selectedId={null}
       onSelect={onSelect}
       onUnselect={onUnselect}
-      onRemove={() => {}}
     />
   );
 
@@ -108,15 +108,7 @@ it('selects and unselects items on click', async () => {
 });
 
 it('shows popover with details when hovering timeline items', async () => {
-  render(
-    <TimelineChart
-      items={items}
-      selectedId={null}
-      onSelect={() => {}}
-      onRemove={() => {}}
-      onUnselect={() => {}}
-    />
-  );
+  render(<TimelineChart {...defaultProps} />);
 
   const listItems = screen.getAllByRole('listitem');
 
@@ -128,16 +120,8 @@ it('shows popover with details when hovering timeline items', async () => {
   expect(document.body).toHaveTextContent(/2022-02-01.*Start date/);
 });
 
-it('clicking an items focuses it', async () => {
-  render(
-    <TimelineChart
-      items={items}
-      selectedId={null}
-      onSelect={() => {}}
-      onRemove={() => {}}
-      onUnselect={() => {}}
-    />
-  );
+it('focuses item on click', async () => {
+  render(<TimelineChart {...defaultProps} />);
 
   const listItems = screen.getAllByRole('listitem');
 
@@ -154,4 +138,31 @@ it('clicking an items focuses it', async () => {
   await userEvent.click(listItems[1]);
   await new Promise((resolve) => setTimeout(() => resolve(undefined), 0));
   expect(document.activeElement).toEqual(listItems[1]);
+});
+
+describe('Zoom levels', () => {
+  describe('Days', () => {
+    it('renders one grid label per month', () => {
+      render(<TimelineChart {...defaultProps} zoomLevel="days" />);
+      expect(screen.getByText('Jan 2022')).toBeInTheDocument();
+      expect(screen.getByText('Feb 2022')).toBeInTheDocument();
+      expect(screen.getByText('Mar 2022')).toBeInTheDocument();
+    });
+  });
+
+  describe('Months', () => {
+    it('renders one grid label per month', () => {
+      render(<TimelineChart {...defaultProps} zoomLevel="months" />);
+      expect(screen.getByText('Jan 2022')).toBeInTheDocument();
+      expect(screen.getByText('Feb 2022')).toBeInTheDocument();
+      expect(screen.getByText('Mar 2022')).toBeInTheDocument();
+    });
+  });
+
+  describe('Years', () => {
+    it('renders one grid label per year', () => {
+      render(<TimelineChart {...defaultProps} zoomLevel="years" />);
+      expect(screen.getByText('2022')).toBeInTheDocument();
+    });
+  });
 });

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
@@ -1,4 +1,4 @@
-import { FC, CSSProperties, useState, useEffect, useRef } from 'react';
+import { FC, CSSProperties, useState, useEffect } from 'react';
 import { Classes } from '@blueprintjs/core';
 import c from 'classnames';
 import { differenceInDays } from 'date-fns';
@@ -12,38 +12,6 @@ import TimelineChartItem from './TimelineChartItem';
 import TimelineChartPopover from './TimelineChartPopover';
 
 import './TimelineChart.scss';
-
-function getScrollParent(element: HTMLElement): HTMLElement {
-  const style = window.getComputedStyle(element);
-  const scrollable = ['scroll', 'auto'];
-
-  if (
-    (scrollable.includes(style.overflowX) &&
-      element.scrollWidth > element.clientWidth) ||
-    (scrollable.includes(style.overflowY) &&
-      element.scrollHeight > element.clientHeight)
-  ) {
-    return element;
-  }
-
-  if (element.parentElement) {
-    return getScrollParent(element.parentElement);
-  }
-
-  return document.documentElement;
-}
-
-function isVisible(container: HTMLElement, element: HTMLElement): boolean {
-  const containerRect = container.getBoundingClientRect();
-  const elementRect = element.getBoundingClientRect();
-
-  return (
-    elementRect.left < containerRect.right &&
-    elementRect.right > containerRect.left &&
-    elementRect.top < containerRect.bottom &&
-    elementRect.bottom > containerRect.top
-  );
-}
 
 const TimelineChart: FC<TimelineRendererProps> = ({
   items,
@@ -64,36 +32,6 @@ const TimelineChart: FC<TimelineRendererProps> = ({
       itemRefs[0].current?.scrollIntoView({ inline: 'center' });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
-
-  const lastSelectedElement = useRef<HTMLElement>();
-
-  useEffect(() => {
-    if (!selectedId) {
-      return;
-    }
-
-    const selectedIndex = items.findIndex(
-      ({ entity }) => entity.id == selectedId
-    );
-    const selectedElement =
-      selectedIndex >= 0 ? itemRefs[selectedIndex]?.current : null;
-
-    if (!selectedElement || selectedElement === lastSelectedElement.current) {
-      return;
-    }
-
-    if (isVisible(getScrollParent(selectedElement), selectedElement)) {
-      return;
-    }
-
-    selectedElement.focus({ preventScroll: true });
-    selectedElement.scrollIntoView({
-      inline: 'center',
-      block: 'nearest',
-      behavior: 'smooth',
-    });
-    lastSelectedElement.current = selectedElement;
-  }, [selectedId, items, itemRefs]);
 
   const earliestDate = items
     .map((item) => item.getEarliestDate())

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
@@ -1,38 +1,17 @@
 import { FC, CSSProperties, useState } from 'react';
 import { Classes } from '@blueprintjs/core';
 import c from 'classnames';
-import {
-  differenceInDays,
-  startOfMonth,
-  endOfMonth,
-  startOfYear,
-  endOfYear,
-} from 'date-fns';
+import { differenceInDays } from 'date-fns';
 import { useTimelineKeyboardNavigation } from '../util';
-import type { TimelineRendererProps, TimelineChartZoomLevel } from '../types';
+import type { TimelineRendererProps } from '../types';
 import { TimelineItem } from '../util';
+import { getStart, getEnd } from './util';
 import TimelineChartGrid from './TimelineChartGrid';
 import TimelineChartLabels from './TimelineChartLabels';
 import TimelineChartItem from './TimelineChartItem';
 import TimelineChartPopover from './TimelineChartPopover';
 
 import './TimelineChart.scss';
-
-const getStart = (zoomLevel: TimelineChartZoomLevel, earliestDate: Date) => {
-  if (zoomLevel === 'days') {
-    return startOfMonth(earliestDate);
-  }
-
-  return startOfYear(earliestDate);
-};
-
-const getEnd = (zoomLevel: TimelineChartZoomLevel, latestDate: Date) => {
-  if (zoomLevel === 'days') {
-    return endOfMonth(latestDate);
-  }
-
-  return endOfYear(latestDate);
-};
 
 const TimelineChart: FC<TimelineRendererProps> = ({
   items,
@@ -57,8 +36,8 @@ const TimelineChart: FC<TimelineRendererProps> = ({
     .filter((date): date is Date => date !== undefined)
     .sort((a, b) => b.getTime() - a.getTime())[0];
 
-  const start = getStart(zoomLevel, earliestDate);
-  const end = getEnd(zoomLevel, latestDate);
+  const start = getStart(zoomLevel, earliestDate, latestDate);
+  const end = getEnd(zoomLevel, earliestDate, latestDate);
   const days = differenceInDays(end, start) + 1;
 
   const style: CSSProperties = {

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
@@ -1,4 +1,4 @@
-import { FC, CSSProperties, useState, useEffect } from 'react';
+import { FC, CSSProperties, useState, useEffect, useRef } from 'react';
 import { Classes } from '@blueprintjs/core';
 import c from 'classnames';
 import { differenceInDays } from 'date-fns';
@@ -12,6 +12,38 @@ import TimelineChartItem from './TimelineChartItem';
 import TimelineChartPopover from './TimelineChartPopover';
 
 import './TimelineChart.scss';
+
+function getScrollParent(element: HTMLElement): HTMLElement {
+  const style = window.getComputedStyle(element);
+  const scrollable = ['scroll', 'auto'];
+
+  if (
+    (scrollable.includes(style.overflowX) &&
+      element.scrollWidth > element.clientWidth) ||
+    (scrollable.includes(style.overflowY) &&
+      element.scrollHeight > element.clientHeight)
+  ) {
+    return element;
+  }
+
+  if (element.parentElement) {
+    return getScrollParent(element.parentElement);
+  }
+
+  return document.documentElement;
+}
+
+function isVisible(container: HTMLElement, element: HTMLElement): boolean {
+  const containerRect = container.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+
+  return (
+    elementRect.left < containerRect.right &&
+    elementRect.right > containerRect.left &&
+    elementRect.top < containerRect.bottom &&
+    elementRect.bottom > containerRect.top
+  );
+}
 
 const TimelineChart: FC<TimelineRendererProps> = ({
   items,
@@ -32,6 +64,36 @@ const TimelineChart: FC<TimelineRendererProps> = ({
       itemRefs[0].current?.scrollIntoView({ inline: 'center' });
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const lastSelectedElement = useRef<HTMLElement>();
+
+  useEffect(() => {
+    if (!selectedId) {
+      return;
+    }
+
+    const selectedIndex = items.findIndex(
+      ({ entity }) => entity.id == selectedId
+    );
+    const selectedElement =
+      selectedIndex >= 0 ? itemRefs[selectedIndex]?.current : null;
+
+    if (!selectedElement || selectedElement === lastSelectedElement.current) {
+      return;
+    }
+
+    if (isVisible(getScrollParent(selectedElement), selectedElement)) {
+      return;
+    }
+
+    selectedElement.focus({ preventScroll: true });
+    selectedElement.scrollIntoView({
+      inline: 'center',
+      block: 'nearest',
+      behavior: 'smooth',
+    });
+    lastSelectedElement.current = selectedElement;
+  }, [selectedId, items, itemRefs]);
 
   const earliestDate = items
     .map((item) => item.getEarliestDate())

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
@@ -1,4 +1,4 @@
-import { FC, CSSProperties, useState } from 'react';
+import { FC, CSSProperties, useState, useEffect } from 'react';
 import { Classes } from '@blueprintjs/core';
 import c from 'classnames';
 import { differenceInDays } from 'date-fns';
@@ -25,6 +25,13 @@ const TimelineChart: FC<TimelineRendererProps> = ({
 
   const [itemRefs, keyboardProps] =
     useTimelineKeyboardNavigation<HTMLLIElement>(items, onUnselect);
+
+  // Scroll first item into view on initial render
+  useEffect(() => {
+    if (itemRefs.length >= 1) {
+      itemRefs[0].current?.scrollIntoView({ inline: 'center' });
+    }
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   const earliestDate = items
     .map((item) => item.getEarliestDate())

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
@@ -55,8 +55,8 @@ const TimelineChart: FC<TimelineRendererProps> = ({
       style={style}
       onClick={() => onUnselect()}
     >
-      <TimelineChartGrid start={start} end={end} zoomLevel={zoomLevel} />
       <TimelineChartLabels start={start} end={end} zoomLevel={zoomLevel} />
+      <TimelineChartGrid start={start} end={end} zoomLevel={zoomLevel} />
 
       {popoverItem && (
         <TimelineChartPopover

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartGrid.scss
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartGrid.scss
@@ -6,6 +6,7 @@
   left: 0;
   width: 100%;
   height: 100%;
+  overflow: hidden;
 }
 
 .TimelineChartGrid__line {
@@ -21,5 +22,13 @@
 .TimelineChartGrid__line--main {
   border-right-style: solid;
   border-right-width: 2px;
-  transform: translateX(-1px);
+  transform: translateX(-50%);
+}
+
+.TimelineChartGrid__line--main:first-child {
+  transform: translateX(0);
+}
+
+.TimelineChartGrid__line:last-child {
+  transform: translateX(-100%);
 }

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartGrid.scss
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartGrid.scss
@@ -2,10 +2,10 @@
 
 .TimelineChartGrid {
   position: absolute;
-  top: 0;
   left: 0;
+  top: var(--timeline-chart-labels-height);
+  bottom: 0;
   width: 100%;
-  height: 100%;
   overflow: hidden;
 }
 
@@ -17,6 +17,11 @@
   height: 100%;
   width: 0;
   border-right: 1px dotted $aleph-border-color;
+
+  transition-duration: var(--timeline-chart-transition-duration);
+  transition-property: left;
+  transition-timing-function: var(--timeline-chart-transition-easing);
+  animation: timeline-fadein calc(4 * var(--timeline-chart-transition-duration));
 }
 
 .TimelineChartGrid__line--main {

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartGrid.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartGrid.tsx
@@ -1,22 +1,55 @@
 import { FC } from 'react';
 import c from 'classnames';
-import { eachDayOfInterval, differenceInDays, addDays } from 'date-fns';
+import {
+  eachDayOfInterval,
+  eachMonthOfInterval,
+  differenceInDays,
+  addDays,
+} from 'date-fns';
+import { TimelineChartZoomLevel } from '../types';
 
 import './TimelineChartGrid.scss';
 
 type TimelineChartGridProps = {
   start: Date;
   end: Date;
+  zoomLevel: TimelineChartZoomLevel;
 };
 
-const TimelineChartGrid: FC<TimelineChartGridProps> = ({ start, end }) => {
-  const lines = eachDayOfInterval({ start, end: addDays(end, 1) }).map(
-    (date) => ({
+const generateLines = (
+  zoomLevel: TimelineChartZoomLevel,
+  start: Date,
+  end: Date
+) => {
+  if (zoomLevel === 'days') {
+    return eachDayOfInterval({ start, end }).map((date) => ({
       date,
       startDay: differenceInDays(date, start),
       isMain: date.getDate() === 1,
-    })
-  );
+    }));
+  }
+
+  if (zoomLevel === 'months') {
+    return eachMonthOfInterval({ start, end }).map((date) => ({
+      date,
+      startDay: differenceInDays(date, start),
+      isMain: date.getDate() === 1 && date.getMonth() === 0,
+    }));
+  }
+
+  return eachMonthOfInterval({ start, end }).map((date) => ({
+    date,
+    startDay: differenceInDays(date, start),
+    isMain: date.getDate() === 1 && date.getMonth() === 0,
+  }));
+};
+
+const TimelineChartGrid: FC<TimelineChartGridProps> = ({
+  start,
+  end,
+  zoomLevel,
+}) => {
+  const lines = generateLines(zoomLevel, start, addDays(end, 1));
 
   return (
     <div className="TimelineChartGrid">

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartItem.scss
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartItem.scss
@@ -59,26 +59,27 @@
 }
 
 .TimelineChartItem--singleDay {
-  padding-block: 0.25 * $aleph-grid-size;
+  --timeline-item-bullet-size: 15px;
+  padding-block: 0.5 * $aleph-grid-size;
 }
 
 .TimelineChartItem--singleDay::before {
   content: '';
   display: block;
-  width: 66%;
-  padding-bottom: 66%;
-  margin: 17%;
-  transform: rotate(45deg);
+  width: var(--timeline-item-bullet-size);
+  height: var(--timeline-item-bullet-size);
+  transform: rotate(45deg) translateX(-50%);
+  transform-origin: center left;
   background-color: var(--timeline-item-color);
   border-radius: $pt-border-radius;
 }
 
 .TimelineChartItem--singleDay .TimelineChartItem__caption {
   position: absolute;
-  left: 100%;
+  left: var(--timeline-item-bullet-size);
   top: 50%;
   transform: translateY(-50%);
-  padding-left: 0.5 * $aleph-grid-size;
+  padding-left: 0.25 * $aleph-grid-size;
   color: var(--timeline-item-color);
   text-shadow: 0 0 1px white, 0 0 2px white, 0 0 3px white;
 }

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartItem.scss
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartItem.scss
@@ -10,6 +10,10 @@
     var(--timeline-chart-item-start-day) * var(--timeline-chart-day-width)
   );
   cursor: pointer;
+
+  transition-duration: var(--timeline-chart-transition-duration);
+  transition-property: width, margin;
+  transition-timing-function: var(--timeline-chart-transition-easing);
 }
 
 .TimelineChartItem__caption {

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.scss
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.scss
@@ -5,8 +5,7 @@
   top: -1 * $aleph-content-padding;
   z-index: 1;
   width: 100%;
-  height: 3 * $aleph-grid-size;
-  margin-bottom: $aleph-grid-size;
+  height: var(--timeline-chart-labels-height);
 }
 
 .TimelineChartLabels__label {
@@ -24,6 +23,8 @@
   color: $aleph-greyed-text;
   background-color: white;
   border-bottom: 1px solid $aleph-border-color;
+
+  animation: timeline-fadein var(--timeline-chart-transition-duration);
 }
 
 .TimelineChartLabels--days .TimelineChartLabels__text,

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.scss
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.scss
@@ -19,17 +19,16 @@
     (var(--timeline-chart-label-end-day) - var(--timeline-chart-label-start-day)) * var(--timeline-chart-day-width)
   );
 
-  padding: 0 $aleph-grid-size;
   line-height: 3 * $aleph-grid-size;
 
   color: $aleph-greyed-text;
   background-color: white;
   border-bottom: 1px solid $aleph-border-color;
-  border-left: 1px solid $aleph-border-color;
-  border-right: 1px solid $aleph-border-color;
 }
 
-.TimelineChartLabels__text {
+.TimelineChartLabels--days .TimelineChartLabels__text,
+.TimelineChartLabels--years .TimelineChartLabels__text {
   position: sticky;
   left: 0;
+  margin-right: $aleph-content-padding;
 }

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.tsx
@@ -51,7 +51,7 @@ const TimelineChartLabels: FC<TimelineChartLabelsProps> = ({
     >
       {labels.map(({ date, startDay, endDay }, index) => (
         <div
-          key={index}
+          key={`${zoomLevel}-${index}`}
           className="TimelineChartLabels__label"
           style={{
             ['--timeline-chart-label-start-day' as string]: startDay,

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.tsx
@@ -1,20 +1,48 @@
 import { FC } from 'react';
 import { FormattedDate } from 'react-intl';
-import { eachMonthOfInterval, differenceInDays, addMonths } from 'date-fns';
+import {
+  eachMonthOfInterval,
+  eachYearOfInterval,
+  differenceInDays,
+  addMonths,
+  addYears,
+} from 'date-fns';
+import { TimelineChartZoomLevel } from '../types';
 
 import './TimelineChartLabels.scss';
 
 type TimelineChartLabelsProps = {
   start: Date;
   end: Date;
+  zoomLevel: TimelineChartZoomLevel;
 };
 
-const TimelineChartLabels: FC<TimelineChartLabelsProps> = ({ start, end }) => {
-  const labels = eachMonthOfInterval({ start, end }).map((date) => ({
+const generateLabels = (
+  zoomLevel: TimelineChartZoomLevel,
+  start: Date,
+  end: Date
+) => {
+  if (zoomLevel === 'days' || zoomLevel === 'months') {
+    return eachMonthOfInterval({ start, end }).map((date) => ({
+      date,
+      startDay: differenceInDays(date, start),
+      endDay: differenceInDays(addMonths(date, 1), start),
+    }));
+  }
+
+  return eachYearOfInterval({ start, end }).map((date) => ({
     date,
     startDay: differenceInDays(date, start),
-    endDay: differenceInDays(addMonths(date, 1), start),
+    endDay: differenceInDays(addYears(date, 1), start),
   }));
+};
+
+const TimelineChartLabels: FC<TimelineChartLabelsProps> = ({
+  start,
+  end,
+  zoomLevel,
+}) => {
+  const labels = generateLabels(zoomLevel, start, end);
 
   return (
     <div className="TimelineChartLabels">
@@ -28,7 +56,11 @@ const TimelineChartLabels: FC<TimelineChartLabelsProps> = ({ start, end }) => {
           }}
         >
           <span className="TimelineChartLabels__text" aria-hidden="true">
-            <FormattedDate value={date} month="short" year="numeric" />
+            <FormattedDate
+              value={date}
+              month={zoomLevel !== 'years' ? 'short' : undefined}
+              year="numeric"
+            />
           </span>
         </div>
       ))}

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartLabels.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react';
+import c from 'classnames';
 import { FormattedDate } from 'react-intl';
 import {
   eachMonthOfInterval,
@@ -45,7 +46,9 @@ const TimelineChartLabels: FC<TimelineChartLabelsProps> = ({
   const labels = generateLabels(zoomLevel, start, end);
 
   return (
-    <div className="TimelineChartLabels">
+    <div
+      className={c('TimelineChartLabels', `TimelineChartLabels--${zoomLevel}`)}
+    >
       {labels.map(({ date, startDay, endDay }, index) => (
         <div
           key={index}

--- a/ui/src/components/Timeline/TimelineChart/TimelineChartPopover.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartPopover.tsx
@@ -52,16 +52,17 @@ function usePopoverState(delay: number) {
 }
 
 function useMousePosition(callback?: CallableFunction) {
-  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const [position, setPosition] = useState<{ x?: number; y?: number }>({});
 
   useEffect(() => {
     const handler = (event: MouseEvent) => {
+      setPosition({ x: event.clientX, y: event.clientY });
+
       // Prevent async state updates in test environment
       if (process.env.NODE_ENV === 'test') {
         return;
       }
 
-      setPosition({ x: event.clientX, y: event.clientY });
       callback && callback();
     };
 
@@ -139,7 +140,7 @@ const TimelineChartPopover: FC<TimelineChartPopoverProps> = ({
   return (
     <Popover2
       className="TimelineChartPopover"
-      isOpen={isOpen}
+      isOpen={isOpen && position.x !== undefined && position.y !== undefined}
       content={content}
       renderTarget={renderTarget}
       ref={popoverRef}

--- a/ui/src/components/Timeline/TimelineChart/util.test.ts
+++ b/ui/src/components/Timeline/TimelineChart/util.test.ts
@@ -1,0 +1,61 @@
+import { getStart, getEnd } from './util';
+
+describe('getStart', () => {
+  it('returns start of month/year depending on zoom level', () => {
+    const earliestDate = new Date('2020-03-01');
+    const latestDate = new Date('2030-03-01');
+    expect(getStart('days', earliestDate, latestDate)).toEqual(
+      new Date('2020-02-01')
+    );
+    expect(getStart('months', earliestDate, latestDate)).toEqual(
+      new Date('2020-02-01')
+    );
+    expect(getStart('years', earliestDate, latestDate)).toEqual(
+      new Date('2019-01-01')
+    );
+  });
+
+  it('adds padding before earliest date if timeline range is small', () => {
+    const earliestDate = new Date('2020-03-01');
+    const latestDate = new Date('2020-03-01');
+    expect(getStart('days', earliestDate, latestDate)).toEqual(
+      new Date('2019-12-01')
+    );
+    expect(getStart('months', earliestDate, latestDate)).toEqual(
+      new Date('2019-03-01')
+    );
+    expect(getStart('years', earliestDate, latestDate)).toEqual(
+      new Date('2017-01-01')
+    );
+  });
+});
+
+describe('getEnd', () => {
+  it('returns end of month/year depending on zoom level', () => {
+    const earliestDate = new Date('2010-03-01');
+    const latestDate = new Date('2020-03-01');
+    expect(getEnd('days', earliestDate, latestDate)).toEqual(
+      new Date('2020-04-30T23:59:59.999')
+    );
+    expect(getEnd('months', earliestDate, latestDate)).toEqual(
+      new Date('2020-04-30T23:59:59.999')
+    );
+    expect(getEnd('years', earliestDate, latestDate)).toEqual(
+      new Date('2021-12-31T23:59:59.999')
+    );
+  });
+
+  it('adds padding after latest date if timeline range is small', () => {
+    const earliestDate = new Date('2020-03-01');
+    const latestDate = new Date('2020-03-01');
+    expect(getEnd('days', earliestDate, latestDate)).toEqual(
+      new Date('2020-06-30T23:59:59.999')
+    );
+    expect(getEnd('months', earliestDate, latestDate)).toEqual(
+      new Date('2021-03-31T23:59:59.999')
+    );
+    expect(getEnd('years', earliestDate, latestDate)).toEqual(
+      new Date('2023-12-31T23:59:59.999')
+    );
+  });
+});

--- a/ui/src/components/Timeline/TimelineChart/util.ts
+++ b/ui/src/components/Timeline/TimelineChart/util.ts
@@ -1,0 +1,67 @@
+import {
+  differenceInMonths,
+  differenceInYears,
+  startOfMonth,
+  endOfMonth,
+  startOfYear,
+  endOfYear,
+  addMonths,
+  addYears,
+  subMonths,
+  subYears,
+} from 'date-fns';
+import { TimelineChartZoomLevel } from '../types';
+
+/**
+ * When a timelines has only very few events or the events cover only a very short time
+ * period the chart view would be significantly smaller than the viewport width. We apply
+ * some padding on the left and right in those cases. How much padding is applied depends
+ * on the zoom level. For example, in the "years" zomm level, a maximum of two years padding
+ * will be applied to each side.
+ */
+function getPadding(
+  zoomLevel: TimelineChartZoomLevel,
+  earliestDate: Date,
+  latestDate: Date
+) {
+  if (zoomLevel === 'days') {
+    const diff = Math.abs(differenceInMonths(latestDate, earliestDate));
+    return Math.max(1, 3 - diff); // in months
+  }
+
+  if (zoomLevel === 'months') {
+    const diff = Math.abs(differenceInMonths(latestDate, earliestDate));
+    return Math.max(1, 12 - diff); // in months
+  }
+
+  const diff = Math.abs(differenceInYears(latestDate, earliestDate));
+  return Math.max(1, 3 - diff); // in years
+}
+
+export function getStart(
+  zoomLevel: TimelineChartZoomLevel,
+  earliestDate: Date,
+  latestDate: Date
+) {
+  const padding = getPadding(zoomLevel, earliestDate, latestDate);
+
+  if (zoomLevel === 'days' || zoomLevel === 'months') {
+    return subMonths(startOfMonth(earliestDate), padding);
+  }
+
+  return subYears(startOfYear(earliestDate), padding);
+}
+
+export function getEnd(
+  zoomLevel: TimelineChartZoomLevel,
+  earliestDate: Date,
+  latestDate: Date
+) {
+  const padding = getPadding(zoomLevel, earliestDate, latestDate);
+
+  if (zoomLevel === 'days' || zoomLevel === 'months') {
+    return addMonths(endOfMonth(latestDate), padding);
+  }
+
+  return addYears(endOfYear(latestDate), padding);
+}

--- a/ui/src/components/Timeline/TimelineItemCreateDialog.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateDialog.tsx
@@ -38,7 +38,12 @@ const TimelineItemCreateDialog: FC<TimelineItemCreateDialogProps> = ({
   );
 
   return (
-    <Dialog title={title} usePortal={true} isOpen={isOpen} onClose={onClose}>
+    <Dialog
+      title={title}
+      isOpen={isOpen}
+      onClose={onClose}
+      shouldReturnFocusOnClose={false}
+    >
       <div className={Classes.DIALOG_BODY}>
         <TimelineItemCreateForm
           id="timeline-item-create-form"

--- a/ui/src/components/Timeline/TimelineList/TimelineList.test.tsx
+++ b/ui/src/components/Timeline/TimelineList/TimelineList.test.tsx
@@ -9,6 +9,7 @@ const model = new Model(defaultModel);
 const defaultProps = {
   selectedId: null,
   writeable: true,
+  zoomLevel: 'months' as const,
   onSelect: () => {},
   onRemove: () => {},
   onUnselect: () => {},

--- a/ui/src/components/Timeline/state.test.ts
+++ b/ui/src/components/Timeline/state.test.ts
@@ -14,6 +14,7 @@ beforeEach(() => {
     entities: [entity],
     layout: { vertices: [] },
     selectedId: null,
+    zoomLevel: 'months',
   };
 });
 
@@ -164,5 +165,18 @@ describe('REMOVE_ENTITY', () => {
 
     expect(newState.entities).toHaveLength(0);
     expect(newState.selectedId).toBeNull();
+  });
+});
+
+describe('SET_ZOOM_LEVEL', () => {
+  it('updates zoom level', () => {
+    expect(state.zoomLevel).toEqual('months');
+
+    const newState = reducer(state, {
+      type: 'SET_ZOOM_LEVEL',
+      payload: { zoomLevel: 'years' },
+    });
+
+    expect(newState.zoomLevel).toEqual('years');
   });
 });

--- a/ui/src/components/Timeline/state.ts
+++ b/ui/src/components/Timeline/state.ts
@@ -1,11 +1,17 @@
 import { Entity } from '@alephdata/followthemoney';
-import type { Vertex, Layout, TimelineEntity } from './types';
+import type {
+  Vertex,
+  Layout,
+  TimelineEntity,
+  TimelineChartZoomLevel,
+} from './types';
 import { updateVertex } from './util';
 
 type State = {
   entities: Array<Entity>;
   layout: Layout;
   selectedId: string | null;
+  zoomLevel: TimelineChartZoomLevel;
 };
 
 type SelectEntityAction = {
@@ -47,13 +53,21 @@ type RemoveEntityAction = {
   };
 };
 
+type SetZoomLevelAction = {
+  type: 'SET_ZOOM_LEVEL';
+  payload: {
+    zoomLevel: TimelineChartZoomLevel;
+  };
+};
+
 type Action =
   | SelectEntityAction
   | UnselectEntityAction
   | UpdateVertexAction
   | UpdateEntityAction
   | CreateEntityAction
-  | RemoveEntityAction;
+  | RemoveEntityAction
+  | SetZoomLevelAction;
 
 const reducer = (state: State, action: Action): State => {
   const { type } = action;
@@ -109,6 +123,10 @@ const reducer = (state: State, action: Action): State => {
       state.selectedId === action.payload.entity.id ? null : state.selectedId;
 
     return { ...state, selectedId, entities };
+  }
+
+  if (type === 'SET_ZOOM_LEVEL') {
+    return { ...state, zoomLevel: action.payload.zoomLevel };
   }
 
   throw new Error('Invalid action type.');

--- a/ui/src/components/Timeline/types.ts
+++ b/ui/src/components/Timeline/types.ts
@@ -1,16 +1,9 @@
 import { Schema, Entity, Value } from '@alephdata/followthemoney';
 import { TimelineItem } from './util';
 
-export enum TimelineRenderer {
-  List = 'list',
-  Chart = 'chart',
-}
+export type TimelineRenderer = 'list' | 'chart';
 
-export enum TimelineChartZoomLevel {
-  Day = 'day',
-  Month = 'month',
-  Year = 'year',
-}
+export type TimelineChartZoomLevel = 'days' | 'months' | 'years';
 
 export type TimelineEntity = Omit<Entity, 'getTemporalStart'> & {
   getTemporalStart: () => NonNullable<ReturnType<Entity['getTemporalStart']>>;
@@ -36,6 +29,7 @@ export type EntityProperties = {
 export type TimelineRendererProps = {
   items: Array<TimelineItem>;
   selectedId: string | null;
+  zoomLevel: TimelineChartZoomLevel;
   writeable?: boolean;
   onSelect: (entity: Entity) => void;
   onRemove: (entity: Entity) => void;

--- a/ui/src/components/Timeline/util.ts
+++ b/ui/src/components/Timeline/util.ts
@@ -28,6 +28,10 @@ function endOfMonth(year: number, month: number): number {
   return date.getDate();
 }
 
+/**
+ * Returns the first scrollable parent element for the given element
+ * or the element itself if it is scrollable.
+ */
 function getScrollParent(element: HTMLElement): HTMLElement {
   const style = window.getComputedStyle(element);
   const scrollable = ['scroll', 'auto'];
@@ -48,6 +52,10 @@ function getScrollParent(element: HTMLElement): HTMLElement {
   return document.documentElement;
 }
 
+/**
+ * Checks whether the element is at least partially within the visible
+ * part of the scroll parent.
+ */
 export function isScrolledIntoView(element: HTMLElement): boolean {
   const container = getScrollParent(element);
   const containerRect = container.getBoundingClientRect();
@@ -61,6 +69,10 @@ export function isScrolledIntoView(element: HTMLElement): boolean {
   );
 }
 
+/**
+ * Merges multiple refs, ensuring that all refs get updated whenever the
+ * merged ref is updated.
+ */
 export function mergeRefs<T>(
   ...refs: Array<RefCallback<T> | MutableRefObject<T | null> | null>
 ): RefCallback<T> {
@@ -150,7 +162,7 @@ export class TimelineItem {
 }
 
 /**
- * FollowTheMoney allows dates with different degress of precision, e.g. `2022`,
+ * FollowTheMoney allows dates with different degrees of precision, e.g. `2022`,
  * `2022-01`, and `2022-01-01` are all valid dates. This class parses FtM date strings
  * and provides utility methods to work with imprecise dates, e.g. to get the earliest
  * or latest possible date.
@@ -221,6 +233,11 @@ export class ImpreciseDate {
   }
 }
 
+/**
+ * Handles keyboard-related logic for a list of timeline items, for example
+ * moving focus to the next/previous element when pressing arrow keys and
+ * unselecting elements when pressing the escape key.
+ */
 export function useTimelineKeyboardNavigation<T extends HTMLElement>(
   items: Array<TimelineItem>,
   onUnselect: () => void
@@ -257,6 +274,10 @@ export function useTimelineKeyboardNavigation<T extends HTMLElement>(
   return [itemRefs, { onKeyDown }] as const;
 }
 
+/**
+ * Handles keyboard-related logic for a single timeline item, for example
+ * selecting the item when pressing enter.
+ */
 export function useTimelineItemKeyboardNavigation(
   entity: Entity,
   onSelect: (entity: Entity) => void
@@ -270,6 +291,9 @@ export function useTimelineItemKeyboardNavigation(
   return { onKeyUp } as const;
 }
 
+/**
+ * Executes a side-effect whenever a timeline item is selected.
+ */
 export function useTimelineItemSelectedChange(
   selected: boolean | undefined,
   onSelected: () => void
@@ -292,6 +316,11 @@ export function useTimelineItemSelectedChange(
   }, [selected, onSelected]);
 }
 
+/**
+ * Provides an easy way to fetch entity suggestions in component (for
+ * example when using entity auto-complete fields, handling request
+ * throttling and state updates.
+ */
 export function useEntitySuggestions(
   schema: Schema,
   fetchSuggestions: FetchEntitySuggestions
@@ -329,6 +358,9 @@ export function useEntitySuggestions(
   return [suggestions, isFetching, onQueryChange] as const;
 }
 
+/**
+ * Exposes the native browser form validation state in a simple state variable.
+ */
 export function useFormValidity(formRef: RefObject<HTMLFormElement>) {
   const [isValid, setIsValid] = useState(false);
 
@@ -339,6 +371,9 @@ export function useFormValidity(formRef: RefObject<HTMLFormElement>) {
   return [isValid, onInput] as const;
 }
 
+/**
+ * Return a new layout object, replacing or inserting the given vertex.
+ */
 export function updateVertex(layout: Layout, updatedVertex: Vertex): Layout {
   const { vertices } = layout;
   const index = layout.vertices.findIndex(


### PR DESCRIPTION
This adds three different zoom levels (days/months/years) for the new timelines chart view. The default zoom level is "months".

The chart view is currently not enabled in the UI. In order to enable it, add a `renderer="chart"` property to the `Timeline` component here:

https://github.com/alephdata/aleph/blob/267d93611846c079cc72838ef5464d0878506c62/ui/src/screens/TimelineScreen/TimelineScreen.jsx#L195-L204

***

**Possible future enhancements:**

- [ ] Select default zoom level based on time period the timeline covers. For example, if the timeline contains only events within a single month, use the "days" view. If events are distributed across multiple years, use the "years" view.
- [ ] Store the zoom level setting (per timeline and user).