### PR TITLE
Fix unsupported date formats

### DIFF
--- a/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
@@ -151,20 +151,27 @@ it('supports a variety of different date formats', async () => {
 
   // Invalid dates
   await userEvent.clear(input);
-  await userEvent.type(input, '20222');
-  expect(input.checkValidity()).toBe(false);
-
-  await userEvent.clear(input);
   await userEvent.type(input, '2022-');
-  expect(input.checkValidity()).toBe(false);
-
-  await userEvent.clear(input);
-  await userEvent.type(input, '2022-123');
   expect(input.checkValidity()).toBe(false);
 
   await userEvent.clear(input);
   await userEvent.type(input, '2022-01-');
   expect(input.checkValidity()).toBe(false);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-01-123');
+  expect(input.checkValidity()).toBe(false);
+
+  // Automatically reformats to match supported format
+  await userEvent.clear(input);
+  await userEvent.type(input, '202302');
+  expect(input).toHaveValue('2023-02');
+  expect(input.checkValidity()).toBe(true);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '20230203');
+  expect(input).toHaveValue('2023-02-03');
+  expect(input.checkValidity()).toBe(true);
 });
 
 it('calls callback with new entity object', async () => {

--- a/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
@@ -121,6 +121,52 @@ it('renders temporal extent fields', async () => {
   expect(closeDate).toBeInTheDocument();
 });
 
+it('supports a variety of different date formats', async () => {
+  render(<TimelineItemCreateForm {...defaultProps} />);
+
+  const input = screen.getByRole('textbox', {
+    name: 'Start date',
+  }) as HTMLInputElement;
+  expect(input.checkValidity()).toBe(false);
+
+  // Valid dates
+  await userEvent.type(input, '2022');
+  expect(input.checkValidity()).toBe(true);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-1');
+  expect(input.checkValidity()).toBe(true);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-01');
+  expect(input.checkValidity()).toBe(true);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-1-1');
+  expect(input.checkValidity()).toBe(true);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-01-01');
+  expect(input.checkValidity()).toBe(true);
+
+  // Invalid dates
+  await userEvent.clear(input);
+  await userEvent.type(input, '20222');
+  expect(input.checkValidity()).toBe(false);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-');
+  expect(input.checkValidity()).toBe(false);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-123');
+  expect(input.checkValidity()).toBe(false);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-01-');
+  expect(input.checkValidity()).toBe(false);
+});
+
 it('calls callback with new entity object', async () => {
   const onSubmit = jest.fn();
 

--- a/ui/src/components/Timeline/TimelineItemCreateForm.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.tsx
@@ -4,6 +4,7 @@ import {
   useState,
   forwardRef,
   FormEventHandler,
+  ChangeEventHandler,
   KeyboardEventHandler,
   ForwardedRef,
 } from 'react';
@@ -21,7 +22,7 @@ import type {
   EdgeSchema,
   FetchEntitySuggestions,
 } from './types';
-import { useEntitySuggestions } from './util';
+import { useEntitySuggestions, reformatDateString } from './util';
 import { SchemaSelect, EntitySelect } from 'react-ftm';
 import { Button, Alignment, FormGroup, InputGroup } from '@blueprintjs/core';
 
@@ -39,7 +40,8 @@ type PropertyFieldProps = {
   required?: boolean;
   placeholder?: string;
   pattern?: string;
-  onChange: (property: Property, value: Value) => void;
+  onChange?: ChangeEventHandler<HTMLInputElement>;
+  onInput?: KeyboardEventHandler<HTMLInputElement>;
 };
 
 type EntityPropertyFieldProps = {
@@ -103,6 +105,7 @@ const PropertyField: FC<PropertyFieldProps> = ({
   placeholder,
   pattern,
   onChange,
+  onInput,
 }) => (
   <FormGroup
     label={property.label}
@@ -123,7 +126,8 @@ const PropertyField: FC<PropertyFieldProps> = ({
       required={required}
       placeholder={placeholder}
       pattern={pattern}
-      onChange={(event) => onChange(property, event.target.value)}
+      onChange={onChange}
+      onInput={onInput}
     />
   </FormGroup>
 );
@@ -209,7 +213,15 @@ const TemporalExtentFields: FC<TemporalExtentFieldsProps> = ({
           key={property.name}
           property={property}
           value={typeof value === 'string' ? value : ''}
-          onChange={onChange}
+          onChange={(event) => onChange(property, event.currentTarget.value)}
+          onInput={(event) => {
+            const target = event.currentTarget;
+            const newValue = reformatDateString(target.value);
+
+            if (target.value !== newValue) {
+              target.value = newValue;
+            }
+          }}
           placeholder="YYYY-MM-DD"
           pattern="\d{4}(?:-\d{1,2}){0,2}"
           required={required}
@@ -261,7 +273,7 @@ const CaptionField: FC<CaptionFieldProps> = ({
       property={caption}
       value={typeof value === 'string' ? value : ''}
       required
-      onChange={onChange}
+      onChange={(event) => onChange(caption, event.currentTarget.value)}
     />
   );
 };

--- a/ui/src/components/Timeline/TimelineItemCreateForm.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.tsx
@@ -211,7 +211,7 @@ const TemporalExtentFields: FC<TemporalExtentFieldsProps> = ({
           value={typeof value === 'string' ? value : ''}
           onChange={onChange}
           placeholder="YYYY-MM-DD"
-          pattern="\d{4}-\d{1,2}-\d{1,2}"
+          pattern="\d{4}(?:-\d{1,2}){0,2}"
           required={required}
         />
       ))}

--- a/ui/src/components/Timeline/util.test.ts
+++ b/ui/src/components/Timeline/util.test.ts
@@ -1,5 +1,5 @@
 import { Model, defaultModel } from '@alephdata/followthemoney';
-import { TimelineItem, ImpreciseDate } from './util';
+import { TimelineItem, ImpreciseDate, reformatDateString } from './util';
 
 const model = new Model(defaultModel);
 
@@ -231,5 +231,28 @@ describe('ImpreciseDate', () => {
     date = new ImpreciseDate('2022');
     expect(date.getEarliest()).toEqual(new Date(2022, 0, 1));
     expect(date.getLatest()).toEqual(new Date(2022, 11, 31));
+  });
+});
+
+describe('reformatDateString', () => {
+  it('returns original value if format is not recognized', () => {
+    expect(reformatDateString('what is this')).toEqual('what is this');
+  });
+
+  it('returns original value if format is already supported', () => {
+    expect(reformatDateString('2022')).toEqual('2022');
+    expect(reformatDateString('2022-1')).toEqual('2022-1');
+    expect(reformatDateString('2022-01')).toEqual('2022-01');
+    expect(reformatDateString('2022-1-1')).toEqual('2022-1-1');
+    expect(reformatDateString('2022-01-01')).toEqual('2022-01-01');
+  });
+
+  it('reformats values to use hyphens', () => {
+    expect(reformatDateString('20220')).toEqual('2022-0');
+    expect(reformatDateString('202201')).toEqual('2022-01');
+    expect(reformatDateString('2022010')).toEqual('2022-01-0');
+    expect(reformatDateString('2022-010')).toEqual('2022-01-0');
+    expect(reformatDateString('20220101')).toEqual('2022-01-01');
+    expect(reformatDateString('2022-0101')).toEqual('2022-01-01');
   });
 });

--- a/ui/src/components/Timeline/util.ts
+++ b/ui/src/components/Timeline/util.ts
@@ -389,3 +389,28 @@ export function updateVertex(layout: Layout, updatedVertex: Vertex): Layout {
 
   return { vertices: newVertices };
 }
+
+/**
+ * Reformat a date string to match one of the formats supported by FtM.
+ * For example, this will reformat `20220102` to `2022-01-02`. Returns the
+ * original value if the string cannot be reformatted automatically or
+ * already is in a supported format.
+ */
+export function reformatDateString(value: string) {
+  const yearMonth = /^(\d{4})(\d{1,2})$/;
+  const yearMonthDay = /^(\d{4})-?(\d{2})-?(\d{1,2})$/;
+
+  let match = value.match(yearMonth);
+
+  if (match) {
+    return `${match[1]}-${match[2]}`;
+  }
+
+  match = value.match(yearMonthDay);
+
+  if (match) {
+    return `${match[1]}-${match[2]}-${match[3]}`;
+  }
+
+  return value;
+}


### PR DESCRIPTION
* Allows users to add items with imprecise/vague dates (e.g. `2022` or `2022-01`).
* Allows users to enter (or copy-paste) dates without hyphens (e.g. `20220322` or `202203`).