### PR TITLE
Add feedback button and popover message

### DIFF
--- a/ui/src/components/Timeline/FeedbackButton.scss
+++ b/ui/src/components/Timeline/FeedbackButton.scss
@@ -1,0 +1,10 @@
+@import 'app/variables.scss';
+
+.FeedbackButton__text {
+  text-decoration: underline;
+  color: $aleph-greyed-text;
+}
+
+.FeedbackButton:hover .FeedbackButton__text {
+  color: inherit;
+}

--- a/ui/src/components/Timeline/FeedbackButton.tsx
+++ b/ui/src/components/Timeline/FeedbackButton.tsx
@@ -1,0 +1,67 @@
+import { FC } from 'react';
+import { connect } from 'react-redux';
+import { AnchorButton, Button } from '@blueprintjs/core';
+import { Popover2 as Popover, Classes } from '@blueprintjs/popover2';
+import { setConfigValue } from 'actions/configActions';
+
+import './FeedbackButton.scss';
+
+type FeedbackButtonProps = {
+  showMessage: boolean;
+  setConfigValue: (payload: object) => void;
+};
+
+const FeedbackButton: FC<FeedbackButtonProps> = ({
+  showMessage,
+  setConfigValue,
+}) => {
+  const popoverContent = (
+    <>
+      <p>
+        <strong>We have overhauled the timelines feature! 🎉</strong>
+      </p>
+      <p>
+        It’s now easier to add items to a timeline and the new chart view allows
+        you to visualize your data.
+      </p>
+      <p>
+        There are still a few rough edges here and there. And we have a few more
+        enhancements planned for the future.
+      </p>
+      <p>
+        We’d love to hear your feedback. Is there something that would make
+        timelines more useful to you? Click the link above to let us know.
+      </p>
+      <Button
+        fill
+        onClick={() => setConfigValue({ timelinesMessageDismissed: true })}
+      >
+        Don’t show this message again
+      </Button>
+    </>
+  );
+
+  return (
+    <Popover
+      placement="bottom"
+      isOpen={showMessage}
+      popoverClassName={Classes.POPOVER2_CONTENT_SIZING}
+      content={popoverContent}
+    >
+      <AnchorButton
+        href="https://forms.gle/yU3bTKv2qG62AEBEA"
+        target="_blank"
+        minimal
+        className="FeedbackButton"
+      >
+        <span className="FeedbackButton__text">Give Feedback</span>
+      </AnchorButton>
+    </Popover>
+  );
+};
+
+const mapStateToProps = (state: any) => ({
+  showMessage: !state.config.timelinesMessageDismissed,
+});
+
+export default connect(mapStateToProps, { setConfigValue })(FeedbackButton);

--- a/ui/src/components/Timeline/TimelineActions.tsx
+++ b/ui/src/components/Timeline/TimelineActions.tsx
@@ -5,6 +5,7 @@ import { FormattedMessage, useIntl } from 'react-intl';
 
 import TimelineItemCreateButton from './TimelineItemCreateButton';
 import TimelineZoomLevelSwitch from './TimelineZoomLevelSwitch';
+import FeedbackButton from './FeedbackButton';
 import {
   selectIsEmpty,
   selectIsZoomEnabled,
@@ -79,6 +80,15 @@ const TimelineActions: FC<TimelineActionsProps> = ({ writeable }) => {
           })
         }
       />
+      {
+        // The `FeedbackButton` component relies on a Redux store being provided
+        // in a context. Apart from the feedback button, the entire timeliens feature
+        // is independent from the Redux app store, so instead of setting up a test
+        // environment that mocks the store, we resort to this hacky workaround and
+        // simply do not render the feedback button in tests. This is fine because
+        // the feedback button is not critical.
+        process.env.NODE_ENV !== 'test' && <FeedbackButton />
+      }
     </div>
   );
 };


### PR DESCRIPTION
* Adds a feedback button. The button links to an external Google Form.
* Displays a popover message when a user opens the new timelines for the first time. The message can be dismissed (which will be persisted in local storage).
* The message text is hard-coded and cannot be translated, because it’s temporary and unlikely that it gets translated anyway.

![Screen Shot 2023-03-24 at 15 44 44](https://user-images.githubusercontent.com/1512805/227560584-9cbbc2ad-62bf-4f2f-997a-b946282b9686.png)
