### PR TITLE
Show timeline items with invalid dates

### DIFF
--- a/ui/src/components/Timeline/Timeline.scss
+++ b/ui/src/components/Timeline/Timeline.scss
@@ -29,10 +29,6 @@
   scroll-padding-block: 50px;
 }
 
-.Timeline--list .Timeline__main {
-  padding: $aleph-content-padding;
-}
-
 .Timeline--selected .Timeline__main {
   right: var(--viewer-width);
 }

--- a/ui/src/components/Timeline/Timeline.tsx
+++ b/ui/src/components/Timeline/Timeline.tsx
@@ -53,13 +53,7 @@ const Timeline: FC<TimelineProps> = ({
   const zoomLevel = selectZoomLevel(state);
 
   return (
-    <div
-      className={c(
-        'Timeline',
-        `Timeline--${state.renderer}`,
-        selectedEntity && 'Timeline--selected'
-      )}
-    >
+    <div className={c('Timeline', selectedEntity && 'Timeline--selected')}>
       <TimelineItemCreateDialog
         model={model}
         isOpen={state.showCreateDialog}

--- a/ui/src/components/Timeline/TimelineCallout.scss
+++ b/ui/src/components/Timeline/TimelineCallout.scss
@@ -1,0 +1,12 @@
+@import 'app/variables.scss';
+
+.TimelineCallout.TimelineCallout {
+  display: flex;
+  align-items: center;
+  gap: 0.75 * $aleph-grid-size;
+  padding-inline: $aleph-content-padding;
+  border-top: 1px solid rgba($pt-intent-warning, 0.25);
+  border-bottom: 1px solid rgba($pt-intent-warning, 0.25);
+  border-radius: 0;
+  font-weight: 500;
+}

--- a/ui/src/components/Timeline/TimelineCallout.tsx
+++ b/ui/src/components/Timeline/TimelineCallout.tsx
@@ -1,0 +1,13 @@
+import { FC } from 'react';
+import { Callout, Icon, Intent } from '@blueprintjs/core';
+
+import './TimelineCallout.scss';
+
+const TimelineCallout: FC = ({ children }) => (
+  <Callout className="TimelineCallout" intent={Intent.WARNING} icon={null}>
+    <Icon icon="warning-sign" />
+    <div className="TimelineCallout__text">{children}</div>
+  </Callout>
+);
+
+export default TimelineCallout;

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.test.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.test.tsx
@@ -146,6 +146,31 @@ it('focuses item on click', async () => {
   expect(document.activeElement).toEqual(listItems[1]);
 });
 
+it('handles empty timelines gracefully', () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2022-01-01'));
+
+  render(<TimelineChart {...defaultProps} items={[]} />);
+
+  expect(screen.getByText('Jan 2021')).toBeInTheDocument();
+  expect(screen.getByText('Jan 2023')).toBeInTheDocument();
+});
+
+it('handles timelines that contain only items with invalid dates gracefully', () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2022-01-01'));
+  const eventWithoutDate = model.getEntity({
+    schema: 'Event',
+    id: '0',
+  });
+  const items = [new TimelineItem(eventWithoutDate)];
+
+  render(<TimelineChart {...defaultProps} items={items} />);
+
+  expect(screen.getByText('Jan 2021')).toBeInTheDocument();
+  expect(screen.getByText('Jan 2023')).toBeInTheDocument();
+});
+
 describe('Zoom levels', () => {
   describe('Days', () => {
     it('renders one grid label per month', () => {

--- a/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChart.tsx
@@ -20,11 +20,15 @@ const TimelineChart: FC<TimelineRendererProps> = ({
   onUnselect,
   zoomLevel,
 }) => {
+  const validItems = items.filter(
+    (item) => item.entity.getTemporalStart() !== null
+  );
+
   const [showPopover, setShowPopover] = useState(false);
   const [popoverItem, setPopoverItem] = useState<TimelineItem | null>(null);
 
   const [itemRefs, keyboardProps] =
-    useTimelineKeyboardNavigation<HTMLLIElement>(items, onUnselect);
+    useTimelineKeyboardNavigation<HTMLLIElement>(validItems, onUnselect);
 
   // Scroll first item into view on initial render
   useEffect(() => {
@@ -33,15 +37,17 @@ const TimelineChart: FC<TimelineRendererProps> = ({
     }
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const earliestDate = items
-    .map((item) => item.getEarliestDate())
-    .filter((date): date is Date => date !== undefined)
-    .sort((a, b) => a.getTime() - b.getTime())[0];
+  const earliestDate =
+    validItems
+      .map((item) => item.getEarliestDate())
+      .filter((date): date is Date => date !== undefined)
+      .sort((a, b) => a.getTime() - b.getTime())[0] || new Date();
 
-  const latestDate = items
-    .map((item) => item.getLatestDate())
-    .filter((date): date is Date => date !== undefined)
-    .sort((a, b) => b.getTime() - a.getTime())[0];
+  const latestDate =
+    validItems
+      .map((item) => item.getLatestDate())
+      .filter((date): date is Date => date !== undefined)
+      .sort((a, b) => b.getTime() - a.getTime())[0] || new Date();
 
   const start = getStart(zoomLevel, earliestDate, latestDate);
   const end = getEnd(zoomLevel, earliestDate, latestDate);
@@ -73,7 +79,7 @@ const TimelineChart: FC<TimelineRendererProps> = ({
       )}
 
       <ul className="TimelineChart__list">
-        {items.map((item, index) => (
+        {validItems.map((item, index) => (
           <TimelineChartItem
             key={item.entity.id}
             timelineStart={start}

--- a/ui/src/components/Timeline/TimelineList/TimelineList.scss
+++ b/ui/src/components/Timeline/TimelineList/TimelineList.scss
@@ -1,11 +1,11 @@
 @import 'app/variables';
 
-.TimelineList {
+.TimelineList__list {
   --timeline-list-padding: #{0.75 * $aleph-grid-size} #{1.5 * $aleph-grid-size};
   --timeline-list-color-width: 4px;
 
-  width: 100%;
-  margin: 0;
+  width: calc(100% - #{2 * $aleph-content-padding});
+  margin: $aleph-content-padding;
   padding: 0;
   border-spacing: 0 0.25 * $aleph-grid-size;
 }

--- a/ui/src/components/Timeline/TimelineList/TimelineList.test.tsx
+++ b/ui/src/components/Timeline/TimelineList/TimelineList.test.tsx
@@ -164,3 +164,18 @@ it('shows end date column if at least one entity has a temporal end', () => {
 
   expect(headers).toEqual(['Start date', 'End date', 'Caption', 'Actions']);
 });
+
+it('shows a warning callout if timeline has items with invalid dates', () => {
+  const eventWithoutDate = model.getEntity({
+    schema: 'Event',
+    id: '0',
+  });
+  const items = [new TimelineItem(eventWithoutDate)];
+
+  render(<TimelineList {...defaultProps} items={items} />);
+
+  const callout = screen.getByText(
+    /This timeline has items with invalid or missing dates./
+  );
+  expect(callout).toBeInTheDocument();
+});

--- a/ui/src/components/Timeline/TimelineList/TimelineList.tsx
+++ b/ui/src/components/Timeline/TimelineList/TimelineList.tsx
@@ -2,6 +2,7 @@ import { FC } from 'react';
 import { Classes } from '@blueprintjs/core';
 import c from 'classnames';
 import TimelineListItem from './TimelineListItem';
+import TimelineCallout from '../TimelineCallout';
 import { useTimelineKeyboardNavigation } from '../util';
 import type { TimelineRendererProps } from '../types';
 
@@ -16,72 +17,88 @@ const TimelineList: FC<TimelineRendererProps> = ({
   onUnselect,
   selectedId,
 }) => {
+  const hasInvalidItems = items.some(
+    (item) => item.entity.getTemporalStart() === null
+  );
   const showEndDate = items.some((item) => item.entity.getTemporalEnd());
   const [itemRefs, keyboardProps] =
     useTimelineKeyboardNavigation<HTMLTableRowElement>(items, onUnselect);
 
   return (
-    <table
-      {...keyboardProps}
-      className={c('TimelineList', Classes.FOCUS_STYLE_MANAGER_IGNORE)}
-    >
-      <thead>
-        <tr className="TimelineList__header">
-          {showEndDate ? (
-            <>
-              <th>
-                <FormattedMessage
-                  id="timeline.list.start_date"
-                  defaultMessage="Start date"
-                />
-              </th>
-              <th>
-                <FormattedMessage
-                  id="timeline.list.end_date"
-                  defaultMessage="End date"
-                />
-              </th>
-            </>
-          ) : (
-            <th>
-              <FormattedMessage id="timeline.list.date" defaultMessage="Date" />
-            </th>
-          )}
-          <th>
-            <FormattedMessage
-              id="timeline.list.caption"
-              defaultMessage="Caption"
-            />
-          </th>
-          {writeable && (
-            <th>
-              <span className="visually-hidden">
-                <FormattedMessage
-                  id="timeline.list.actions"
-                  defaultMessage="Actions"
-                />
-              </span>
-            </th>
-          )}
-        </tr>
-      </thead>
-      <tbody>
-        {items.map((item, index) => (
-          <TimelineListItem
-            key={item.entity.id}
-            entity={item.entity}
-            writeable={writeable}
-            muted={!!selectedId && item.entity.id !== selectedId}
-            selected={item.entity.id === selectedId}
-            color={item.getColor()}
-            showEndDate={showEndDate}
-            onSelect={onSelect}
-            onRemove={onRemove}
-            ref={itemRefs[index]}
+    <div className="TimelineList">
+      {hasInvalidItems && (
+        <TimelineCallout>
+          <FormattedMessage
+            id="timeline.invalid_dates_warning"
+            defaultMessage="This timeline has items with invalid or missing dates. Check the list below and add dates or remove items."
           />
-        ))}
-      </tbody>
-    </table>
+        </TimelineCallout>
+      )}
+      <table
+        {...keyboardProps}
+        className={c('TimelineList__list', Classes.FOCUS_STYLE_MANAGER_IGNORE)}
+      >
+        <thead>
+          <tr className="TimelineList__header">
+            {showEndDate ? (
+              <>
+                <th>
+                  <FormattedMessage
+                    id="timeline.list.start_date"
+                    defaultMessage="Start date"
+                  />
+                </th>
+                <th>
+                  <FormattedMessage
+                    id="timeline.list.end_date"
+                    defaultMessage="End date"
+                  />
+                </th>
+              </>
+            ) : (
+              <th>
+                <FormattedMessage
+                  id="timeline.list.date"
+                  defaultMessage="Date"
+                />
+              </th>
+            )}
+            <th>
+              <FormattedMessage
+                id="timeline.list.caption"
+                defaultMessage="Caption"
+              />
+            </th>
+            {writeable && (
+              <th>
+                <span className="visually-hidden">
+                  <FormattedMessage
+                    id="timeline.list.actions"
+                    defaultMessage="Actions"
+                  />
+                </span>
+              </th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item, index) => (
+            <TimelineListItem
+              key={item.entity.id}
+              entity={item.entity}
+              writeable={writeable}
+              muted={!!selectedId && item.entity.id !== selectedId}
+              selected={item.entity.id === selectedId}
+              color={item.getColor()}
+              showEndDate={showEndDate}
+              onSelect={onSelect}
+              onRemove={onRemove}
+              ref={itemRefs[index]}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 };
 

--- a/ui/src/components/Timeline/TimelineList/TimelineListItem.scss
+++ b/ui/src/components/Timeline/TimelineList/TimelineListItem.scss
@@ -30,6 +30,19 @@
   color: $aleph-greyed-text;
 }
 
+.TimelineListItem__warning {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5 * $aleph-grid-size;
+  padding: 0.5 * $aleph-grid-size $aleph-grid-size;
+  margin: 0.5 * $aleph-grid-size 0;
+
+  font-weight: 500;
+  background-color: var(--timeline-item-color);
+  color: rgba(255, 255, 255, 0.9);
+  border-radius: $aleph-border-radius;
+}
+
 // Double class is required in order to increase specificity over the
 // default Blueprint table styles.
 .TimelineListItem__actions.TimelineListItem__actions {

--- a/ui/src/components/Timeline/TimelineList/TimelineListItem.test.tsx
+++ b/ui/src/components/Timeline/TimelineList/TimelineListItem.test.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen } from 'testUtils';
 import TimelineListItem from './TimelineListItem';
 import { Entity, Model, defaultModel } from '@alephdata/followthemoney';
 
@@ -58,6 +58,20 @@ it('renders start and end date', () => {
   const endCell = screen.getByText('2022-02-01');
   expect(startCell).toHaveTextContent(/2022-01-01\s*Start date/);
   expect(endCell).toHaveTextContent(/2022-02-01\s*End date/);
+});
+
+it('renders warning if item has no valid date', () => {
+  renderRow(
+    <TimelineListItem
+      entity={entity}
+      color="blue"
+      onSelect={() => {}}
+      onRemove={() => {}}
+    />
+  );
+
+  const warning = screen.getByText('Invalid or no date');
+  expect(warning).toBeInTheDocument();
 });
 
 it('renders caption', () => {

--- a/ui/src/components/Timeline/TimelineList/TimelineListItem.tsx
+++ b/ui/src/components/Timeline/TimelineList/TimelineListItem.tsx
@@ -64,11 +64,23 @@ const TimelineListItem = forwardRef<HTMLTableRowElement, TimelineListItemProps>(
         )}
       >
         <td className="TimelineListItem__date">
-          {start?.value}
-          <br />
-          <span className="TimelineListItem__property">
-            {start?.property.label}
-          </span>
+          {start ? (
+            <>
+              {start.value}
+              <br />
+              <span className="TimelineListItem__property">
+                {start?.property.label}
+              </span>
+            </>
+          ) : (
+            <div className="TimelineListItem__warning">
+              <Icon icon="warning-sign" color="white" />
+              <FormattedMessage
+                id="timeline.item.invalid_date"
+                defaultMessage="Invalid or no date"
+              />
+            </div>
+          )}
         </td>
         {showEndDate && (
           <td className="TimelineListItem__date">

--- a/ui/src/components/Timeline/state.ts
+++ b/ui/src/components/Timeline/state.ts
@@ -4,7 +4,6 @@ import { differenceInYears } from 'date-fns';
 import type {
   Vertex,
   Layout,
-  TimelineEntity,
   TimelineChartZoomLevel,
   TimelineRenderer,
 } from './types';
@@ -199,26 +198,30 @@ export function selectSelectedVertex(state: State): Vertex | null {
 }
 
 export function selectItems(state: State): Array<TimelineItem> {
-  return selectSortedEntities(state).map(
-    (entity) => new TimelineItem(entity, state.layout)
-  );
-}
-
-export function selectSortedEntities(state: State): Array<Entity> {
   return state.entities
-    .filter(
-      (entity): entity is TimelineEntity => entity.getTemporalStart() !== null
-    )
+    .map((entity) => new TimelineItem(entity, state.layout))
     .sort((a, b) => {
-      const aStart = a.getTemporalStart().value;
-      const bStart = b.getTemporalStart().value;
+      const aStart = a.entity.getTemporalStart();
+      const bStart = b.entity.getTemporalStart();
 
-      return aStart.localeCompare(bStart);
+      if (aStart === null && bStart === null) {
+        return 0;
+      }
+
+      if (aStart === null) {
+        return -1;
+      }
+
+      if (bStart === null) {
+        return 1;
+      }
+
+      return aStart.value.localeCompare(bStart.value);
     });
 }
 
 export function selectIsEmpty(state: State): boolean {
-  return selectSortedEntities(state).length <= 0;
+  return selectItems(state).length <= 0;
 }
 
 export function selectIsZoomEnabled(state: State): boolean {


### PR DESCRIPTION
**Note:** This PR is set up to be merged into the 3.14 release branch, but I think it would also be fine to merge it into develop and include it in the next release.

*** 

This displays timeline items (in list view) even if an item doesn’t have a valid date. Items without valid dates are displayed at the top of the list.

When creating new items through the timelines UI, dates are validated and users shouldn’t be able to add a new items without a valid date. However, that’s not the only way to add items to a timeline. Users may have created entities in network that don’t have dates yet (because dates aren’t a top priority when mapping out organization structures and relationships in a diagram). So when they add these existing entities to a timeline, we need to make users aware of the fact that they need to add dates to the entities in order to be able to visualize them.

Another case where this is relevant is when users have uploaded tabular data and created an entity mapping, but the source data contains invalid dates or uses an unrecognized date format.

![Screen Shot 2023-03-30 at 00 08 52](https://user-images.githubusercontent.com/1512805/228678877-463b8095-31d1-47c7-a48a-2873194e7a3b.png)

Ref #2673 