### PR TITLE
Add existing entities to timelines

### DIFF
--- a/ui/src/components/EntityTable/EntityTable.jsx
+++ b/ui/src/components/EntityTable/EntityTable.jsx
@@ -272,7 +272,7 @@ export class EntityTable extends Component {
               collection,
               entities: selectedEntities,
               onSuccess: this.clearSelection,
-              showTimelines: schema.isA('Interval'),
+              showTimelines: schema.getTemporalStartProperties().length > 0,
             }}
           />
           <EntityDeleteButton


### PR DESCRIPTION
This allows users to add existing entities of most schemata to timelines. Until now, this was only supported for interval entities (due to the limitations of the old timelines).

Note: Right now, when adding an existing entity that has now filled out date property (e.g. a company without an incorporation date), this entity wouldn’t be visible when displaying the timeline. This will be resolved as soon as #2963 is merged.

https://user-images.githubusercontent.com/1512805/233866664-f6d516b7-509b-4dcf-9bba-0610944141ad.mov

Ref #2673 