### PR TITLE
Add additional confirmation UI before destructive actions

### DIFF
--- a/e2e/models/investigations.py
+++ b/e2e/models/investigations.py
@@ -53,7 +53,8 @@ class Investigation:
         self.page.get_by_role("link", name=self.name).click()
         self.page.get_by_role("navigation").get_by_role("button").click()
         self.page.get_by_role("menuitem", name="Delete investigation").click()
-        self.page.get_by_role("button", name="Delete").click()
+        self.page.get_by_label("Confirmation").fill(self.name)
+        self.page.get_by_role("button", name="Delete this investigation").click()
 
         self.page.reload()
         expect(self.page.get_by_text(self.name)).to_have_count(0)

--- a/ui/src/components/common/DeleteDialog.tsx
+++ b/ui/src/components/common/DeleteDialog.tsx
@@ -1,0 +1,87 @@
+import { FC, ReactNode, useState } from 'react';
+import {
+  Dialog,
+  DialogBody,
+  Button,
+  Intent,
+  FormGroup,
+  InputGroup,
+} from '@blueprintjs/core';
+import { FormattedMessage } from 'react-intl';
+
+type DeleteDialogProps = {
+  title: ReactNode;
+  children: ReactNode;
+  buttonLabel: ReactNode;
+  expectedConfirmationValue: string;
+  isOpen: boolean;
+  onClose: () => void;
+  onDelete: () => void;
+};
+
+const DeleteDialog: FC<DeleteDialogProps> = ({
+  title,
+  children,
+  buttonLabel,
+  expectedConfirmationValue,
+  isOpen,
+  onClose,
+  onDelete,
+}) => {
+  const [confirmationValue, setConfirmationValue] = useState<string>('');
+  const enabled = confirmationValue === expectedConfirmationValue;
+
+  return (
+    <Dialog isOpen={isOpen} title={title} icon="trash" onClose={onClose}>
+      <DialogBody>
+        {children}
+
+        <p>
+          <FormattedMessage
+            id="delete_dialog.enter_label"
+            defaultMessage="Please enter {expectedConfirmationValue} to confirm:"
+            values={{
+              expectedConfirmationValue: (
+                <strong>{expectedConfirmationValue}</strong>
+              ),
+            }}
+          />
+        </p>
+
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            onDelete();
+          }}
+        >
+          <FormGroup
+            labelFor="delete-dialog-confirmation"
+            label={
+              <span className="visually-hidden">
+                <FormattedMessage
+                  id="delete_dialog.confirmation_label"
+                  defaultMessage="Confirmation"
+                />
+              </span>
+            }
+          >
+            <InputGroup
+              id="delete-dialog-confirmation"
+              placeholder={expectedConfirmationValue}
+              required
+              autoComplete="off"
+              onInput={(event) =>
+                setConfirmationValue(event.currentTarget.value)
+              }
+            />
+          </FormGroup>
+          <Button type="submit" intent={Intent.DANGER} fill disabled={!enabled}>
+            {buttonLabel}
+          </Button>
+        </form>
+      </DialogBody>
+    </Dialog>
+  );
+};
+
+export default DeleteDialog;

--- a/ui/src/components/common/DeleteDialog.tsx
+++ b/ui/src/components/common/DeleteDialog.tsx
@@ -28,6 +28,7 @@ const DeleteDialog: FC<DeleteDialogProps> = ({
   onClose,
   onDelete,
 }) => {
+  const [isLoading, setIsLoading] = useState<boolean>(false);
   const [confirmationValue, setConfirmationValue] = useState<string>('');
   const enabled = confirmationValue === expectedConfirmationValue;
 
@@ -51,6 +52,7 @@ const DeleteDialog: FC<DeleteDialogProps> = ({
         <form
           onSubmit={(event) => {
             event.preventDefault();
+            setIsLoading(true);
             onDelete();
           }}
         >
@@ -75,7 +77,13 @@ const DeleteDialog: FC<DeleteDialogProps> = ({
               }
             />
           </FormGroup>
-          <Button type="submit" intent={Intent.DANGER} fill disabled={!enabled}>
+          <Button
+            type="submit"
+            intent={Intent.DANGER}
+            fill
+            disabled={!enabled}
+            loading={isLoading}
+          >
             {buttonLabel}
           </Button>
         </form>

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -50,6 +50,7 @@ import JudgementButtons from './JudgementButtons';
 import LinkMenuItem from './LinkMenuItem';
 import LinkButton from './LinkButton';
 import WidthBoundary from './WidthBoundary';
+import DeleteDialog from './DeleteDialog';
 
 export {
   AnimatedCount,
@@ -104,6 +105,7 @@ export {
   LinkMenuItem,
   LinkButton,
   WidthBoundary,
+  DeleteDialog,
 };
 
 export * from './types';

--- a/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
+++ b/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
@@ -1,11 +1,19 @@
 import React, { Component } from 'react';
-import { FormattedMessage } from 'react-intl';
+import { FormattedMessage, defineMessages, injectIntl } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
+import { showSuccessToast } from 'app/toast';
 import withRouter from 'app/withRouter';
 import { deleteCollection } from 'actions';
 import { DeleteDialog } from 'components/common';
+
+const messages = defineMessages({
+  success: {
+    id: 'collection.delete.success',
+    defaultMessage: 'Successfully deleted {label}',
+  },
+});
 
 class CollectionDeleteDialog extends Component {
   constructor(props) {
@@ -14,9 +22,14 @@ class CollectionDeleteDialog extends Component {
   }
 
   async onDelete() {
-    const { collection, navigate, deleteCollection } = this.props;
+    const { collection, navigate, deleteCollection, intl } = this.props;
     const path = collection.casefile ? '/investigations' : '/datasets';
+    const successMessage = intl.formatMessage(messages.success, {
+      label: collection.label,
+    });
+
     await deleteCollection(collection);
+    showSuccessToast(successMessage);
     navigate({ pathname: path });
   }
 
@@ -82,5 +95,6 @@ const mapDispatchToProps = { deleteCollection };
 
 export default compose(
   withRouter,
-  connect(null, mapDispatchToProps)
+  connect(null, mapDispatchToProps),
+  injectIntl
 )(CollectionDeleteDialog);

--- a/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
+++ b/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
@@ -1,6 +1,13 @@
 import React, { Component } from 'react';
-import { Alert, Intent } from '@blueprintjs/core';
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  Intent,
+  FormGroup,
+  InputGroup,
+} from '@blueprintjs/core';
+import { FormattedMessage, injectIntl } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
@@ -8,21 +15,12 @@ import withRouter from 'app/withRouter';
 import { deleteCollection } from 'actions';
 import { Collection } from 'components/common';
 
-const messages = defineMessages({
-  button_confirm: {
-    id: 'collection.delete.confirm',
-    defaultMessage: 'Delete',
-  },
-  button_cancel: {
-    id: 'collection.delete.cancel',
-    defaultMessage: 'Cancel',
-  },
-});
-
 class CollectionDeleteDialog extends Component {
   constructor(props) {
     super(props);
     this.onDelete = this.onDelete.bind(this);
+
+    this.state = { confirmationValue: '' };
   }
 
   async onDelete() {
@@ -33,27 +31,107 @@ class CollectionDeleteDialog extends Component {
   }
 
   render() {
-    const { collection, intl } = this.props;
-    return (
-      <Alert
-        isOpen={this.props.isOpen}
-        icon="trash"
-        intent={Intent.DANGER}
-        cancelButtonText={intl.formatMessage(messages.button_cancel)}
-        confirmButtonText={intl.formatMessage(messages.button_confirm)}
-        onCancel={this.props.toggleDialog}
-        onConfirm={this.onDelete}
-      >
+    const { collection } = this.props;
+
+    const title = collection.casefile ? (
+      <FormattedMessage
+        id="collection.delete.title.investigation"
+        defaultMessage="Delete investigation"
+      />
+    ) : (
+      <FormattedMessage
+        id="collection.delete.title.dataset"
+        defaultMessage="Delete dataset"
+      />
+    );
+
+    const buttonLabel = (
+      <>
         <FormattedMessage
-          id="collection.delete.question"
-          defaultMessage="Are you sure you want to delete {collectionLabel} and all contained items?"
-          values={{
-            collectionLabel: (
-              <Collection.Label collection={collection} icon={false} />
-            ),
-          }}
-        />
-      </Alert>
+          id="collection.delete.confirm"
+          defaultMessage="I understand the consequences."
+        />{' '}
+        {collection.casefile ? (
+          <FormattedMessage
+            id="collection.delete.confirm.investigation"
+            defaultMessage="Delete this investigation."
+          />
+        ) : (
+          <FormattedMessage
+            id="collection.delete.confirm.dataset"
+            defaultMessage="Delete this dataset."
+          />
+        )}
+      </>
+    );
+
+    const collectionLabel = (
+      <strong>
+        <Collection.Label collection={collection} icon={false} />
+      </strong>
+    );
+
+    return (
+      <Dialog
+        isOpen={this.props.isOpen}
+        title={title}
+        icon="trash"
+        onClose={this.props.toggleDialog}
+      >
+        <DialogBody>
+          <p>
+            <FormattedMessage
+              id="collection.delete.question"
+              defaultMessage="Are you sure you want to permanently delete {collectionLabel} and all contained items? This cannot be undone."
+              values={{ collectionLabel }}
+            />
+          </p>
+
+          <p>
+            <FormattedMessage
+              id="collection.delete.enter_label"
+              defaultMessage="Please enter {collectionLabel} to confirm:"
+              values={{ collectionLabel }}
+            />
+          </p>
+
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              this.onDelete();
+            }}
+          >
+            <FormGroup
+              labelFor="collection-delete-confirmation"
+              label={
+                <span className="visually-hidden">
+                  <FormattedMessage
+                    id="collection.delete.collection_label"
+                    defaultMessage="Label"
+                  />
+                </span>
+              }
+            >
+              <InputGroup
+                id="collection-delete-confirmation"
+                placeholder={collection.label}
+                required
+                onInput={(event) =>
+                  this.setState({ confirmationValue: event.target.value })
+                }
+              />
+            </FormGroup>
+            <Button
+              type="submit"
+              intent={Intent.DANGER}
+              fill
+              disabled={this.state.confirmationValue !== collection.label}
+            >
+              {buttonLabel}
+            </Button>
+          </form>
+        </DialogBody>
+      </Dialog>
     );
   }
 }

--- a/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
+++ b/ui/src/dialogs/CollectionDeleteDialog/CollectionDeleteDialog.jsx
@@ -1,32 +1,22 @@
 import React, { Component } from 'react';
-import {
-  Button,
-  Dialog,
-  DialogBody,
-  Intent,
-  FormGroup,
-  InputGroup,
-} from '@blueprintjs/core';
-import { FormattedMessage, injectIntl } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 
 import withRouter from 'app/withRouter';
 import { deleteCollection } from 'actions';
-import { Collection } from 'components/common';
+import { DeleteDialog } from 'components/common';
 
 class CollectionDeleteDialog extends Component {
   constructor(props) {
     super(props);
     this.onDelete = this.onDelete.bind(this);
-
-    this.state = { confirmationValue: '' };
   }
 
   async onDelete() {
-    const { collection, navigate } = this.props;
+    const { collection, navigate, deleteCollection } = this.props;
     const path = collection.casefile ? '/investigations' : '/datasets';
-    await this.props.deleteCollection(collection);
+    await deleteCollection(collection);
     navigate({ pathname: path });
   }
 
@@ -65,73 +55,25 @@ class CollectionDeleteDialog extends Component {
       </>
     );
 
-    const collectionLabel = (
-      <strong>
-        <Collection.Label collection={collection} icon={false} />
-      </strong>
-    );
-
     return (
-      <Dialog
+      <DeleteDialog
         isOpen={this.props.isOpen}
         title={title}
-        icon="trash"
+        buttonLabel={buttonLabel}
+        expectedConfirmationValue={collection.label}
         onClose={this.props.toggleDialog}
+        onDelete={this.onDelete}
       >
-        <DialogBody>
-          <p>
-            <FormattedMessage
-              id="collection.delete.question"
-              defaultMessage="Are you sure you want to permanently delete {collectionLabel} and all contained items? This cannot be undone."
-              values={{ collectionLabel }}
-            />
-          </p>
-
-          <p>
-            <FormattedMessage
-              id="collection.delete.enter_label"
-              defaultMessage="Please enter {collectionLabel} to confirm:"
-              values={{ collectionLabel }}
-            />
-          </p>
-
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              this.onDelete();
+        <p>
+          <FormattedMessage
+            id="collection.delete.question"
+            defaultMessage="Are you sure you want to permanently delete {collectionLabel} and all contained items? This cannot be undone."
+            values={{
+              collectionLabel: <strong>{collection.label}</strong>,
             }}
-          >
-            <FormGroup
-              labelFor="collection-delete-confirmation"
-              label={
-                <span className="visually-hidden">
-                  <FormattedMessage
-                    id="collection.delete.collection_label"
-                    defaultMessage="Label"
-                  />
-                </span>
-              }
-            >
-              <InputGroup
-                id="collection-delete-confirmation"
-                placeholder={collection.label}
-                required
-                onInput={(event) =>
-                  this.setState({ confirmationValue: event.target.value })
-                }
-              />
-            </FormGroup>
-            <Button
-              type="submit"
-              intent={Intent.DANGER}
-              fill
-              disabled={this.state.confirmationValue !== collection.label}
-            >
-              {buttonLabel}
-            </Button>
-          </form>
-        </DialogBody>
-      </Dialog>
+          />
+        </p>
+      </DeleteDialog>
     );
   }
 }
@@ -140,6 +82,5 @@ const mapDispatchToProps = { deleteCollection };
 
 export default compose(
   withRouter,
-  connect(null, mapDispatchToProps),
-  injectIntl
+  connect(null, mapDispatchToProps)
 )(CollectionDeleteDialog);

--- a/ui/src/dialogs/EntitySetDeleteDialog/EntitySetDeleteDialog.jsx
+++ b/ui/src/dialogs/EntitySetDeleteDialog/EntitySetDeleteDialog.jsx
@@ -1,5 +1,12 @@
 import React, { Component } from 'react';
-import { Alert, Intent } from '@blueprintjs/core';
+import {
+  Button,
+  Dialog,
+  DialogBody,
+  Intent,
+  InputGroup,
+  FormGroup,
+} from '@blueprintjs/core';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -10,24 +17,37 @@ import { showSuccessToast } from 'app/toast';
 import getCollectionLink from 'util/getCollectionLink';
 
 const messages = defineMessages({
-  button_confirm: {
-    id: 'entityset.delete.confirm',
-    defaultMessage: 'Delete',
-  },
-  button_cancel: {
-    id: 'entityset.delete.cancel',
-    defaultMessage: 'Cancel',
-  },
   success: {
     id: 'entityset.delete.success',
     defaultMessage: 'Successfully deleted {title}',
   },
 });
 
+const typeLabels = {
+  diagram: (
+    <FormattedMessage
+      id="entityset.delete.diagram"
+      defaultMessage="network diagram"
+    />
+  ),
+  timeline: (
+    <FormattedMessage
+      id="entityset.delete.timeline"
+      defaultMessage="timeline"
+    />
+  ),
+  list: <FormattedMessage id="entityset.delete.list" defaultMessage="list" />,
+  profile: (
+    <FormattedMessage id="entityset.delete.profile" defaultMessage="profile" />
+  ),
+};
+
 class EntitySetDeleteDialog extends Component {
   constructor(props) {
     super(props);
     this.onDelete = this.onDelete.bind(this);
+
+    this.state = { confirmationValue: '' };
   }
 
   onDelete() {
@@ -44,37 +64,97 @@ class EntitySetDeleteDialog extends Component {
   }
 
   render() {
-    const { intl, entitySet } = this.props;
+    const { entitySet } = this.props;
     const { label, type } = entitySet;
 
+    const typeLabel = typeLabels[type];
+
+    const title = (
+      <FormattedMessage
+        id="collection.delete.title.investigation"
+        defaultMessage="Delete {typeLabel}"
+        values={{ typeLabel }}
+      />
+    );
+
+    const buttonLabel = (
+      <FormattedMessage
+        id="collection.delete.confirm"
+        defaultMessage="I understand the consequences. Delete this {typeLabel}."
+        values={{ typeLabel }}
+      />
+    );
+
     return (
-      <Alert
+      <Dialog
         isOpen={this.props.isOpen}
+        title={title}
         icon="trash"
-        intent={Intent.DANGER}
-        cancelButtonText={intl.formatMessage(messages.button_cancel)}
-        confirmButtonText={intl.formatMessage(messages.button_confirm)}
-        onCancel={this.props.toggleDialog}
-        onConfirm={this.onDelete}
+        onClose={this.props.toggleDialog}
       >
-        <p>
-          <strong>
-            <FormattedMessage
-              id="entityset.delete.question"
-              defaultMessage="Are you sure you want to delete {label}?"
-              values={{ label }}
-            />
-          </strong>
-        </p>
-        {type === 'profile' && (
+        <DialogBody>
           <p>
             <FormattedMessage
-              id="profile.delete.warning"
-              defaultMessage="(Deleting this profile will not delete any of the entities or entity decisions contained within it)"
+              id="entityset.delete.question"
+              defaultMessage="Are you sure you want to permanently delete {label}? This cannot be undone."
+              values={{ label: <strong>{label}</strong> }}
             />
           </p>
-        )}
-      </Alert>
+
+          {type === 'profile' && (
+            <p>
+              <FormattedMessage
+                id="profile.delete.warning"
+                defaultMessage="(Deleting this profile will not delete any of the entities or entity decisions contained within it)"
+              />
+            </p>
+          )}
+
+          <p>
+            <FormattedMessage
+              id="entityset.delete.enter_label"
+              defaultMessage="Please enter {label} to confirm:"
+              values={{ label: <strong>{label}</strong> }}
+            />
+          </p>
+
+          <form
+            onSubmit={(event) => {
+              event.preventDefault();
+              this.onDelete();
+            }}
+          >
+            <FormGroup
+              labelFor="collection-delete-confirmation"
+              label={
+                <span className="visually-hidden">
+                  <FormattedMessage
+                    id="collection.delete.collection_label"
+                    defaultMessage="Label"
+                  />
+                </span>
+              }
+            >
+              <InputGroup
+                id="collection-delete-confirmation"
+                placeholder={entitySet.label}
+                required
+                onInput={(event) =>
+                  this.setState({ confirmationValue: event.target.value })
+                }
+              />
+            </FormGroup>
+            <Button
+              type="submit"
+              intent={Intent.DANGER}
+              fill
+              disabled={this.state.confirmationValue !== entitySet.label}
+            >
+              {buttonLabel}
+            </Button>
+          </form>
+        </DialogBody>
+      </Dialog>
     );
   }
 }

--- a/ui/src/dialogs/EntitySetDeleteDialog/EntitySetDeleteDialog.jsx
+++ b/ui/src/dialogs/EntitySetDeleteDialog/EntitySetDeleteDialog.jsx
@@ -22,16 +22,14 @@ class EntitySetDeleteDialog extends Component {
     this.onDelete = this.onDelete.bind(this);
   }
 
-  onDelete() {
-    const { entitySet, navigate, intl } = this.props;
-    this.props
-      .deleteEntitySet(entitySet.id)
-      .then(() =>
-        showSuccessToast(
-          intl.formatMessage(messages.success, { title: entitySet.label })
-        )
-      );
+  async onDelete() {
+    const { entitySet, navigate, intl, deleteEntitySet } = this.props;
+    const successMessage = intl.formatMessage(messages.success, {
+      title: entitySet.label,
+    });
 
+    await deleteEntitySet(entitySet.id);
+    showSuccessToast(successMessage);
     navigate(getCollectionLink({ collection: entitySet.collection }));
   }
 

--- a/ui/src/dialogs/EntitySetDeleteDialog/EntitySetDeleteDialog.jsx
+++ b/ui/src/dialogs/EntitySetDeleteDialog/EntitySetDeleteDialog.jsx
@@ -1,12 +1,4 @@
 import React, { Component } from 'react';
-import {
-  Button,
-  Dialog,
-  DialogBody,
-  Intent,
-  InputGroup,
-  FormGroup,
-} from '@blueprintjs/core';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -15,6 +7,7 @@ import withRouter from 'app/withRouter';
 import { deleteEntitySet } from 'actions';
 import { showSuccessToast } from 'app/toast';
 import getCollectionLink from 'util/getCollectionLink';
+import { DeleteDialog } from 'components/common';
 
 const messages = defineMessages({
   success: {
@@ -23,31 +16,10 @@ const messages = defineMessages({
   },
 });
 
-const typeLabels = {
-  diagram: (
-    <FormattedMessage
-      id="entityset.delete.diagram"
-      defaultMessage="network diagram"
-    />
-  ),
-  timeline: (
-    <FormattedMessage
-      id="entityset.delete.timeline"
-      defaultMessage="timeline"
-    />
-  ),
-  list: <FormattedMessage id="entityset.delete.list" defaultMessage="list" />,
-  profile: (
-    <FormattedMessage id="entityset.delete.profile" defaultMessage="profile" />
-  ),
-};
-
 class EntitySetDeleteDialog extends Component {
   constructor(props) {
     super(props);
     this.onDelete = this.onDelete.bind(this);
-
-    this.state = { confirmationValue: '' };
   }
 
   onDelete() {
@@ -67,94 +39,103 @@ class EntitySetDeleteDialog extends Component {
     const { entitySet } = this.props;
     const { label, type } = entitySet;
 
-    const typeLabel = typeLabels[type];
-
     const title = (
-      <FormattedMessage
-        id="collection.delete.title.investigation"
-        defaultMessage="Delete {typeLabel}"
-        values={{ typeLabel }}
-      />
+      <>
+        {type === 'diagram' && (
+          <FormattedMessage
+            id="entityset.delete.title.diagram"
+            defaultMessage="Delete network diagram"
+            values={{ type }}
+          />
+        )}
+        {type === 'timeline' && (
+          <FormattedMessage
+            id="entityset.delete.title.timeline"
+            defaultMessage="Delete timeline"
+            values={{ type }}
+          />
+        )}
+        {type === 'list' && (
+          <FormattedMessage
+            id="entityset.delete.title.list"
+            defaultMessage="Delete list"
+            values={{ type }}
+          />
+        )}
+        {type === 'profile' && (
+          <FormattedMessage
+            id="entityset.delete.title.profile"
+            defaultMessage="Delete profile"
+            values={{ type }}
+          />
+        )}
+      </>
     );
 
     const buttonLabel = (
-      <FormattedMessage
-        id="collection.delete.confirm"
-        defaultMessage="I understand the consequences. Delete this {typeLabel}."
-        values={{ typeLabel }}
-      />
+      <>
+        <FormattedMessage
+          id="entityset.delete.confirm"
+          defaultMessage="I understand the consequences."
+          values={{ type }}
+        />{' '}
+        {type === 'diagram' && (
+          <FormattedMessage
+            id="entityset.delete.confirm.diagram"
+            defaultMessage="Delete this network diagram."
+            values={{ type }}
+          />
+        )}
+        {type === 'timeline' && (
+          <FormattedMessage
+            id="entityset.delete.confirm.timeline"
+            defaultMessage="Delete this timeline."
+            values={{ type }}
+          />
+        )}
+        {type === 'list' && (
+          <FormattedMessage
+            id="entityset.delete.confirm.list"
+            defaultMessage="Delete this list."
+            values={{ type }}
+          />
+        )}
+        {type === 'profile' && (
+          <FormattedMessage
+            id="entityset.delete.confirm.profile"
+            defaultMessage="Delete this profile."
+            values={{ type }}
+          />
+        )}
+      </>
     );
 
     return (
-      <Dialog
+      <DeleteDialog
         isOpen={this.props.isOpen}
         title={title}
-        icon="trash"
+        buttonLabel={buttonLabel}
+        expectedConfirmationValue={entitySet.label}
         onClose={this.props.toggleDialog}
+        onDelete={this.onDelete}
       >
-        <DialogBody>
-          <p>
-            <FormattedMessage
-              id="entityset.delete.question"
-              defaultMessage="Are you sure you want to permanently delete {label}? This cannot be undone."
-              values={{ label: <strong>{label}</strong> }}
-            />
-          </p>
-
+        <p>
+          <FormattedMessage
+            id="entityset.delete.question"
+            defaultMessage="Are you sure you want to permanently delete {label}? This cannot be undone."
+            values={{ label: <strong>{label}</strong> }}
+          />
           {type === 'profile' && (
-            <p>
+            <>
+              {' '}
               <FormattedMessage
                 id="profile.delete.warning"
-                defaultMessage="(Deleting this profile will not delete any of the entities or entity decisions contained within it)"
+                defaultMessage="Deleting this profile will not delete any of the entities or entity decisions contained within it."
               />
-            </p>
+            </>
           )}
-
-          <p>
-            <FormattedMessage
-              id="entityset.delete.enter_label"
-              defaultMessage="Please enter {label} to confirm:"
-              values={{ label: <strong>{label}</strong> }}
-            />
-          </p>
-
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              this.onDelete();
-            }}
-          >
-            <FormGroup
-              labelFor="collection-delete-confirmation"
-              label={
-                <span className="visually-hidden">
-                  <FormattedMessage
-                    id="collection.delete.collection_label"
-                    defaultMessage="Label"
-                  />
-                </span>
-              }
-            >
-              <InputGroup
-                id="collection-delete-confirmation"
-                placeholder={entitySet.label}
-                required
-                onInput={(event) =>
-                  this.setState({ confirmationValue: event.target.value })
-                }
-              />
-            </FormGroup>
-            <Button
-              type="submit"
-              intent={Intent.DANGER}
-              fill
-              disabled={this.state.confirmationValue !== entitySet.label}
-            >
-              {buttonLabel}
-            </Button>
-          </form>
-        </DialogBody>
-      </Dialog>
+        </p>
+      </DeleteDialog>
     );
   }
 }


### PR DESCRIPTION
Recently, we had to handle multiple support cases of users deleting collections and entity sets by accident. In some cases, this was because users thought they were only deleting an entity within the investigation or entity set. Even though we do show a confirmation dialog before destructive actions, users often do not read the actual dialog message.

In order to prevent users from deleting data by accident, this PR adds an additional confirmation UI before deleting collections or entity sets and asks users to confirm the title of the collection/investigation.

The following video shows the flow to delete a collection:

https://user-images.githubusercontent.com/1512805/234068743-d6768c09-d2d4-47ad-8a0f-41ab9175cb99.mov

The flows for deleting entity sets (diagrams, lists, timelines, profiles) use a similar UI:

<img width="541" alt="Screen Shot 2023-04-24 at 19 16 45" src="https://user-images.githubusercontent.com/1512805/234069492-103c8589-1d5a-410d-a8f5-13e614774ea9.png">

***

**To do:**

- [x] Extract common UI into `DeleteDialog` component to reduce redundancy
- [x] Adjust steps to delete investigation in e2e tests

Closes #2334 