### PR TITLE
Push Docker images for tags only

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -37,6 +37,7 @@ jobs:
         run: make test-ui
 
       - name: Build production image
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         run: docker build -t ghcr.io/alephdata/aleph-ui-production:${GITHUB_SHA} -f ui/Dockerfile.production ui
 
       - name: Push docker image (tagged)

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -39,17 +39,10 @@ jobs:
       - name: Build production image
         run: docker build -t ghcr.io/alephdata/aleph-ui-production:${GITHUB_SHA} -f ui/Dockerfile.production ui
 
-      - name: Push docker image (hash)
-        env:
-          GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        if: env.GITHUB_PASSWORD != null
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin 
-          docker push ghcr.io/alephdata/aleph-ui-production:${GITHUB_SHA}
-
       - name: Push docker image (tagged)
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
           export ALEPH_TAG=${GITHUB_REF/refs\/tags\//}
           docker tag ghcr.io/alephdata/aleph-ui-production:${GITHUB_SHA} ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG};
           docker push ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG};

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,17 +44,10 @@ jobs:
       - name: Run aleph tests
         run: make ALEPH_TAG=${GITHUB_SHA} test
 
-      - name: Push docker image (hash)
-        env:
-          GITHUB_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
-        if: env.GITHUB_PASSWORD != null
-        run: |
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin 
-          docker push ghcr.io/alephdata/aleph:${GITHUB_SHA}
-
       - name: Push docker images for tags
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         run: |
+          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
           export ALEPH_TAG=${GITHUB_REF/refs\/tags\//}
           docker tag ghcr.io/alephdata/aleph:${GITHUB_SHA} ghcr.io/alephdata/aleph:${ALEPH_TAG};
           docker push ghcr.io/alephdata/aleph:${ALEPH_TAG};


### PR DESCRIPTION
We have implemented a process that uses release candidates for pre-release testing and deployments, so there’s no need anymore to push Docker images for every commit. This is wasteful in terms of bandwidth and storage resources and clutters the image repository.

@catileptic @Rosencrantz @stchris This is something we have discussed a few times before, tbh I’m not sure anymore what exactly our conclusion was. Let me know if you have concerns or in case we do actually still depend on images built from commits that are not tagged.