### PR TITLE
Update Docker image tags to use GHCR repo

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -41,3 +41,11 @@ replace = tag: "{new_version}"
 [bumpversion:file:helm/charts/aleph/README.md]
 search = global.image.tag | string | `"{current_version}"`
 replace = global.image.tag | string | `"{new_version}"`
+
+[bumpversion:file:contrib/aleph-traefik-minio-keycloak/docker-compose.yml]
+search = ALEPH_TAG:-{current_version}
+replace = ALEPH_TAG:-{new_version}
+
+[bumpversion:file:contrib/keycloak/docker-compose.dev-keycloak.yml]
+search = ALEPH_TAG:-{current_version}
+replace = ALEPH_TAG:-{new_version}

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ build:
 	$(COMPOSE) build
 
 build-ui:
-	docker build -t alephdata/aleph-ui-production:$(ALEPH_TAG) -f ui/Dockerfile.production ui
+	docker build -t ghcr.io/alephdata/aleph-ui-production:$(ALEPH_TAG) -f ui/Dockerfile.production ui
 
 build-e2e:
 	$(COMPOSE_E2E) build

--- a/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
+++ b/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - "traefik.enable=false"
 
   worker:
-    image: alephdata/aleph:${ALEPH_TAG:-3.12.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.12.2}
     command: aleph worker
     restart: on-failure
     links:
@@ -90,7 +90,7 @@ services:
       - "traefik.enable=false"
 
   shell:
-    image: alephdata/aleph:${ALEPH_TAG:-3.12.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.12.2}
     command: /bin/bash
     depends_on:
       - postgres
@@ -110,7 +110,7 @@ services:
       - "traefik.enable=false"
 
   api:
-    image: alephdata/aleph:${ALEPH_TAG:-3.12.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.12.2}
     command: gunicorn -w 6 -b 0.0.0.0:8000 --log-level debug --log-file - aleph.wsgi:app
     expose:
       - 8000
@@ -132,7 +132,7 @@ services:
       - "traefik.enable=false"
 
   ui:
-    image: alephdata/aleph-ui-production:${ALEPH_TAG:-3.12.2}
+    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-3.12.2}
     depends_on:
       - api
       - traefik

--- a/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
+++ b/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
@@ -65,7 +65,7 @@ services:
       - "traefik.enable=false"
 
   worker:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.12.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.14.0}
     command: aleph worker
     restart: on-failure
     links:
@@ -90,7 +90,7 @@ services:
       - "traefik.enable=false"
 
   shell:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.12.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.14.0}
     command: /bin/bash
     depends_on:
       - postgres
@@ -110,7 +110,7 @@ services:
       - "traefik.enable=false"
 
   api:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.12.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.14.0}
     command: gunicorn -w 6 -b 0.0.0.0:8000 --log-level debug --log-file - aleph.wsgi:app
     expose:
       - 8000
@@ -132,7 +132,7 @@ services:
       - "traefik.enable=false"
 
   ui:
-    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-3.12.2}
+    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-3.14.0}
     depends_on:
       - api
       - traefik

--- a/contrib/keycloak/docker-compose.dev-keycloak.yml
+++ b/contrib/keycloak/docker-compose.dev-keycloak.yml
@@ -16,7 +16,7 @@ services:
   elasticsearch:
     build:
       context: services/elasticsearch
-    image: alephdata/aleph-elasticsearch:${ALEPH_TAG:-latest}
+    image: ghcr.io/alephdata/aleph-elasticsearch:${ALEPH_TAG:-latest}
     hostname: elasticsearch
     environment:
       - discovery.type=single-node

--- a/contrib/keycloak/docker-compose.dev-keycloak.yml
+++ b/contrib/keycloak/docker-compose.dev-keycloak.yml
@@ -16,7 +16,7 @@ services:
   elasticsearch:
     build:
       context: services/elasticsearch
-    image: ghcr.io/alephdata/aleph-elasticsearch:${ALEPH_TAG:-3.14.0}
+    image: ghcr.io/alephdata/aleph-elasticsearch:3bb5dbed97cfdb9955324d11e5c623a5c5bbc410
     hostname: elasticsearch
     environment:
       - discovery.type=single-node

--- a/contrib/keycloak/docker-compose.dev-keycloak.yml
+++ b/contrib/keycloak/docker-compose.dev-keycloak.yml
@@ -16,7 +16,7 @@ services:
   elasticsearch:
     build:
       context: services/elasticsearch
-    image: ghcr.io/alephdata/aleph-elasticsearch:${ALEPH_TAG:-latest}
+    image: ghcr.io/alephdata/aleph-elasticsearch:${ALEPH_TAG:-3.14.0}
     hostname: elasticsearch
     environment:
       - discovery.type=single-node
@@ -64,7 +64,7 @@ services:
   app:
     build:
       context: .
-    image: alephdata/aleph:${ALEPH_TAG:-latest}
+    image: alephdata/aleph:${ALEPH_TAG:-3.14.0}
     hostname: aleph
     command: /bin/bash
     links:
@@ -92,7 +92,7 @@ services:
   api:
     build:
       context: .
-    image: alephdata/aleph:${ALEPH_TAG:-latest}
+    image: alephdata/aleph:${ALEPH_TAG:-3.14.0}
     command: aleph run -h 0.0.0.0 -p 5000 --with-threads --reload --debugger
     ports:
       - "127.0.0.1:5000:5000"
@@ -126,7 +126,7 @@ services:
   ui:
     build:
       context: ui
-    image: alephdata/aleph-ui:${ALEPH_TAG:-latest}
+    image: alephdata/aleph-ui:${ALEPH_TAG:-3.14.0}
     links:
       - api
     command: npm run start

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -82,7 +82,7 @@ services:
   app:
     build:
       context: .
-    image: alephdata/aleph:${ALEPH_TAG:-latest}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-latest}
     hostname: aleph
     command: /bin/bash
     depends_on:
@@ -110,7 +110,7 @@ services:
   api:
     build:
       context: .
-    image: alephdata/aleph:${ALEPH_TAG:-latest}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-latest}
     command: python3 -m debugpy --listen 0.0.0.0:5678 -m flask run -h 0.0.0.0 -p 5000 --with-threads --reload --debugger
     ports:
       - "127.0.0.1:5000:5000"
@@ -137,7 +137,7 @@ services:
   ui:
     build:
       context: ui
-    image: alephdata/aleph-ui:${ALEPH_TAG:-latest}
+    image: ghcr.io/alephdata/aleph-ui:${ALEPH_TAG:-latest}
     depends_on:
       - api
     command: "bash -c 'rsync --archive --inplace --no-compress --whole-file /node_modules /alephui && npm run start'"
@@ -156,7 +156,7 @@ services:
       - aleph.env
 
   worker:
-    image: alephdata/aleph:${ALEPH_TAG:-3.13.2-rc3}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.13.2-rc3}
     command: aleph worker
     restart: on-failure
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - aleph.env
 
   worker:
-    image: alephdata/aleph:${ALEPH_TAG:-3.14.0}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.14.0}
     command: aleph worker
     restart: on-failure
     depends_on:
@@ -62,7 +62,7 @@ services:
       - aleph.env
 
   shell:
-    image: alephdata/aleph:${ALEPH_TAG:-3.14.0}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.14.0}
     command: /bin/bash
     depends_on:
       - postgres
@@ -80,7 +80,7 @@ services:
       - aleph.env
 
   api:
-    image: alephdata/aleph:${ALEPH_TAG:-3.14.0}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.14.0}
     command: gunicorn -w 6 -b 0.0.0.0:8000 --timeout 3600 --log-level debug --log-file - aleph.wsgi:app
     expose:
       - 8000
@@ -98,7 +98,7 @@ services:
       - aleph.env
 
   ui:
-    image: alephdata/aleph-ui-production:${ALEPH_TAG:-3.14.0}
+    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-3.14.0}
     depends_on:
       - api
     ports:

--- a/helm/charts/aleph/values.yaml
+++ b/helm/charts/aleph/values.yaml
@@ -5,7 +5,7 @@ global:
   namingPrefix: aleph # prefix for service names. eg: with prefix=aleph the api will be named aleph-api
 
   image:
-    repository: alephdata/aleph
+    repository: ghcr.io/alephdata/aleph
     tag: "3.14.0"
     pullPolicy: Always
 
@@ -208,7 +208,7 @@ ui:
   podSecurityContext: {}
 
   image:
-    repository: alephdata/aleph-ui-production
+    repository: ghcr.io/alephdata/aleph-ui-production
     pullPolicy: Always
 
   containerSecurityContext: {}


### PR DESCRIPTION
Right now, UI tests build the Docker image twice because the tags do not match, causing CI runs to take 2-3 mins longer than necessary.