### PR TITLE
Allow users to add timeline items with times

### DIFF
--- a/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.test.tsx
@@ -149,6 +149,22 @@ it('supports a variety of different date formats', async () => {
   await userEvent.type(input, '2022-01-01');
   expect(input.checkValidity()).toBe(true);
 
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-01-01T00:00:00');
+  expect(input.checkValidity()).toBe(true);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-01-01T00:00');
+  expect(input.checkValidity()).toBe(true);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-01-01 00:00:00');
+  expect(input.checkValidity()).toBe(true);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-01-01 00:00');
+  expect(input.checkValidity()).toBe(true);
+
   // Invalid dates
   await userEvent.clear(input);
   await userEvent.type(input, '2022-');
@@ -160,6 +176,10 @@ it('supports a variety of different date formats', async () => {
 
   await userEvent.clear(input);
   await userEvent.type(input, '2022-01-123');
+  expect(input.checkValidity()).toBe(false);
+
+  await userEvent.clear(input);
+  await userEvent.type(input, '2022-01T00:00:00');
   expect(input.checkValidity()).toBe(false);
 
   // Automatically reformats to match supported format

--- a/ui/src/components/Timeline/TimelineItemCreateForm.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.tsx
@@ -22,7 +22,11 @@ import type {
   EdgeSchema,
   FetchEntitySuggestions,
 } from './types';
-import { useEntitySuggestions, reformatDateString } from './util';
+import {
+  useEntitySuggestions,
+  reformatDateString,
+  DATETIME_REGEX,
+} from './util';
 import { SchemaSelect, EntitySelect } from 'react-ftm';
 import { Button, Alignment, FormGroup, InputGroup } from '@blueprintjs/core';
 
@@ -206,6 +210,8 @@ const TemporalExtentFields: FC<TemporalExtentFieldsProps> = ({
     };
   });
 
+  const pattern = DATETIME_REGEX.source.replace('^', '').replace('$', '');
+
   return (
     <>
       {props.map(({ property, value, required }) => (
@@ -223,7 +229,7 @@ const TemporalExtentFields: FC<TemporalExtentFieldsProps> = ({
             }
           }}
           placeholder="YYYY-MM-DD"
-          pattern="\d{4}(?:-\d{1,2}(?:-\d{1,2}(?:[T ].*)?)?)?"
+          pattern={pattern}
           required={required}
         />
       ))}

--- a/ui/src/components/Timeline/TimelineItemCreateForm.tsx
+++ b/ui/src/components/Timeline/TimelineItemCreateForm.tsx
@@ -223,7 +223,7 @@ const TemporalExtentFields: FC<TemporalExtentFieldsProps> = ({
             }
           }}
           placeholder="YYYY-MM-DD"
-          pattern="\d{4}(?:-\d{1,2}){0,2}"
+          pattern="\d{4}(?:-\d{1,2}(?:-\d{1,2}(?:[T ].*)?)?)?"
           required={required}
         />
       ))}

--- a/ui/src/components/Timeline/util.test.ts
+++ b/ui/src/components/Timeline/util.test.ts
@@ -211,6 +211,22 @@ describe('ImpreciseDate', () => {
       const validDates = dates.filter((date) => date.isValid());
       expect(validDates).toHaveLength(0);
     });
+
+    it('accepts (and ignores) datetime values', () => {
+      let date: ImpreciseDate;
+
+      date = new ImpreciseDate('2022-01-01T00:00:00');
+      expect(date.isValid()).toBe(true);
+
+      date = new ImpreciseDate('2022-01-01T00:00');
+      expect(date.isValid()).toBe(true);
+
+      date = new ImpreciseDate('2022-01-01 00:00:00');
+      expect(date.isValid()).toBe(true);
+
+      date = new ImpreciseDate('2022-01-01 00:00');
+      expect(date.isValid()).toBe(true);
+    });
   });
 
   describe('getEarliest() and getLatest()', () => {

--- a/ui/src/components/Timeline/util.ts
+++ b/ui/src/components/Timeline/util.ts
@@ -207,8 +207,11 @@ export class ImpreciseDate {
     const monthRegex = /(0?[1-9]|1[0-2])/.source;
     const dayRegex = /(0?[1-9]|[1-2][0-9]|3[0-1])/.source;
 
+    // At the moment, we accept datetime values, but simply ignore and do not validate them
+    const timeRegex = /.*/.source;
+
     const regex = new RegExp(
-      `^${yearRegex}(?:-${monthRegex}(?:-${dayRegex})?)?$`
+      `^${yearRegex}(?:-${monthRegex}(?:-${dayRegex}(?:[T ]${timeRegex})?)?)?$`
     );
 
     const result = regex.exec(raw);

--- a/ui/src/components/Timeline/util.ts
+++ b/ui/src/components/Timeline/util.ts
@@ -16,6 +16,17 @@ import { Entity, Schema } from '@alephdata/followthemoney';
 import { DEFAULT_COLOR } from './Timeline';
 import { FetchEntitySuggestions, Layout, Vertex } from './types';
 
+const yearRegex = /(\d{4})/.source;
+const monthRegex = /(0?[1-9]|1[0-2])/.source;
+const dayRegex = /(0?[1-9]|[1-2][0-9]|3[0-1])/.source;
+
+// At the moment, we accept datetime values, but simply ignore and do not validate them
+const timeRegex = /.*/.source;
+
+export const DATETIME_REGEX = new RegExp(
+  `^${yearRegex}(?:-${monthRegex}(?:-${dayRegex}(?:[T ]${timeRegex})?)?)?$`
+);
+
 function endOfMonth(year: number, month: number): number {
   // Months in ECMAScript are zero-based:
   // new Date(2000, 0, 1) // Jan 1st
@@ -203,18 +214,7 @@ export class ImpreciseDate {
       return;
     }
 
-    const yearRegex = /(\d{4})/.source;
-    const monthRegex = /(0?[1-9]|1[0-2])/.source;
-    const dayRegex = /(0?[1-9]|[1-2][0-9]|3[0-1])/.source;
-
-    // At the moment, we accept datetime values, but simply ignore and do not validate them
-    const timeRegex = /.*/.source;
-
-    const regex = new RegExp(
-      `^${yearRegex}(?:-${monthRegex}(?:-${dayRegex}(?:[T ]${timeRegex})?)?)?$`
-    );
-
-    const result = regex.exec(raw);
+    const result = DATETIME_REGEX.exec(raw);
 
     if (!result) {
       return;


### PR DESCRIPTION
FtM supports times in date properties (see [docs](https://followthemoney.tech/explorer/types/date/)), but when adding items to a timeline in Aleph, you can’t add a time.

Additionally, if a timeline contains an item with a datetime value, an unhandled error occurs when switching to the chart view.

This PR fixes both issues. When adding a new timeline item, the form now allows entering values like `2023-05-02T00:00:00` or `2023-05-02 00:00`.

When parsing those dates, we now simply ignore the time part. This also ensures that the chart view renders successfully.

Closes #3009

**To do:**

- [x] Use the same date regex for HTML `pattern` attribute in form an for parsing in `ImpreciseDate`?