### PR TITLE
Fix incorrect concurrency settings for docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,6 +4,8 @@ on:
   push:
     paths:
       - "docs/**"
+    branches:
+      - "**"
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
Chris made me aware that the docs sometimes do not get deployed. This is due to the combination of the limited workflow concurrency and the condition for the deploy job. Sometimes the workflow run for a pushed tag cancels a previous run triggered by a commit pushed to main. However, the run triggered by the tag does not execute the deploy job.

This change prevents a situation like this, as pushed tags won't trigger a run anymore.

We could also consider aligning with our release process by deploying only when a new tag is pushed. However, there may be situations where we want to make and deploy changes unrelated to code changes in a release.