### PR TITLE
Add service annotations to the helm chart

### DIFF
--- a/helm/charts/aleph/templates/api.yaml
+++ b/helm/charts/aleph/templates/api.yaml
@@ -149,6 +149,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+{{- if .Values.api.serviceAnnotations }}
+  annotations:
+  {{- range $key, $value := .Values.api.serviceAnnotations }}
+    {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
   name: {{ .Values.global.namingPrefix }}-api
   labels:
     app: {{ .Values.global.namingPrefix }}-api

--- a/helm/charts/aleph/values.yaml
+++ b/helm/charts/aleph/values.yaml
@@ -57,6 +57,8 @@ api:
 
   podAnnotations: {}
 
+  serviceAnnotations: {}
+
   nodeSelector: {}
 
   podSecurityContext:


### PR DESCRIPTION
When running Aleph in the google cloud with [container native loadbalancing](https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing), the healthcheck of the default `BackendConfig` google cloud generates won't work (because of the non-standard name `api` of the service port if i remember correctly.).

This can be solved in multiple ways:
- I think renaming the port to `http` would make the defaults work, but i haven't tested this.
- Making it possible for the user to set `annotations` on the service. Which seems like a good idea anyway.