### PR TITLE
Send null value if collection metadata fields are empty

### DIFF
--- a/ui/src/dialogs/CollectionEditDialog/CollectionEditDialog.jsx
+++ b/ui/src/dialogs/CollectionEditDialog/CollectionEditDialog.jsx
@@ -98,7 +98,7 @@ export class CollectionEditDialog extends Component {
 
   onFieldChange({ target }) {
     const { collection } = this.state;
-    collection[target.id] = target.value;
+    collection[target.id] = target.value !== '' ? target.value : null;
     this.setState({ collection, changed: true });
   }
 


### PR DESCRIPTION
See #3060 for details. Decided to go with the second option and adjusting the UI form to send actual `null` values (instead of empty strings) in case fields are empty rather than relaxing the validation. After thinking about it for 5 more minutes, this felt like the cleaner solution.