### PR TITLE
Use fuzzy search for collections search

### DIFF
--- a/aleph/search/__init__.py
+++ b/aleph/search/__init__.py
@@ -48,7 +48,7 @@ class CollectionsQuery(Query):
                         "query": self.parser.text,
                         "fields": ensure_list(self.TEXT_FIELDS),
                         "operator": "AND",
-                        "fuzziness": "AUTO",
+                        "fuzziness": "AUTO:3,4",
                     }
                 }
             )

--- a/aleph/search/__init__.py
+++ b/aleph/search/__init__.py
@@ -31,6 +31,23 @@ class CollectionsQuery(Query):
             filters.append({"ids": {"values": ids}})
         return filters
 
+    def get_text_query(self):
+        return [
+            {
+                "multi_match": {
+                    "query": self.parser.text or "",
+                    "fields": ensure_list(self.TEXT_FIELDS),
+                    "operator": "AND",
+                    "zero_terms_query": "all",
+                    # We currently do not apply stemming at index time, so using a fuzzy search
+                    # supports common cases like "owner"/"owners", "Russia"/"Russian","leaks/leaked".
+                    # This is a simple solution and does not require changing the index configuration,
+                    # but it is not perfect. For example, "contracting"/"contracts" does not match.
+                    "fuzziness": "AUTO",
+                },
+            },
+        ]
+
     def get_index(self):
         return collections_index()
 

--- a/aleph/tests/test_collections_api.py
+++ b/aleph/tests/test_collections_api.py
@@ -58,6 +58,19 @@ class CollectionsApiTestCase(TestCase):
         assert res.json["total"] == 1, res.json
         assert res.json["results"][0]["label"] == "Test Collection"
 
+    def test_index_advanced_search(self):
+        _, headers = self.login(is_admin=True)
+        self.col = self.create_collection(
+            label="OpenContracting",
+            category="procurement",
+        )
+
+        res = self.client.get("/api/2/collections?q=Open*", headers=headers)
+
+        assert res.status_code == 200, res
+        assert res.json["total"] == 1, res.json
+        assert res.json["results"][0]["label"] == "OpenContracting"
+
     def test_sitemap(self):
         res = self.client.get("/api/2/sitemap.xml")
         assert res.status_code == 200, res

--- a/aleph/tests/test_collections_api.py
+++ b/aleph/tests/test_collections_api.py
@@ -48,6 +48,16 @@ class CollectionsApiTestCase(TestCase):
         assert res.json["results"][0]["countries"] == ["us"], res.json
         assert validate(res.json["results"][0], "Collection")
 
+    def test_index_fuzzy_search(self):
+        _, headers = self.login(is_admin=True)
+
+        # Note the typo in "Colection"
+        res = self.client.get("/api/2/collections?q=Test Colection", headers=headers)
+
+        assert res.status_code == 200, res
+        assert res.json["total"] == 1, res.json
+        assert res.json["results"][0]["label"] == "Test Collection"
+
     def test_sitemap(self):
         res = self.client.get("/api/2/sitemap.xml")
         assert res.status_code == 200, res


### PR DESCRIPTION
The collections search returns results with exact matches only. Users do however expect the search to be fuzzy by default, i.e. "Romania" should also match "Romanian" etc. By changing the query type from `query_string` to `multi_match`, we can use fuzzy search by default.

The advantage of using fuzzy search is that it is applied at search time, i.e. we do not need to change the index configuration or re-index contents.

The main disadvantage is that it doesn't cover all variations that would be covered if we used proper stemming. For example, the following variations are not matched:

* Contracts/contracting
* Company/companies
* Malta/Maltese

Also, fuzzy search cannot be combined with prefix search (for example "Open" does not match "OpenContracting").

Fix #2109