### PR TITLE
Fix search highlights disappearing when opening entity previews

### DIFF
--- a/ui/src/app/variables.scss
+++ b/ui/src/app/variables.scss
@@ -47,7 +47,7 @@ $aleph-sidebar-width: $aleph-grid-size * 35;
 $aleph-sidebar-sm-width: $aleph-grid-size * 20;
 $aleph-sidepane-md-width: $aleph-grid-size * 27;
 
-$aleph-text-highlight-color: yellow;
+$aleph-text-highlight-color: rgba($gold5, 0.5);
 $aleph-visited-link-color: rgba($aleph-link-color, 0.6);
 $warning-border-color: #faebcc;
 $warning-background-color: #fcf8e3;

--- a/ui/src/reducers/util.js
+++ b/ui/src/reducers/util.js
@@ -31,7 +31,10 @@ export function loadComplete(data) {
 }
 
 export function objectLoadComplete(state, id, data = {}) {
-  return { ...state, [id]: loadComplete(data) };
+  const oldData = state[id] || {};
+  const newData = loadComplete(data);
+
+  return { ...state, [id]: { ...oldData, ...newData } };
 }
 
 export function updateResultsKeyed(state, { query, result }) {


### PR DESCRIPTION
When searching, we keep the search results in the Redux store in a structure similar to the following:

```json
{
  "entities": {
    "abc123": {
      "id": "abc123",
      "schema": "Company",
      "highlight": "<em>Twitter</em> is an online social media and social networking service."
    }
  },
  "results": {
    "entities?filter:schemata:Company&highlight=true&limit=30&q=twitter": {
      "total": 1,
      "page": 1,
      "results": ["abc123"]
    }
  }
}
```

After clicking on one of the search results, we load detailed entity data and use the detailed data to replace the (partial) entity data from the initial search request. However, the response from the second request does not contain the search highlight, i.e. the highlight is removed from the state when loading additional entity data.

We can work around this by merging data instead of replacing data. It does still feel a bit like a hacky workaround, but a proper solution would require making significant changes to our state management solution (probably replacing it with an off-the-shelf solution).

Fix https://github.com/alephdata/aleph/issues/2268