### PR TITLE
Fix whitespace in timelines chart view

### DIFF
--- a/ui/src/components/Timeline/TimelineChart/TimelineChartItem.scss
+++ b/ui/src/components/Timeline/TimelineChart/TimelineChartItem.scss
@@ -54,7 +54,7 @@
 
 .TimelineChartItem--multiDay .TimelineChartItem__caption {
   position: sticky;
-  left: 0;
+  left: $aleph-grid-size;
   width: max-content;
   max-width: 100%;
   overflow: hidden;


### PR DESCRIPTION
This is a super tiny fix for a tiny visual problem (other’s have noticed it too though, it’s not just me!)

Right now, the labels of timeline items stick to the left viewport edge with no whitespace.

https://github.com/alephdata/aleph/assets/1512805/1f4652e0-eddd-42b1-b1c1-d5591a3528c0

This PR fixes that:

https://github.com/alephdata/aleph/assets/1512805/412febcd-5c73-4858-92e3-3e7d7ce74167
