### PR TITLE
UI docker image python package

### DIFF
--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -2,8 +2,7 @@ FROM node:18-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get -qq -y update \
-    && apt-get -qq -y install build-essential rsync
+RUN apt-get -qq -y update && apt-get -qq -y install rsync
 
 RUN mkdir /alephui
 WORKDIR /alephui

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18-slim
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq -y update \
-    && apt-get -qq -y install python3 build-essential rsync
+    && apt-get -qq -y install build-essential rsync
 
 RUN mkdir /alephui
 WORKDIR /alephui

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -3,7 +3,7 @@ FROM node:18-slim
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq -y update \
-    && apt-get -qq -y install python build-essential rsync
+    && apt-get -qq -y install python3 build-essential rsync
 
 RUN mkdir /alephui
 WORKDIR /alephui


### PR DESCRIPTION
While working on https://github.com/alephdata/aleph/pull/2755 a CI run triggered a build of the UI container which failed because of no installation candidate for `python` (see https://github.com/alephdata/aleph/actions/runs/5276096256/jobs/9542371623?pr=2755). 

We are based off of `node:18-slim` which got[ updated 2 days ago](https://hub.docker.com/layers/library/node/18-slim/images/sha256-ce802ad553e7957cd2c01fcecab98b39689f6e54cbb173c2538aac18db310795?context=explore), seemingly to be based off of the newly released Debian 12 (Bookworm).

This change here makes the build work, but I'm not entirely sure where exactly `python` is invoked in the build chain so we may need to do other changes as well.