### PR TITLE
bump ingestfile to 3.18.4

### DIFF
--- a/helm/charts/aleph/values.yaml
+++ b/helm/charts/aleph/values.yaml
@@ -162,7 +162,7 @@ ingestfile:
 
   image:
     repository: ghcr.io/alephdata/ingest-file
-    tag: "3.18.1"
+    tag: "3.18.4"
     pullPolicy: Always
 
   containerSecurityContext:


### PR DESCRIPTION
The currently referenced `3.18.1` version does not exist.