### PR TITLE
Disable ES security in the development docker setup

### DIFF
--- a/aleph/manage.py
+++ b/aleph/manage.py
@@ -395,7 +395,7 @@ def renameuser(email, name):
 @click.argument("name")
 def creategroup(name):
     """Create a user group."""
-    role = create_group(name)
+    create_group(name)
     print(f"Group {name} created.")
 
 

--- a/aleph/tests/test_manage.py
+++ b/aleph/tests/test_manage.py
@@ -1,10 +1,9 @@
 import os
 from click.testing import CliRunner
 
-from aleph.core import db
 from aleph.tests.util import TestCase
 from aleph import manage
-from aleph.model import Role, Collection
+from aleph.model import Role
 from aleph.logic.roles import user_add
 
 
@@ -99,7 +98,7 @@ class ManageTestCase(TestCase):
             prog_name="aleph",
         )
         assert result.exit_code == 0
-        assert f"User renamed. ID: " in result.output
+        assert "User renamed. ID: " in result.output
         assert f", new name: {name}" in result.output
 
         # Check that the user was renamed

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,7 @@ services:
     restart: on-failure
     environment:
       - discovery.type=single-node
+      - xpack.security.enabled=false
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
       - "http.cors.enabled=true"
       - "http.cors.allow-origin=*"


### PR DESCRIPTION
When running the tests (via `make test`), a certain ES Warning message pollutes the output of the `nosetests` execution. 

The Warning looks like this:
```
ElasticsearchWarning: Elasticsearch built-in security features are not enabled. Without authentication, your cluster could be accessible to anyone. See https://www.elastic.co/guide/en/elasticsearch/reference/7.16/security-minimal-setup.html to enable security.
 warnings.warn(message, category=ElasticsearchWarning)
 ```

In order to suppress this warning, I have added a the following environment variable setting to `docker-compose.dev.yml`: `xpack.security.enabled=false`. This should only be used in the development environment, for our convenience. 