### PR TITLE
Bumps version of FTM libs, SQLAlchemy, Flask and related to latest

### DIFF
--- a/aleph/core.py
+++ b/aleph/core.py
@@ -39,6 +39,17 @@ babel = Babel()
 talisman = Talisman()
 
 
+def determine_locale():
+    try:
+        options = SETTINGS.UI_LANGUAGES
+        locale = request.accept_languages.best_match(options)
+        locale = locale or str(babel.default_locale)
+    except RuntimeError:
+        locale = str(babel.default_locale)
+    set_model_locale(locale)
+    return locale
+
+
 def create_app(config=None):
     if config is None:
         config = {}
@@ -80,7 +91,7 @@ def create_app(config=None):
     configure_oauth(app, cache=get_cache())
     mail.init_app(app)
     db.init_app(app)
-    babel.init_app(app)
+    babel.init_app(app, locale_selector=determine_locale)
     CORS(
         app,
         resources=r"/api/*",
@@ -115,18 +126,6 @@ def create_app(config=None):
         plugin(app=app)
 
     return app
-
-
-@babel.localeselector
-def determine_locale():
-    try:
-        options = SETTINGS.UI_LANGUAGES
-        locale = request.accept_languages.best_match(options)
-        locale = locale or str(babel.default_locale)
-    except RuntimeError:
-        locale = str(babel.default_locale)
-    set_model_locale(locale)
-    return locale
 
 
 @migrate.configure

--- a/aleph/migration.py
+++ b/aleph/migration.py
@@ -29,7 +29,7 @@ def cleanup_deleted():
 def destroy_db():
     metadata = MetaData()
     metadata.bind = db.engine
-    metadata.reflect()
+    metadata.reflect(db.engine)
     tables = list(metadata.sorted_tables)
     while len(tables):
         for table in tables:

--- a/aleph/tests/util.py
+++ b/aleph/tests/util.py
@@ -13,6 +13,7 @@ from followthemoney import model
 from followthemoney.cli.util import read_entity
 from werkzeug.utils import cached_property
 from faker import Factory
+from sqlalchemy import text
 
 from aleph.settings import SETTINGS
 from aleph.authz import Authz
@@ -230,7 +231,9 @@ class TestCase(unittest.TestCase):
             clear_index()
             for table in reversed(db.metadata.sorted_tables):
                 q = "TRUNCATE %s RESTART IDENTITY CASCADE;" % table.name
-                db.engine.execute(q)
+                with db.engine.connect() as conn:
+                    conn.execute(text(q))
+                    conn.commit()
 
         kv.flushall()
         create_system_roles()

--- a/aleph/views/archive_api.py
+++ b/aleph/views/archive_api.py
@@ -52,7 +52,7 @@ def retrieve():
             str(local_path),
             as_attachment=True,
             conditional=True,
-            attachment_filename=file_name,
+            download_name=file_name,
             mimetype=mime_type,
         )
     finally:

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -43,7 +43,7 @@ def _metadata_locale(locale):
     # This is dumb but we agreed it with ARIJ
     # https://github.com/alephdata/aleph/issues/1432
     app_logo = SETTINGS.APP_LOGO
-    if locale.startswith("ar"):
+    if locale.language.startswith("ar"):
         app_logo = SETTINGS.APP_LOGO_AR or app_logo
 
     return {
@@ -59,7 +59,7 @@ def _metadata_locale(locale):
             "publish": archive.can_publish,
             "logo": app_logo,
             "favicon": SETTINGS.APP_FAVICON,
-            "locale": locale,
+            "locale": str(locale),
             "locales": locales,
         },
         "categories": Collection.CATEGORIES,
@@ -95,7 +95,7 @@ def metadata():
       - System
     """
     request.rate_limit = None
-    locale = str(get_locale())
+    locale = get_locale()
     data = _metadata_locale(locale)
     if SETTINGS.SINGLE_USER:
         role = Role.load_cli_user()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,19 +4,19 @@ followthemoney==3.4.2
 followthemoney-store[postgresql]==3.0.5
 followthemoney-compare==0.4.4
 fingerprints==1.0.3
-servicelayer[google,amazon]==1.20.7
+servicelayer[google,amazon]==1.21.0
 normality==2.4.0
 pantomime==0.5.3
 
 # Flask ecosystem
 Flask==2.3.2
-Flask-SQLAlchemy==3.0.3
+Flask-SQLAlchemy==3.0.5
 Flask-Mail==0.9.1
 Flask-Migrate==3.1.0
 Flask-Cors==3.0.10
 Flask-Babel==3.1.0
 flask-talisman==1.0.0
-SQLAlchemy==2.0.15
+SQLAlchemy==2.0.17
 alembic==1.8.1
 authlib==0.15.5
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Dependencies maintained by OCCRP
 banal==1.0.6
-followthemoney==3.4.0
+followthemoney==3.4.2
 followthemoney-store[postgresql]==3.0.5
 followthemoney-compare==0.4.4
 fingerprints==1.0.3
@@ -14,7 +14,7 @@ Flask-SQLAlchemy==3.0.3
 Flask-Mail==0.9.1
 Flask-Migrate==3.1.0
 Flask-Cors==3.0.10
-Flask-Babel==3.0.0
+Flask-Babel==3.1.0
 flask-talisman==1.0.0
 SQLAlchemy==2.0.15
 alembic==1.8.1
@@ -27,7 +27,7 @@ jsonschema==4.17.3
 apispec==6.3.0
 apispec-webframeworks==0.5.2
 blinker==1.6.2
-Babel==2.11.0
+Babel==2.12.1
 PyYAML==6.0
 python-frontmatter==1.0.0
 pyjwt >= 2.0.1, < 2.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,22 @@
 # Dependencies maintained by OCCRP
 banal==1.0.6
-followthemoney==3.2.1
-followthemoney-store[postgresql]==3.0.3
+followthemoney==3.4.0
+followthemoney-store[postgresql]==3.0.5
 followthemoney-compare==0.4.4
 fingerprints==1.0.3
-servicelayer[google,amazon]==1.20.5
+servicelayer[google,amazon]==1.20.7
 normality==2.4.0
 pantomime==0.5.3
 
 # Flask ecosystem
-Flask==2.1.3
-Flask-SQLAlchemy==2.5.1
+Flask==2.3.2
+Flask-SQLAlchemy==3.0.3
 Flask-Mail==0.9.1
 Flask-Migrate==3.1.0
 Flask-Cors==3.0.10
-Flask-Babel==2.0.0
+Flask-Babel==3.0.0
 flask-talisman==1.0.0
-SQLAlchemy==1.4.46
+SQLAlchemy==2.0.15
 alembic==1.8.1
 authlib==0.15.5
 


### PR DESCRIPTION
The versions of the following packages were increased to the latest versions: `followthemoney`, `followthemoney-store`, `servicelayer`. Due to the fact that all 3 libraries use a newer version of `SQLAlchemy`, the versions of the following packages were also bumped to latest: `Flask`, `Flask-SQLAlchemy`, `SQLAlchemy`, `Flask-Babel`.

The commit also includes minor refactorings necessary as a result of these version bumps.
* `core.py` was refactored due to the `Flask-Babel` version bump [as per the docs](https://python-babel.github.io/flask-babel/#configuration)
* `migration.py`, `util.py` and `archive_api.py` were refactored due to the `SQLAlchemy` version bump

`archive.apy` was refactored as per [this interface change](https://github.com/pallets/flask/issues/4753)