### PR TITLE
Make code reloading work

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -104,7 +104,7 @@ services:
     build:
       context: .
     image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-latest}
-    command: python3 -m debugpy --listen 0.0.0.0:5678 -m flask run -h 0.0.0.0 -p 5000 --with-threads --reload --debugger
+    command: python3 -m debugpy --listen 0.0.0.0:5678 -m flask run -h 0.0.0.0 -p 5000 --with-threads --eager-loading --reload --debugger
     ports:
       - "127.0.0.1:5000:5000"
       - "127.0.0.1:5678:5678"
@@ -124,6 +124,7 @@ services:
       ALEPH_PROFILE: "false"
       ALEPH_SECRET_KEY: "development"
       FLASK_APP: "aleph.wsgi"
+      FLASK_ENV: "development"
     env_file:
       - aleph.env
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -124,7 +124,6 @@ services:
       ALEPH_PROFILE: "false"
       ALEPH_SECRET_KEY: "development"
       FLASK_APP: "aleph.wsgi"
-      FLASK_ENV: "development"
     env_file:
       - aleph.env
 


### PR DESCRIPTION
@monneyboi reported that the reloading feature of `flask run` wasn't properly working. I'm pretty sure it has to do with the debugger we are trying to attach. In either case [enabling earlier fails](https://flask.palletsprojects.com/en/2.1.x/server/#lazy-or-eager-loading) (instead of trying to fail lazily so a debugger can be shown) fixed the code reloading issue.