### PR TITLE
refactor migrations to sqlalchemy 2, fixes #3176

### DIFF
--- a/aleph/migrate/versions/4c9e198c5b31_entitysets.py
+++ b/aleph/migrate/versions/4c9e198c5b31_entitysets.py
@@ -76,13 +76,12 @@ def upgrade():
 
     bind = op.get_bind()
     meta = sa.MetaData()
-    meta.bind = bind
-    meta.reflect()
+    meta.reflect(bind)
     diagram_table = meta.tables["diagram"]
     entityset_table = meta.tables["entityset"]
     item_table = meta.tables["entityset_item"]
 
-    q = sa.select([diagram_table])
+    q = sa.select(diagram_table)
     rp = bind.execute(q)
     while True:
         diagram = rp.fetchone()

--- a/aleph/migrate/versions/9dcef7592cea_added_fields_to_entitysetitem_to_support_profiles.py
+++ b/aleph/migrate/versions/9dcef7592cea_added_fields_to_entitysetitem_to_support_profiles.py
@@ -33,8 +33,7 @@ def upgrade():
 
     bind = op.get_bind()
     meta = sa.MetaData()
-    meta.bind = bind
-    meta.reflect()
+    meta.reflect(bind)
     linkage_table = meta.tables["linkage"]
     entityset_table = meta.tables["entityset"]
     item_table = meta.tables["entityset_item"]
@@ -43,7 +42,7 @@ def upgrade():
     q = q.values({"judgement": "POSITIVE"})
     bind.execute(q)
 
-    q = sa.select([linkage_table]).order_by("profile_id")
+    q = sa.select(linkage_table).order_by("profile_id")
     rp = bind.execute(q)
 
     profiles = groupby(

--- a/aleph/migrate/versions/aa486b9e627e_hard_deletes.py
+++ b/aleph/migrate/versions/aa486b9e627e_hard_deletes.py
@@ -14,15 +14,15 @@ down_revision = "9dcef7592cea"
 
 def upgrade():
     meta = sa.MetaData()
-    meta.bind = op.get_bind()
-    meta.reflect()
+    bind = op.get_bind()
+    meta.reflect(bind)
     for table_name in ("alert", "entity", "mapping", "permission"):
         table = meta.tables[table_name]
         q = sa.delete(table).where(table.c.deleted_at != None)  # noqa
-        meta.bind.execute(q)
+        bind.execute(q)
     table = meta.tables["permission"]
     q = sa.delete(table).where(table.c.read == False)  # noqa
-    meta.bind.execute(q)
+    bind.execute(q)
 
     op.drop_column("alert", "deleted_at")
     op.drop_column("entity", "deleted_at")

--- a/aleph/migrate/versions/b3959bf8cc66_entity_ids.py
+++ b/aleph/migrate/versions/b3959bf8cc66_entity_ids.py
@@ -18,15 +18,14 @@ down_revision = "1519391870a0"
 def upgrade():
     bind = op.get_bind()
     meta = sa.MetaData()
-    meta.bind = bind
-    meta.reflect()
+    meta.reflect(bind)
     entity_table = meta.tables["entity"]
     collection_table = meta.tables["collection"]
-    q = sa.select([collection_table])
+    q = sa.select(collection_table)
     crp = bind.execute(q)
     for collection in crp.fetchall():
         ns = Namespace(collection.foreign_id)
-        q = sa.select([entity_table])
+        q = sa.select(entity_table)
         q = q.where(entity_table.c.collection_id == collection.id)
         erp = bind.execute(q)
         while True:


### PR DESCRIPTION
Migrations seemed to be forgotten in the sqlalchemy 2 version bump. This PR should fix that.

Changes based on: https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#select-no-longer-accepts-varied-constructor-arguments-columns-are-passed-positionally