### PR TITLE
Plain search highlights

### DIFF
--- a/aleph/search/__init__.py
+++ b/aleph/search/__init__.py
@@ -62,7 +62,6 @@ class CollectionsQuery(Query):
 class EntitiesQuery(Query):
     TEXT_FIELDS = ["fingerprints.text^3", "text"]
     PREFIX_FIELD = "fingerprints.text"
-    HIGHLIGHT_FIELD = "properties.*"
     SKIP_FILTERS = ["schema", "schemata"]
     SOURCE = ENTITY_SOURCE
     SORT_DEFAULT = []
@@ -121,8 +120,10 @@ class XrefQuery(Query):
 
     def __init__(self, parser, collection_id=None):
         self.collection_id = collection_id
-        parser.highlight = False
         super(XrefQuery, self).__init__(parser)
+
+    def get_highlight(self):
+        return {}
 
     def get_filters(self, **kwargs):
         filters = super(XrefQuery, self).get_filters(**kwargs)

--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -33,7 +33,6 @@ class Query(object):
     PREFIX_FIELD = "name"
     SKIP_FILTERS = []
     AUTHZ_FIELD = "collection_id"
-    HIGHLIGHT_FIELD = "text"
     SORT_FIELDS = {
         "label": "label.kw",
         "score": "_score",
@@ -219,16 +218,15 @@ class Query(object):
     def get_highlight(self):
         if not self.parser.highlight:
             return {}
-        query = query_string_query(self.HIGHLIGHT_FIELD, self.parser.highlight_text)
         return {
-            "encoder": "html",
+            "type": "plain",
             "fields": {
-                self.HIGHLIGHT_FIELD: {
-                    "highlight_query": query,
+                'text': {
                     "require_field_match": False,
-                    "number_of_fragments": self.parser.highlight_count,
                     "fragment_size": self.parser.highlight_length,
                     "max_analyzed_offset": self.parser.max_highlight_analyzed_offset,
+                    "number_of_fragments": self.parser.highlight_count,
+                    "fragment_size": 120,
                 }
             },
         }

--- a/ui/src/viewers/PdfViewer.jsx
+++ b/ui/src/viewers/PdfViewer.jsx
@@ -286,8 +286,6 @@ const mapStateToProps = (state, ownProps) => {
     .clear('offset');
 
   const pageQuery = baseQuery
-    .set('highlight', true)
-    .set('highlight_text', queryText)
     .set('highlight_count', 15)
     .setFilter('properties.index', page)
     .set('limit', 1);


### PR DESCRIPTION
Most basic changes i can think of that lead to having search highlights for documents and entities. I tried to not remove any logic that could potentially be used.

From the previous PR:
> I wasn’t able to get this to work locally. I still can’t see highlights for documents on the search results pages.

> Based on my understanding of the ES docs on highlighting, I think no matter what highlighter you use, the text needs to be retrievable from the source field for ES to be able to compute highlights?

Yeah i was surprised by this aswell, but these changes lead to highlights on my end (i am using a newly setup development environment based on `make upgrade` and `make `web`), what could differ between our setups?