### PR TITLE
Feature/3123 switch email type

### DIFF
--- a/contrib/email/generate_test_emails.py
+++ b/contrib/email/generate_test_emails.py
@@ -1,0 +1,116 @@
+# This script generates minimal RFC2822 email messages to test how Aleph ingests
+# and displays different types of emails
+import sys
+from email.message import EmailMessage
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+sender = "john.doe@example.org"
+recipient = "jane.doe@example.org"
+
+def plaintext_only():
+	"""Generate a plaintext-only email."""
+	msg = EmailMessage()
+	msg["From"] = sender
+	msg["To"] = recipient
+	msg["Subject"] = "Plaintext only"
+	msg.set_content("This is the body of a plaintext message.")
+
+	return msg
+
+
+def html_only():
+	"""Generate an email with a single HTML part."""
+	msg = MIMEMultipart("alternative")
+	msg["From"] = sender
+	msg["To"] = recipient
+	msg["Subject"] = "HTML only"
+
+	html_part = MIMEText("This is the body of an <strong>HTML</strong> message.", "html")
+	msg.attach(html_part)
+
+	return msg
+
+
+def multipart_alternative():
+	"""Generate an email with HTML and plaintext alternatives."""
+	msg = MIMEMultipart("alternative")
+	msg["From"] = sender
+	msg["To"] = recipient
+	msg["Subject"] = "Multipart alternative"
+
+	text_part = MIMEText("This is a **multipart/alternative** message.\n", "plain")
+	html_part = MIMEText("This is a <strong>multipart/alterantive</strong> message.\n", "html")
+
+	msg.attach(text_part)
+	msg.attach(html_part)
+
+	return msg
+
+
+def multipart_mixed():
+	"""Generate an email with multiple HTML and plaintext parts, but not alternatives."""
+	msg = MIMEMultipart("mixed")
+	msg["From"] = sender
+	msg["To"] = recipient
+	msg["Subject"] = "Multipart mixed"
+
+	part_1 = MIMEText("This is the first part (plaintext)\n", "plain")
+	part_2 = MIMEText("This is the second part (HTML)\n", "html")
+	part_3 = MIMEText("This is the third part (plaintext)\n", "plain")
+	part_4 = MIMEText("This is the fourth part (HTML)\n", "html")
+
+	msg.attach(part_1)
+	msg.attach(part_2)
+	msg.attach(part_3)
+	msg.attach(part_4)
+
+	return msg
+
+
+def multipart_nested():
+	"""Generate a nested multipart email."""
+	msg = MIMEMultipart("mixed")
+	msg["From"] = sender
+	msg["To"] = recipient
+	msg["Subject"] = "Nested multipart email"
+
+	part_1 = MIMEMultipart("alternative")
+	part_1_text = MIMEText("This is the **first** part\n", "plain")
+	part_1_html = MIMEText("This is the <strong>first</strong> part\n", "html")
+	part_1.attach(part_1_text)
+	part_1.attach(part_1_html)
+
+	part_2 = MIMEText("This is the second part\n", "plain")
+
+	msg.attach(part_1)
+	msg.attach(part_2)
+
+	return msg
+
+
+def empty():
+	msg = EmailMessage()
+	msg["From"] = sender
+	msg["To"] = recipient
+	msg["Subject"] = "Empty body"
+
+	return msg
+
+
+if __name__ == "__main__":
+	examples = {
+		"plaintext": plaintext_only(),
+		"html": html_only(),
+		"alternative": multipart_alternative(),
+		"mixed": multipart_mixed(),
+		"nested": multipart_nested(),
+		"empty": empty(),
+	}
+
+	args = sys.argv[1:]
+
+	if not len(args) or args[0] not in examples.keys():
+		print(plaintext_only())
+	else:
+		print(examples[args[0]])

--- a/ui/src/viewers/EmailViewer.scss
+++ b/ui/src/viewers/EmailViewer.scss
@@ -23,4 +23,18 @@
       box-shadow: unset;
     }
   }
+
+  &__type-switch {
+    display: flex;
+    gap: 1.5 * $aleph-grid-size;
+
+    input[type='radio'] {
+      margin: 0;
+      margin-inline-end: 0.5 * $aleph-grid-size;
+    }
+  }
+
+  &__unavailable-type {
+    color: $aleph-greyed-text;
+  }
 }


### PR DESCRIPTION
This PR adds an option to switch between HTML and plaintext view. As can be seen in the screencast below, this is not a perfect solution and contents might be missing from one of the two views (which will only be resolved after fixing https://github.com/alephdata/aleph/issues/3161).

https://github.com/alephdata/aleph/assets/1512805/d6851307-cca2-48cb-9ed1-04df67de1fa0

I’m also not entirely sure about the UI, it’s not ideal that the switch is integrated into the email view/into the data. I had previously implemented a version that displayed a separate tab at the top (similar to how we display a view and plaintext tab for text documents).

<img width="1017" alt="Screen Shot 2023-06-28 at 22 42 19" src="https://github.com/alephdata/aleph/assets/1512805/16f793ca-8ccc-44ad-82a1-5da47d2a09ee">

These files can be used for testing, although you will need to change the extension from `.eml.txt` to just `.eml` (but GitHub doesn’t allow uploading `.eml` files).

- [alternative.eml.txt](https://github.com/alephdata/aleph/files/11899793/alternative.eml.txt)
- [empty.eml.txt](https://github.com/alephdata/aleph/files/11899794/empty.eml.txt)
- [html.eml.txt](https://github.com/alephdata/aleph/files/11899795/html.eml.txt)
- [mixed.eml.txt](https://github.com/alephdata/aleph/files/11899796/mixed.eml.txt)
- [nested.eml.txt](https://github.com/alephdata/aleph/files/11899797/nested.eml.txt)
- [plain.eml.txt](https://github.com/alephdata/aleph/files/11899798/plain.eml.txt)