### PR TITLE
Enable IAM role-based auth between EC2 and S3

### DIFF
--- a/aleph.env.tmpl
+++ b/aleph.env.tmpl
@@ -66,7 +66,6 @@ ALEPH_OAUTH_SECRET=
 # AWS_REGION=
 # Leave these next two keys empty if you prefer IAM Role-based auth
 # (see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#id1)
-# Otherwise, provide key ID and access key.
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
 

--- a/aleph.env.tmpl
+++ b/aleph.env.tmpl
@@ -63,9 +63,11 @@ ALEPH_OAUTH_SECRET=
 # Or, if 'ALEPH_ARCHIVE_TYPE' configuration is 's3':
 # ARCHIVE_TYPE=s3
 # ARCHIVE_BUCKET=
+# AWS_REGION=
+# If server is running on EC2, prefer role-based authentication and leave key ID and access key null.
+# Otherwise, provide key ID and access key.
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=
-# AWS_REGION=
 
 # To use an external ElasticSearch service:
 # ALEPH_ELASTICSEARCH_URI=

--- a/aleph.env.tmpl
+++ b/aleph.env.tmpl
@@ -64,7 +64,8 @@ ALEPH_OAUTH_SECRET=
 # ARCHIVE_TYPE=s3
 # ARCHIVE_BUCKET=
 # AWS_REGION=
-# If server is running on EC2, prefer role-based authentication and leave key ID and access key null.
+# Leave these next two keys empty if you prefer IAM Role-based auth
+# (see https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#id1)
 # Otherwise, provide key ID and access key.
 # AWS_ACCESS_KEY_ID=
 # AWS_SECRET_ACCESS_KEY=

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ followthemoney==3.4.3
 followthemoney-store[postgresql]==3.0.5
 followthemoney-compare==0.4.4
 fingerprints==1.0.3
-servicelayer[google,amazon]==1.21.0
+https://github.com/guardian/aleph-servicelayer/archive/iam-role-based-s3-auth.zip
 normality==2.4.0
 pantomime==0.5.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ followthemoney==3.4.3
 followthemoney-store[postgresql]==3.0.5
 followthemoney-compare==0.4.4
 fingerprints==1.0.3
-https://github.com/guardian/aleph-servicelayer/archive/iam-role-based-s3-auth.zip
+servicelayer[google,amazon]==1.21.0
 normality==2.4.0
 pantomime==0.5.3
 


### PR DESCRIPTION
resolves https://github.com/alephdata/aleph/issues/3185

- ~bump version of servicelayer to include changes in https://github.com/alephdata/servicelayer/pull/99~
- add comment explaining that role-based auth is to be preferred over user-based, and that environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are only required for user-based auth.