### PR TITLE
Populate type groups in ES index

### DIFF
--- a/aleph/index/entities.py
+++ b/aleph/index/entities.py
@@ -27,6 +27,16 @@ PROXY_INCLUDES = [
     "updated_at",
 ]
 ENTITY_SOURCE = {"includes": PROXY_INCLUDES}
+FACET_PROPERTY_TYPE_GROUPS = [
+    "dates",
+    "countries",
+    "languages",
+    "emails",
+    "phones",
+    "names",
+    "addresses",
+    "mimetypes",
+]
 
 
 def _source_spec(includes, excludes):
@@ -193,6 +203,12 @@ def format_proxy(proxy, collection):
     fps = set([fingerprints.generate(name) for name in names])
     fps.update(names)
     data["fingerprints"] = [fp for fp in fps if fp is not None]
+
+    # Populate property type groups used in search facets
+    for group in FACET_PROPERTY_TYPE_GROUPS:
+        values = proxy.get_type_values(registry.groups[group])
+        if values:
+            data[group] = values
 
     # Slight hack: a magic property in followthemoney that gets taken out
     # of the properties and added straight to the index text.


### PR DESCRIPTION
This will likely fix a few bugs related to search facets. The common root cause for all of these is that values for property type groups such as `languages`, `countries`, `dates` etc. are not populated correctly before indexing entities.

I’m not a 100% sure this is the best solution and whether it might have unintended side effects and need to do a little more research before this can be merged.

Fixes #2675, fixes #2500, fixes #2315.

**To do:**

- [x] Check whether populating type groups has unintended side effects (besides slightly increasing index size), especially with regards to XREF.
- [x] Decide how to handle `processingDate`. Make it a hidden property and ignore hidden properties when generating group values?
- [ ] Exclude properties from type groups that will likely add too much noise (`Thing:createdAt`, `Thing:retrievedAt`, `Document:processedAt`, …)
- [ ] Double-check that including non-matchable properties in type groups doesn’t affect XREF results.
- [ ] Increase number of XREF candidates???
- [ ] Add tests