### PR TITLE
PoC OAuth2

### DIFF
--- a/aleph/core.py
+++ b/aleph/core.py
@@ -120,6 +120,11 @@ def create_app(config=None):
 
     mount_app_blueprints(app)
 
+    # TODO Fix circular dependency?
+    from aleph.oauth2.server import configure_oauth2_server
+
+    configure_oauth2_server(app)
+
     # This executes all registered init-time plugins so that other
     # applications can register their behaviour.
     for plugin in get_extensions("aleph.init"):

--- a/aleph/manage.py
+++ b/aleph/manage.py
@@ -43,6 +43,7 @@ from aleph.logic.permissions import update_permission
 from aleph.util import JSONEncoder
 from aleph.index.collections import get_collection as _get_index_collection
 from aleph.index.entities import get_entity as _get_index_entity
+from aleph.oauth2.logic import create_oauth_client
 
 log = logging.getLogger("aleph")
 
@@ -517,3 +518,21 @@ def evilshit():
     delete_index()
     destroy_db()
     upgrade()
+
+
+@cli.group(help="Manage OAuth clients")
+def oauth_client():
+    pass
+
+
+@oauth_client.command("create")
+@click.option("-n", "--name", help="Name of the OAuth client", required=True)
+@click.option(
+    "-r", "--redirect-uri", help="OAuth redirect URI", required=True, multiple=True
+)
+def create_app(name, redirect_uri):
+    client = create_oauth_client(name, redirect_uri)
+
+    print(f"OAuth 2 client created.")
+    print(f"Client ID: {client.client_id}")
+    print(f"Client secret: {client.client_secret}")

--- a/aleph/migrate/versions/c298a4c0b9cb_create_oauth2_client_table.py
+++ b/aleph/migrate/versions/c298a4c0b9cb_create_oauth2_client_table.py
@@ -1,0 +1,30 @@
+"""create oauth2_client table
+
+Revision ID: c298a4c0b9cb
+Revises: c52a1f469ac7
+Create Date: 2023-07-31 10:43:55.330921
+
+"""
+
+# revision identifiers, used by Alembic.
+from alembic import op
+import sqlalchemy as sa
+
+revision = "c298a4c0b9cb"
+down_revision = "c52a1f469ac7"
+
+
+def upgrade():
+    op.create_table(
+        "oauth2_client",
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("client_id", sa.String(48), index=True, unique=True, nullable=False),
+        sa.Column("client_secret", sa.String(120)),
+        sa.Column("client_id_issued_at", sa.Integer, nullable=False, default=0),
+        sa.Column("client_secret_expires_at", sa.Integer, nullable=False, default=0),
+        sa.Column("client_metadata", sa.Text),
+    )
+
+
+def downgrade():
+    op.drop_table("oauth2_client")

--- a/aleph/oauth2/logic.py
+++ b/aleph/oauth2/logic.py
@@ -1,0 +1,98 @@
+import time
+from werkzeug.security import gen_salt
+from banal import ensure_list
+
+from aleph.core import db, cache
+from aleph.oauth2.model import OAuth2Client, OAuth2AuthorizationCode, OAuth2Token
+
+AUTH_CODE_CACHE_PREFIX = "oauth2-auth-code"
+TOKEN_CACHE_PREFIX = "oauth2-token"
+
+
+def create_oauth_client(name, redirect_uris):
+    redirect_uris = ensure_list(redirect_uris)
+
+    client_id = gen_salt(24)
+    client_secret = gen_salt(48)
+    client_id_issued_at = int(time.time())
+    client = OAuth2Client(
+        client_id=client_id,
+        client_id_issued_at=client_id_issued_at,
+        client_secret=client_secret,
+    )
+
+    client.set_client_metadata(
+        {
+            "client_name": name,
+            "redirect_uris": redirect_uris,
+            "response_types": ["code"],
+            "grant_types": ["authorization_code"],
+            "token_endpoint_auth_method": "client_secret_post",
+        }
+    )
+
+    db.session.add(client)
+    db.session.commit()
+
+    return client
+
+
+def _auth_code_key(code):
+    return cache.key(AUTH_CODE_CACHE_PREFIX, code)
+
+
+def save_auth_code(auth_code):
+    key = _auth_code_key(auth_code.code)
+    state = {
+        "client_id": auth_code.client_id,
+        "auth_time": auth_code.auth_time,
+        "redirect_uri": auth_code.redirect_uri,
+        "scope": auth_code.scope,
+        "user_id": auth_code.user_id,
+        "code_challenge": auth_code.code_challenge,
+        "code_challenge_method": auth_code.code_challenge_method,
+    }
+
+    cache.set_complex(key, state, expires=OAuth2AuthorizationCode.EXPIRES)
+
+
+def delete_auth_code(auth_code):
+    cache.delete(_auth_code_key(auth_code.code))
+
+
+def load_auth_code(code):
+    key = _auth_code_key(code)
+    state = cache.get_complex(key)
+
+    if not state:
+        return None
+
+    return OAuth2AuthorizationCode(code=code, **state)
+
+
+def _token_key(token):
+    return cache.key(TOKEN_CACHE_PREFIX, token)
+
+
+def save_token(token):
+    key = _token_key(token.access_token)
+    state = {
+        "client_id": token.client_id,
+        "token_type": token.token_type,
+        "user_id": token.user_id,
+        "scope": token.scope,
+        "issued_at": token.issued_at,
+        "expires_in": token.expires_in,
+    }
+
+    cache.set_complex(key, state, token.expires_in)
+
+
+def load_token(access_token):
+    key = cache.key(TOKEN_CACHE_PREFIX, access_token)
+    state = cache.get_complex(key)
+
+    if not state:
+        return None
+
+    return OAuth2Token(access_token, **state)

--- a/aleph/oauth2/model.py
+++ b/aleph/oauth2/model.py
@@ -1,0 +1,95 @@
+import time
+import logging
+import secrets
+from authlib.oauth2.rfc6749 import AuthorizationCodeMixin, TokenMixin
+from authlib.integrations.sqla_oauth2 import OAuth2ClientMixin
+
+from aleph.model import db
+
+log = logging.getLogger(__name__)
+
+
+class User:
+    def __init__(self, role):
+        self.role = role
+
+    def get_user_id(self):
+        return self.role.id
+
+
+class OAuth2Client(db.Model, OAuth2ClientMixin):
+    __tablename__ = "oauth2_client"
+    id = db.Column(db.Integer, primary_key=True)
+
+
+class OAuth2AuthorizationCode(AuthorizationCodeMixin):
+    EXPIRES = 60
+
+    def __init__(
+        self,
+        code,
+        auth_time,
+        client_id,
+        redirect_uri,
+        scope,
+        user_id,
+        code_challenge,
+        code_challenge_method,
+    ):
+        self.code = code
+        self.client_id = client_id
+        self.auth_time = auth_time
+        self.redirect_uri = redirect_uri
+        self.scope = scope
+        self.user_id = user_id
+        self.code_challenge = code_challenge
+        self.code_challenge_method = code_challenge_method
+
+    def get_redirect_uri(self):
+        return self.redirect_uri
+
+    def get_scope(self):
+        return self.scope
+
+    def is_expired(self):
+        return self.auth_time + self.EXPIRES < time.time()
+
+
+class OAuth2Token(TokenMixin):
+    def __init__(
+        self,
+        access_token,
+        client_id,
+        token_type,
+        user_id,
+        scope=None,
+        issued_at=None,
+        expires_in=None,
+    ):
+        self.access_token = access_token
+        self.client_id = client_id
+        self.token_type = token_type
+        self.user_id = user_id
+        self.scope = scope
+        self.issued_at = issued_at
+        self.expires_in = expires_in
+
+    def check_client(self, client):
+        return self.client_id == client.get_client_id()
+
+    def get_scope(self):
+        return self.scope
+
+    def get_expires_in(self):
+        return self.expires_in
+
+    def is_expired(self):
+        if not self.expires_in:
+            return False
+
+        expires_at = self.issued_at + self.expires_in
+        return expires_at < time.time()
+
+    def is_revoked(self):
+        # Currently not implemented
+        return False

--- a/aleph/oauth2/server.py
+++ b/aleph/oauth2/server.py
@@ -1,0 +1,84 @@
+import logging
+import time
+from authlib.oauth2.rfc6749 import AuthorizationCodeGrant
+from authlib.integrations.flask_oauth2 import AuthorizationServer
+
+from aleph.model import Role
+from aleph.oauth2.model import User, OAuth2Client, OAuth2AuthorizationCode, OAuth2Token
+from aleph.oauth2.logic import (
+    delete_auth_code,
+    save_auth_code,
+    load_auth_code,
+    save_token,
+)
+
+log = logging.getLogger(__name__)
+
+
+class AuthorizationCodeGrant(AuthorizationCodeGrant):
+    def save_authorization_code(self, code, request):
+        code_challenge = request.data.get("code_challenge")
+        code_challenge_method = request.data.get("code_challenge_method")
+
+        auth_code = OAuth2AuthorizationCode(
+            code=code,
+            client_id=request.client.client_id,
+            auth_time=int(time.time()),
+            redirect_uri=request.redirect_uri,
+            scope=request.scope,
+            user_id=request.user.id,
+            code_challenge=code_challenge,
+            code_challenge_method=code_challenge_method,
+        )
+
+        save_auth_code(auth_code)
+
+    def query_authorization_code(self, code, client):
+        auth_code = load_auth_code(code)
+
+        if not auth_code:
+            return None
+
+        if auth_code.client_id != client.client_id:
+            return None
+
+        if auth_code.is_expired():
+            return None
+
+        return auth_code
+
+    def delete_authorization_code(self, auth_code):
+        delete_auth_code(auth_code)
+
+    def authenticate_user(self, auth_code):
+        role = Role.by_id(auth_code.user_id)
+        # authlib expects a model that implements the `get_user_id` method,
+        # so we wrap the `Role` model to adapt to this API
+        return User(role=role)
+
+
+def _save_token(token, request):
+    if request.user:
+        user_id = request.user.get_user_id()
+    else:
+        user_id = None
+    client_id = request.client.client_id
+    token = OAuth2Token(
+        client_id=client_id,
+        user_id=user_id,
+        issued_at=time.time(),
+        **token,
+    )
+    save_token(token)
+
+
+def _query_client(client_id):
+    return OAuth2Client.query.filter_by(client_id=client_id).first()
+
+
+server = AuthorizationServer(query_client=_query_client, save_token=_save_token)
+
+
+def configure_oauth2_server(app):
+    server.init_app(app)
+    server.register_grant(AuthorizationCodeGrant)

--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -120,6 +120,15 @@ class Settings:
         )
 
         ###############################################################################
+        # OAuth 2 Server
+
+        self.OAUTH2_TOKEN_EXPIRES_IN = {
+            "authorization_code": env.to_int(
+                "ALEPH_OAUTH2_SERVER_TOKEN_EXPIRES_IN", 60 * 60
+            ),
+        }
+
+        ###############################################################################
         # Content processing options
 
         self.DEFAULT_LANGUAGE = env.get("ALEPH_DEFAULT_LANGUAGE", "en")

--- a/aleph/views/__init__.py
+++ b/aleph/views/__init__.py
@@ -19,6 +19,7 @@ from aleph.views.mappings_api import blueprint as mappings_api
 from aleph.views.entitysets_api import blueprint as entitysets_api
 from aleph.views.exports_api import blueprint as exports_api
 from aleph.views.bookmarks_api import blueprint as bookmarks_api
+from aleph.views.oauth2_api import blueprint as oauth2_api
 
 
 def mount_app_blueprints(app):
@@ -43,3 +44,4 @@ def mount_app_blueprints(app):
     app.register_blueprint(entitysets_api)
     app.register_blueprint(exports_api)
     app.register_blueprint(bookmarks_api)
+    app.register_blueprint(oauth2_api)

--- a/aleph/views/context.py
+++ b/aleph/views/context.py
@@ -76,7 +76,13 @@ def _get_credential_authz(credential):
     if " " in credential:
         method, credential = credential.split(" ", 1)
         if method == "Token":
-            return Authz.from_token(credential)
+            authz = Authz.from_token(credential)
+            log.info(f"Authenticated {authz.id} using token")
+            return authz
+        if method == "Bearer":
+            authz = Authz.from_oauth2_token(credential)
+            log.info(f"Authenticated {authz} using OAuth 2 access token")
+            return authz
 
     role = Role.by_api_key(credential)
     if role is not None:

--- a/aleph/views/oauth2_api.py
+++ b/aleph/views/oauth2_api.py
@@ -1,0 +1,23 @@
+from flask import Blueprint, request
+from aleph.views.util import require
+from aleph.oauth2.server import server
+
+blueprint = Blueprint("oauth2_api", __name__)
+
+
+@blueprint.route("/api/2/oauth2/authorize", methods=["GET", "POST"])
+def authorize():
+    require(request.authz.logged_in)
+
+    # This is where we'd usually display a page and ask the user
+    # whether they'd like to authorize the OAuth app before granting
+    # auhorization to the app.
+
+    return server.create_authorization_response(
+        grant_user=request.authz.role,
+    )
+
+
+@blueprint.route("/api/2/oauth2/token", methods=["POST"])
+def issue_token():
+    return server.create_token_response()

--- a/aleph/views/roles_api.py
+++ b/aleph/views/roles_api.py
@@ -156,6 +156,15 @@ def create():
     return RoleSerializer.jsonify(role, status=201)
 
 
+@blueprint.route("/api/2/roles/me", methods=["GET"])
+def me():
+    require(request.authz.logged_in)
+    role = request.authz.role
+    data = role.to_dict()
+    data.update(get_deep_role(role))
+    return RoleSerializer.jsonify(data)
+
+
 @blueprint.route("/api/2/roles/<int:id>", methods=["GET"])
 def view(id):
     """Retrieve role details.

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -4,7 +4,7 @@ import string
 import logging
 from banal import as_bool, ensure_dict, is_mapping, is_listish
 from normality import stringify
-from flask import Response, request, render_template
+from flask import Response, request, session, render_template
 from flask_babel import gettext
 from werkzeug.urls import url_parse
 from werkzeug.exceptions import Forbidden
@@ -17,6 +17,7 @@ from aleph.validation import get_validator
 from aleph.index.entities import get_entity as _get_index_entity
 from aleph.index.collections import get_collection as _get_index_collection
 from aleph.util import JSONEncoder
+from aleph.settings import SETTINGS
 
 log = logging.getLogger(__name__)
 CALLBACK_VALID = string.ascii_letters + string.digits + "_"
@@ -185,3 +186,15 @@ def stream_csv(iterable):
 def render_xml(template, **kwargs):
     data = render_template(template, **kwargs)
     return Response(data, mimetype="text/xml")
+
+
+def store_token(token):
+    session["token"] = token
+
+
+def delete_token():
+    session.pop("token")
+
+
+def get_token():
+    return session.get("token")

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -164,6 +164,16 @@ services:
     env_file:
       - aleph.env
 
+  oauth-example-app:
+    image: denoland/deno
+    command: deno run --allow-env --allow-net --allow-read /app/index.js
+    volumes:
+      - "./oauth-example-app:/app/"
+    ports:
+      - "1234:1234"
+    env_file:
+      - "./oauth-example-app/.env"
+
 volumes:
   archive-data: {}
   elasticsearch-data: {}

--- a/oauth-example-app/.env.example
+++ b/oauth-example-app/.env.example
@@ -1,0 +1,5 @@
+OAUTH2_AUTHORIZE_URL="http://api:5000/api/2/oauth2/authorize"
+OAUTH2_TOKEN_URL="http://api:5000/api/2/oauth2/token"
+OAUTH2_CLIENT_ID=""
+OAUTH2_CLIENT_SECRET=""
+ALEPH_API_URL="http://api:5000/api/2/"

--- a/oauth-example-app/callback.js
+++ b/oauth-example-app/callback.js
@@ -1,0 +1,46 @@
+import { makeUrl, setToken } from "./util.js";
+
+async function issueToken(authCode, settings) {
+  const headers = new Headers();
+  headers.set("Content-Type", "application/x-www-form-urlencoded; charset=utf-8");
+
+  const body = new URLSearchParams();
+  body.set("client_id", settings.clientId);
+  body.set("client_secret", settings.clientSecret);
+  body.set("redirect_uri", settings.redirectUrl);
+  body.set("grant_type", "authorization_code");
+  body.set("code", authCode);
+
+  const res = await fetch(settings.tokenUrl, { method: "POST", headers, body });
+  const data = await res.json();
+
+  return {
+    token: data.access_token,
+    expires: data.expires_in,
+  };
+}
+
+async function handler(url, request, settings) {
+  const headers = new Headers();
+
+  const location = makeUrl(request, "/");
+  headers.set("Location", location.toString());
+
+  const authCode = url.searchParams.get("code");
+
+  if (!authCode) {
+    return new Response("No auth code provided", {
+      status: 400,
+    });
+  }
+
+  const { token, expires } = await issueToken(authCode, settings);  
+  setToken(headers, token, expires);
+
+  return new Response("", {
+    status: 302,
+    headers,
+  });
+}
+
+export default handler;

--- a/oauth-example-app/home.js
+++ b/oauth-example-app/home.js
@@ -1,0 +1,29 @@
+import { getToken, makeUrl } from "./util.js";
+
+async function getUserInfo(token, settings) {
+  const url = new URL("/api/2/roles/me", settings.apiUrl);
+  const headers = new Headers();
+  headers.set("Authorization", `Bearer ${token}`);
+  const res = await fetch(url, { headers });
+  const data = await res.json();
+
+  return data;
+}
+
+async function handler(url, request, settings) {
+  const token = getToken(request);
+  let body;
+
+  if (!token) {
+    const loginUrl = makeUrl(request, "login").toString();
+    body = `<a href="${loginUrl}">Log in</a>`;
+  } else {
+    const logoutUrl = makeUrl(request, "logout").toString();
+    const { name } = await getUserInfo(token, settings);
+    body = `Hi ${name}! <a href="${logoutUrl}">Log out</a>`;
+  }
+
+  return new Response(body, { status: 200 });
+}
+
+export default handler;

--- a/oauth-example-app/index.js
+++ b/oauth-example-app/index.js
@@ -1,0 +1,55 @@
+import { serve } from "https://deno.land/std@0.196.0/http/server.ts";
+import homeHandler from "./home.js";
+import loginHandler from "./login.js";
+import logoutHandler from "./logout.js";
+import callbackHandler from "./callback.js";
+
+const settings = {
+  clientId: Deno.env.get("OAUTH2_CLIENT_ID"),
+  clientSecret: Deno.env.get("OAUTH2_CLIENT_SECRET"),
+  authUrl: Deno.env.get("OAUTH2_AUTHORIZE_URL"),
+  tokenUrl: Deno.env.get("OAUTH2_TOKEN_URL"),
+  apiUrl: Deno.env.get("ALEPH_API_URL"),
+  redirectUrl: "http://localhost:1234/callback",
+};
+
+if (
+  !settings.clientId ||
+  !settings.clientSecret ||
+  !settings.authUrl ||
+  !settings.tokenUrl ||
+  !settings.apiUrl
+) {
+  console.log("Missing configuration options.");
+  Deno.exit(1);
+}
+
+await serve(handler, { port: 1234 });
+
+async function handler(request) {
+  const url = new URL(request.url);
+  let res;
+
+  if (url.pathname === "/") {
+    res = await homeHandler(url, request, settings);
+  }
+
+  if (url.pathname === "/login") {
+    res = await loginHandler(url, request, settings);
+  }
+
+  if (url.pathname === "/logout") {
+    res = await logoutHandler(url, request, settings);
+  }
+
+  if (url.pathname === "/callback") {
+    res = await callbackHandler(url, request, settings);
+  }
+
+  if (!res) {
+    return new Response("Not found", { status: 404 });
+  }
+
+  res.headers.set("Content-Type", "text/html");
+  return res;
+}

--- a/oauth-example-app/login.js
+++ b/oauth-example-app/login.js
@@ -1,0 +1,28 @@
+import { getToken, makeUrl } from "./util.js";
+
+async function handler(url, request, settings) {
+  const token = getToken(request);
+
+  if (token) {
+    // Already logged in
+    const headers = new Headers();
+    headers.set("Location", makeUrl("/").toString());
+    return new Response("", { status: 302, headers });
+  }
+
+  const headers = new Headers();
+
+  const location = new URL(settings.authUrl);
+  location.searchParams.set("client_id", settings.clientId);
+  location.searchParams.set("response_type", "code");
+  location.searchParams.set("redirect_uri", settings.redirectUrl);
+
+  headers.set("Location", location);
+
+  return new Response("", {
+    status: 302,
+    headers,
+  });
+}
+
+export default handler;

--- a/oauth-example-app/logout.js
+++ b/oauth-example-app/logout.js
@@ -1,0 +1,10 @@
+import { deleteToken, makeUrl } from "./util.js";
+
+async function handler(url, request, settings) {
+  const headers = new Headers();
+  headers.set("Location", makeUrl(request, "/").toString());
+  deleteToken(headers);
+  return new Response("", { status: 302, headers });
+}
+
+export default handler;

--- a/oauth-example-app/util.js
+++ b/oauth-example-app/util.js
@@ -1,0 +1,42 @@
+import { getCookies, setCookie } from "https://deno.land/std@0.196.0/http/cookie.ts";
+
+function makeUrl(request, pathname) {
+  const url = new URL(request.url);
+  url.path = "/";
+  url.search = "";
+  url.pathname = pathname;
+
+  return url;
+}
+
+const COOKIE_NAME = "session_token";
+
+function getToken(request) {
+  const cookies = getCookies(request.headers);
+  return cookies[COOKIE_NAME];
+}
+
+function setToken(headers, token, expires) {
+  const cookie = {
+    name: COOKIE_NAME,
+    value: token,
+    maxAge: expires,
+    secure: true,
+    httpOnly: true,
+    sameSite: "Strict",
+  };
+
+  setCookie(headers, cookie);
+}
+
+function deleteToken(headers) {
+  const cookie = {
+    name: COOKIE_NAME,
+    value: '',
+    expires: 0,
+  };
+
+  setCookie(headers, cookie);
+}
+
+export { makeUrl, getToken, setToken, deleteToken };


### PR DESCRIPTION
### Do not merge this!

This is a proof of concept to allow authentication against the Aleph API using OAuth 2. It is definitely not production-ready. I’m only using this PR to document my findings for future reference.

### Why

Aleph is used in by many different organizations and individuals and some of its users (including OCCRP) have custom requirements or processes. However, features that are only relevant to a small subset of Aleph’s users or that go beyond the scope of Aleph should most likely not be part of Aleph’s core.

Also, being able to deploy experiments for new features outside of Aleph would be very useful. This would enable faster development and iterations outside of Aleph’s regular release cycle, without being limited by technical legacy in Aleph, and with limited risk of breaking things.

Some example use cases include:

* Allowing users to load spreadsheets uploaded to or entities created in Aleph into a Datasette (Light) instance.
* Deploying an experimental, new UI to edit and view timelines.
* Creating an integration with or layer on top of Jupyter notebooks (or a similar environment) to allow users to run notebooks/scripts for common tasks self-service. (At OCCRP the Data Desk has notebooks for common tasks like exporting or post-processing data from Aleph.
* Experimenting with new search interfaces (new UIs, query builders, natural language, …)
* Developing a Wiki integration to display rich previews of linked Aleph entities.
* Developing an integration with ID to suggest relevant search results based on a ticket or to store data from a ticket in Aleph.
* Building a browser extension to extract information from articles and pages on the web as Aleph entities.

Many of the these use cases can be covered by deploying standalone apps side-by-side with Aleph. However, right now there is no authentication mechanism to let these apps securely authenticate on behalf of a user in order to access data in Aleph.

### What

This PR implements a PoC for an OAuth 2 server in Aleph, allowing OAuth clients to acquire authorization from Aleph users to access their data. Upon authorization, clients can request an access token from the OAuth server that the client can then use to authenticate with the Aleph API.

If you have ever used a [third-party GitHub App](https://github.com/marketplace?type=apps), this is exactly the same auth flow. However, one notable difference is that GitHub allows anyone to create a third-party app. For Aleph, it might make sense to limit this only to admins/operators of Aleph instance.

The PR uses [authlib](https://docs.authlib.org/en/latest/) (we already use the OAuth client from authlib for integration with OAuth identity providers like Keycloak). authlib implements most of the OAuth standards, this PR implements only application-specific logic (storing client information and tokens, setting up routes to handle request).

OAuth 2 specifies multiple different auth flows. This PR implements the [authorization code](https://datatracker.ietf.org/doc/html/rfc6749#section-4.1) flow which is quite common for this use case.

This PR also includes a command for the `aleph` CLI to create OAuth clients and a small example app. The example app implements the client auth flow manually, which is obviously a bad idea for a production use case -- I did that as a learning exercise.

### Implementation details

* authlib comes with many integrations, including integrations for Flask and SQLAlchemy. This means that creating a SA model to store client information in the database is super simple: https://github.com/alephdata/aleph/blob/feature/oauth-poc/aleph/oauth2/model.py#L20-L22

* While the SA integration also comes with model mixins for access tokens, this implementation doesn’t make use of them and instead stores them in Redis. This is what we already do for "normal" access tokens issued when authenticating in the UI and removes the need for a database roundtrip on every request. This requires some additional custom implementation to store, read, and delete tokens in Redis, something that might actually not be necessary/worth it.

* When logging in to the Aleph UI, the user’s authentication token is stored in local storage. This means that API requests always have to explicitly include the token in the request headers. However, the OAuth Authorization Code flow relies on a redirect to the `/oauth2/authorize` API endpoint (after the user has logged in). As the authentication token is stored in local storage, it isn’t included in the request to the `/oauth2/authorize` endpoint.

  To work around this, I have updated Aleph’s session handling to store the authentication token in an HTTP-only cookie (instead of local storage). This might be a good idea anyways (as it makes it impossible for JavaScript code to extract the authentication token), but it might also have unintended side effects?

### Ideas

* We use a custom auth flow for the UI which requires that the Aleph API knows about implementation details of the UI. Could we decouple this and simply implement the UI as a generic OAuth client, removing the need for custom auth flows in Aleph?

* Support public clients without a secret (currently client secrets are required) and PKCE or PKCE in addition to client secret.

* This PoC issues access tokens that always have access to everything the user has access to. Depending on use cases, using OAuth scopes to limit access might make sense, for example to limit access to specific datasets/investigations, actions (e.g. read only) or endpoints (e.g. user/role info only, no access to datasets/investigations).

* This PoC currently uses short access token lifetimes (60 mins), but doesn’t issue refresh tokens. authlib can easily be configured to generate refresh tokens, but this would require a small change to also persist the refresh tokens (potentially in a more permanent store than Redis).

* It might make sense to permanently store access tokens (even after they expire) for auditing purposes.

### Demo

I’ve pushed a very simple example application. It let’s users authenticate via Aleph and fetches some basic information about the user to display a personalized greeting. Nothing fancy. Here’s how to run it:

Make sure to run database migrations after checking out this branch, then start Aleph:

```
make upgrade
make web
```

Open the Aleph UI in your browser and sign in. (You need to be sign in, otherwise the auth flow will fail. Usually in an OAuth flow, when a user is not signed in, you’d redirect them to the sign in page of your app and then continue the flow afterwards. This would require a few small changes to the Aleph UI, but I haven’t implemented them in this PoC.)

Next, create a new OAuth client using the `aleph` CLI:

```
make shell
aleph oauth-client create --name "My Aleph App" --redirect-uri "http://localhost:1234/callback"
```

Create `oauth-example-app/.env` based on the template and add the client ID and secret from the previous step.

```
cp ./oauth-example-app/.env.template ./oauth-example-app/.env
```

Now start the example app:

```
docker compose -f docker-compose.dev.yml up oauth-example-app
```

Open http://localhost:1234 in your browser. Click on the "Login" link. This will start the OAuth flow. You will be redirected back to http://localhost:1234 on successful completion of the flow. The page should then display "Hi {name}!" where `{name}` is the user’s name requested from the Aleph API. While this is a very simple example, the client app can access other API endpoint too, for example to fetch entity data (as long as the user has access to the entities).