### PR TITLE
Flask defaults, some reduced coupling & cleaning up

### DIFF
--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -77,6 +77,7 @@ class Authz(object):
             return False
         return collection in self.collections(action)
 
+    @property
     def can_bulk_import(self):
         if not self.can_browse_anonymous or not self.session_write:
             return False
@@ -97,6 +98,7 @@ class Authz(object):
             return True
         return int(role_id) in self.roles
 
+    @property
     def can_register(self):
         if self.logged_in or SETTINGS.MAINTENANCE or not SETTINGS.PASSWORD_LOGIN:
             return False

--- a/aleph/core.py
+++ b/aleph/core.py
@@ -23,7 +23,7 @@ from aleph import __version__ as aleph_version
 from aleph.settings import SETTINGS
 from aleph.cache import Cache
 from aleph.oauth import configure_oauth
-from aleph.util import LoggingTransport
+from aleph.util import LoggingTransport, JSONProvider
 
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -70,6 +70,8 @@ def create_app(config=None):
     app = Flask("aleph")
     app.config.from_object(SETTINGS)
     app.config.update(config)
+
+    app.json = JSONProvider(app)
 
     if "postgres" not in SETTINGS.DATABASE_URI:
         raise RuntimeError("aleph database must be PostgreSQL!")

--- a/aleph/logic/expand.py
+++ b/aleph/logic/expand.py
@@ -90,12 +90,11 @@ def expand_proxies(proxies, authz, properties=None, limit=0):
             entities.update(_expand_adjacent(graph, proxy, prop))
 
         if count > 0:
-            item = {
-                "property": prop.name,
-                "count": count,
-                "entities": entities,
-            }
-            results.append(item)
+            results.append({ 
+                "property": prop.name, 
+                "count": count, 
+                "entities": entities, 
+            })
 
     # pprint(results)
     return results

--- a/aleph/tests/test_alerts_api.py
+++ b/aleph/tests/test_alerts_api.py
@@ -23,7 +23,7 @@ class AlertsApiTestCase(TestCase):
         data = {"query": "banana pumpkin"}
         jdata = json.dumps(data)
         res = self.client.post("/api/2/alerts", data=jdata, content_type=JSON)
-        assert res.status_code == 401, res
+        assert res.status_code == 403, res
         _, headers = self.login()
         res = self.client.post(
             "/api/2/alerts",

--- a/aleph/tests/test_alerts_api.py
+++ b/aleph/tests/test_alerts_api.py
@@ -12,7 +12,7 @@ class AlertsApiTestCase(TestCase):
 
     def test_index(self):
         res = self.client.get("/api/2/alerts")
-        assert res.status_code == 403, res
+        assert res.status_code == 401, res
         _, headers = self.login()
         res = self.client.get("/api/2/alerts", headers=headers)
         assert res.status_code == 200, res
@@ -23,7 +23,7 @@ class AlertsApiTestCase(TestCase):
         data = {"query": "banana pumpkin"}
         jdata = json.dumps(data)
         res = self.client.post("/api/2/alerts", data=jdata, content_type=JSON)
-        assert res.status_code == 403, res
+        assert res.status_code == 401, res
         _, headers = self.login()
         res = self.client.post(
             "/api/2/alerts",

--- a/aleph/tests/test_base_api.py
+++ b/aleph/tests/test_base_api.py
@@ -20,6 +20,16 @@ class BaseApiTestCase(TestCase):
         categories = res.json["categories"]
         assert "leak" in categories, categories
 
+    def test_sitemap(self):
+        collection = self.create_collection(label="Sitemap", foreign_id="test_sitemap")
+        res = self.client.get("/api/2/sitemap.xml")
+        assert res.status_code == 200, res
+        assert res.mimetype == "text/xml", res.headers
+        assert b"<loc>" not in res.data, res.data
+        self.grant_publish(collection)
+        res = self.client.get("/api/2/sitemap.xml")
+        assert b"<loc>" in res.data, res.data
+
     def test_statistics(self):
         cache.flush()
 

--- a/aleph/tests/test_bookmarks_api.py
+++ b/aleph/tests/test_bookmarks_api.py
@@ -19,7 +19,7 @@ class BookmarksApiTestCase(TestCase):
 
     def test_bookmarks_index_auth(self):
         res = self.client.get("/api/2/bookmarks")
-        assert res.status_code == 403, res
+        assert res.status_code == 401, res
 
         res = self.client.get("/api/2/bookmarks", headers=self.headers)
         assert res.status_code == 200, res

--- a/aleph/tests/test_collections_api.py
+++ b/aleph/tests/test_collections_api.py
@@ -71,14 +71,6 @@ class CollectionsApiTestCase(TestCase):
         assert res.json["total"] == 1, res.json
         assert res.json["results"][0]["label"] == "OpenContracting"
 
-    def test_sitemap(self):
-        res = self.client.get("/api/2/sitemap.xml")
-        assert res.status_code == 200, res
-        assert b"<loc>" not in res.data, res.data
-        self.grant_publish(self.col)
-        res = self.client.get("/api/2/sitemap.xml")
-        assert b"<loc>" in res.data, res.data
-
     def test_view(self):
         res = self.client.get("/api/2/collections/%s" % self.col.id)
         assert res.status_code == 403, res

--- a/aleph/tests/test_dashboard_api.py
+++ b/aleph/tests/test_dashboard_api.py
@@ -6,9 +6,11 @@ class DashboardApiTestCase(TestCase):
     def setUp(self):
         super(DashboardApiTestCase, self).setUp()
 
-    def test_index(self):
+    def test_anonymous(self):
         res = self.client.get("/api/2/status")
-        assert res.status_code == 403, res
+        assert res.status_code == 401, res
+    
+    def test_index(self):
         _, headers = self.login()
         res = self.client.get("/api/2/status", headers=headers)
         assert res.status_code == 200, res

--- a/aleph/tests/test_entities_api.py
+++ b/aleph/tests/test_entities_api.py
@@ -87,7 +87,7 @@ class EntitiesApiTestCase(TestCase):
         self.load_fixtures()
         url = "/api/2/search/export?filter:schemata=Thing&q=pakistan"
         res = self.client.post(url)
-        assert res.status_code == 403, res
+        assert res.status_code == 401, res
 
         _, headers = self.login(is_admin=True)
         res = self.client.post(url, headers=headers)

--- a/aleph/tests/test_export_api.py
+++ b/aleph/tests/test_export_api.py
@@ -23,9 +23,11 @@ class ExportApiTestCase(TestCase):
         self.export2.expires_at = datetime.utcnow() + timedelta(days=-1)
         complete_export(self.export2.id, temp_path, "experts.csv")
 
-    def test_exports_index(self):
+    def test_anonymous(self):
         res = self.client.get("/api/2/exports")
-        assert res.status_code == 403, res
+        assert res.status_code == 401, res
+
+    def test_exports_index(self):
         _, headers = self.login()
         res = self.client.get("/api/2/exports", headers=headers)
         assert res.status_code == 200, res

--- a/aleph/tests/test_groups_api.py
+++ b/aleph/tests/test_groups_api.py
@@ -12,9 +12,11 @@ class GroupsApiTestCase(TestCase):
         self.other = self.create_user(foreign_id="other")
         db.session.commit()
 
-    def test_index(self):
+    def test_anonymous(self):
         res = self.client.get("/api/2/groups")
-        assert res.status_code == 403, res
+        assert res.status_code == 401, res
+
+    def test_groups(self):
         _, headers = self.login(foreign_id="user_1")
         res = self.client.get("/api/2/groups", headers=headers)
         assert res.status_code == 200, res

--- a/aleph/tests/test_notifications_api.py
+++ b/aleph/tests/test_notifications_api.py
@@ -31,7 +31,7 @@ class NotificationsApiTestCase(TestCase):
 
     def test_anonymous(self):
         res = self.client.get("/api/2/notifications")
-        assert res.status_code == 403, res
+        assert res.status_code == 401, res
 
     def test_notifications(self):
         _, headers = self.login(foreign_id="admin")

--- a/aleph/tests/test_roles_api.py
+++ b/aleph/tests/test_roles_api.py
@@ -16,7 +16,7 @@ class RolesApiTestCase(TestCase):
 
     def test_suggest(self):
         res = self.client.get("/api/2/roles/_suggest")
-        assert res.status_code == 403, res
+        assert res.status_code == 401, res
         _, headers = self.login(is_admin=True)
         res = self.client.get("/api/2/roles/_suggest?prefix=user", headers=headers)
         assert res.status_code == 200, res

--- a/aleph/tests/test_view_util.py
+++ b/aleph/tests/test_view_util.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from lxml.html import document_fromstring
 from werkzeug.exceptions import BadRequest
@@ -12,7 +13,7 @@ class ViewUtilTest(TestCase):
     def setUp(self):
         super(ViewUtilTest, self).setUp()
 
-    def test_get_url_pat(self):
+    def test_get_url_path(self):
         self.assertEqual("/", get_url_path(""))
         self.assertEqual("/next", get_url_path("/next"))
         self.assertEqual("/next", get_url_path("https://aleph.ui:3000/next"))
@@ -35,6 +36,15 @@ class ViewUtilTest(TestCase):
         assert attr == "https://example.org/blockchain", html
         assert html.find(".//a").get("target") == "_blank", html
         assert "nofollow" in html.find(".//a").get("rel"), html
+
+    def test_jsonp_support(self):
+        callback = "callMe"
+        res = self.client.get("/api/2/metadata", query_string={
+            "callback": callback,
+        })
+        assert res.status_code == 200, res
+        assert res.mimetype == "application/javascript", res.headers
+        assert res.text.startswith(callback)
 
     def test_validate_returns_errors_for_paths(self):
         # given

--- a/aleph/util.py
+++ b/aleph/util.py
@@ -1,4 +1,5 @@
 import json
+from flask.json import provider
 import structlog
 from aleph.settings import SETTINGS
 from datetime import datetime, date
@@ -43,6 +44,14 @@ class JSONEncoder(json.JSONEncoder):
         if hasattr(obj, "to_dict"):
             return obj.to_dict()
         return json.JSONEncoder.default(self, obj)
+
+
+class JSONProvider(provider.JSONProvider):
+    def dumps(self, obj, **kwargs):
+        return json.dumps(obj, **kwargs, cls=JSONEncoder)
+
+    def loads(self, s, **kwargs):
+        return json.loads(s, **kwargs)
 
 
 class Stub(object):

--- a/aleph/views/alerts_api.py
+++ b/aleph/views/alerts_api.py
@@ -1,10 +1,10 @@
-from flask import Blueprint, request
+from flask import Blueprint, request, abort
 
 from aleph.core import db
 from aleph.model import Alert
 from aleph.search import DatabaseQueryResult
 from aleph.views.serializers import AlertSerializer
-from aleph.views.util import require, obj_or_404
+from aleph.views.util import obj_or_404
 from aleph.views.util import parse_request
 from aleph.views.context import tag_request
 
@@ -34,7 +34,8 @@ def index():
       tags:
         - Alert
     """
-    require(request.authz.logged_in)
+    if not request.authz.logged_in:
+        abort(401)
     query = Alert.by_role_id(request.authz.id)
     result = DatabaseQueryResult(request, query)
     return AlertSerializer.jsonify_result(result)
@@ -61,7 +62,8 @@ def create():
       tags:
         - Alert
     """
-    require(request.authz.session_write)
+    if not request.authz.session_write:
+        abort(403, description="Cannot write cache")
     data = parse_request("AlertCreate")
     alert = Alert.create(data, request.authz.id)
     db.session.commit()
@@ -94,7 +96,8 @@ def view(alert_id):
       tags:
       - Alert
     """
-    require(request.authz.logged_in)
+    if not request.authz.logged_in:
+        abort(401)
     alert = obj_or_404(Alert.by_id(alert_id, role_id=request.authz.id))
     return AlertSerializer.jsonify(alert)
 
@@ -120,7 +123,8 @@ def delete(alert_id):
       tags:
       - Alert
     """
-    require(request.authz.session_write)
+    if not request.authz.session_write:
+        abort(403, description="Cannot write cache")
     alert = obj_or_404(Alert.by_id(alert_id, role_id=request.authz.id))
     alert.delete()
     db.session.commit()

--- a/aleph/views/alerts_api.py
+++ b/aleph/views/alerts_api.py
@@ -68,7 +68,7 @@ def create():
     alert = Alert.create(data, request.authz.id)
     db.session.commit()
     tag_request(alert_id=alert.id)
-    return AlertSerializer.jsonify(alert)
+    return AlertSerializer().serialize(alert)
 
 
 @blueprint.route("/api/2/alerts/<int:alert_id>", methods=["GET"])
@@ -99,7 +99,7 @@ def view(alert_id):
     if not request.authz.logged_in:
         abort(401)
     alert = obj_or_404(Alert.by_id(alert_id, role_id=request.authz.id))
-    return AlertSerializer.jsonify(alert)
+    return AlertSerializer().serialize(alert)
 
 
 @blueprint.route("/api/2/alerts/<int:alert_id>", methods=["DELETE"])

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -1,7 +1,7 @@
 import logging
 from babel import Locale
 from functools import lru_cache
-from flask import Blueprint, request, current_app
+from flask import Blueprint, Response, request, current_app, render_template
 from flask_babel import gettext, get_locale
 from elasticsearch import TransportError
 from followthemoney import model
@@ -19,7 +19,6 @@ from aleph.logic.pages import load_pages
 from aleph.logic.util import collection_url
 from aleph.validation import get_openapi_spec
 from aleph.views.context import enable_cache, NotModified
-from aleph.views.util import render_xml
 
 blueprint = Blueprint("base_api", __name__)
 log = logging.getLogger(__name__)
@@ -175,7 +174,9 @@ def sitemap():
         updated_at = max(SETTINGS.SITEMAP_FLOOR, updated_at)
         url = collection_url(collection.id)
         collections.append({"url": url, "updated_at": updated_at})
-    return render_xml("sitemap.xml", collections=collections)
+
+    data = render_template("sitemap.xml", collections=collections)
+    return Response(data, mimetype="text/xml")
 
 
 @blueprint.route("/healthz")

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -236,8 +236,10 @@ def handle_not_found_error(err):
 @blueprint.app_errorhandler(500)
 def handle_server_error(err):
     log.exception("%s: %s", type(err).__name__, err)
-    msg = gettext("Internal server error.")
-    return {"status": "error", "message": msg}, 500
+    return {
+        "status": "error", 
+        "message": str(err) or gettext("Internal server error.")
+    }, 500
 
 
 @blueprint.app_errorhandler(InvalidData)

--- a/aleph/views/bookmarks_api.py
+++ b/aleph/views/bookmarks_api.py
@@ -96,8 +96,7 @@ def create():
         db.session.add(bookmark)
         db.session.commit()
 
-    serializer = BookmarkSerializer()
-    return serializer.serialize(bookmark), 201
+    return BookmarkSerializer().serialize(bookmark), 201
 
 
 @blueprint.route("/api/2/bookmarks/<entity_id>", methods=["DELETE"])

--- a/aleph/views/collections_api.py
+++ b/aleph/views/collections_api.py
@@ -106,7 +106,7 @@ def view(collection_id):
     if get_flag("refresh", False):
         update_collection_stats(collection_id, ["schema"])
     data.update(get_deep_collection(cobj))
-    return CollectionSerializer.jsonify(data)
+    return CollectionSerializer().serialize(data)
 
 
 @blueprint.route("/<int:collection_id>", methods=["POST", "PUT"])
@@ -146,7 +146,7 @@ def update(collection_id):
     collection.update(data, request.authz)
     db.session.commit()
     data = update_collection(collection, sync=sync)
-    return CollectionSerializer.jsonify(data)
+    return CollectionSerializer().serialize(data)
 
 
 @blueprint.route("/<int:collection_id>/reingest", methods=["POST", "PUT"])

--- a/aleph/views/entities_api.py
+++ b/aleph/views/entities_api.py
@@ -1,5 +1,5 @@
 import logging
-from flask import Blueprint, request
+from flask import Blueprint, request, abort
 from flask_babel import gettext
 from werkzeug.exceptions import NotFound
 from followthemoney import model
@@ -19,8 +19,8 @@ from aleph.model.entityset import EntitySet, Judgement
 from aleph.model.bookmark import Bookmark
 from aleph.index.util import MAX_PAGE
 from aleph.views.util import get_index_entity, get_db_collection
-from aleph.views.util import jsonify, parse_request, get_flag
-from aleph.views.util import require, get_nested_collection, get_session_id
+from aleph.views.util import parse_request, get_flag
+from aleph.views.util import  get_nested_collection, get_session_id
 from aleph.views.context import enable_cache, tag_request
 from aleph.views.serializers import EntitySerializer, EntitySetSerializer
 from aleph.views.serializers import SimilarSerializer
@@ -132,7 +132,8 @@ def index():
       tags:
       - Entity
     """
-    require(request.authz.can_browse_anonymous)
+    if not request.authz.can_browse_anonymous:
+        abort(403, description="Anonymous browsing disabled")
     # enable_cache(vary_user=True)
     parser = SearchQueryParser(request.values, request.authz)
     result = EntitiesQuery.handle(request, parser=parser)
@@ -163,7 +164,8 @@ def export():
       tags:
       - Entity
     """
-    require(request.authz.logged_in)
+    if not request.authz.logged_in:
+        abort(401)
     parser = SearchQueryParser(request.args, request.authz)
     tag_request(query=parser.text, prefix=parser.prefix)
     query = EntitiesQuery(parser)
@@ -214,7 +216,8 @@ def match():
       tags:
       - Entity
     """
-    require(request.authz.can_browse_anonymous)
+    if not request.authz.can_browse_anonymous:
+        abort(403, description="Anonymous browsing disabled")
     entity = parse_request("EntityUpdate")
     entity = model.get_proxy(entity, cleaned=False)
     tag_request(schema=entity.schema.name, caption=entity.caption)
@@ -415,7 +418,7 @@ def tags(entity_id):
     entity = get_index_entity(entity_id, request.authz.READ)
     tag_request(collection_id=entity.get("collection_id"))
     results = entity_tags(model.get_proxy(entity), request.authz)
-    return jsonify({"status": "ok", "total": len(results), "results": results})
+    return {"status": "ok", "total": len(results), "results": results}
 
 
 @blueprint.route("/api/2/entities/<entity_id>", methods=["POST", "PUT"])
@@ -459,7 +462,8 @@ def update(entity_id):
     data = parse_request("EntityUpdate")
     try:
         entity = get_index_entity(entity_id, request.authz.WRITE)
-        require(check_write_entity(entity, request.authz))
+        if not check_write_entity(entity, request.authz):
+            abort(403, description="Cannot write entity")
         collection = get_db_collection(entity.get("collection_id"), request.authz.WRITE)
     except NotFound:
         collection = get_nested_collection(data, request.authz.WRITE)
@@ -563,12 +567,11 @@ def expand(entity_id):
         authz=request.authz,
         limit=parser.limit,
     )
-    result = {
+    return {
         "status": "ok",
         "total": sum(result["count"] for result in results),
         "results": results,
     }
-    return jsonify(result)
 
 
 @blueprint.route("/api/2/entities/<entity_id>/entitysets", methods=["GET"])

--- a/aleph/views/entities_api.py
+++ b/aleph/views/entities_api.py
@@ -276,7 +276,7 @@ def create():
     db.session.commit()
     tag_request(entity_id=entity_id, collection_id=collection.id)
     entity = get_index_entity(entity_id, request.authz.READ)
-    return EntitySerializer.jsonify(entity)
+    return EntitySerializer().serialize(entity)
 
 
 @blueprint.route("/api/2/documents/<entity_id>", methods=["GET"])
@@ -324,7 +324,7 @@ def view(entity_id):
         ).first()
         entity["bookmarked"] = True if bookmark else False
 
-    return EntitySerializer.jsonify(entity)
+    return EntitySerializer().serialize(entity)
 
 
 @blueprint.route("/api/2/entities/<entity_id>/similar", methods=["GET"])

--- a/aleph/views/entitysets_api.py
+++ b/aleph/views/entitysets_api.py
@@ -108,7 +108,7 @@ def create():
     collection = get_nested_collection(data, request.authz.WRITE)
     entityset = create_entityset(collection, data, request.authz)
     db.session.commit()
-    return EntitySetSerializer.jsonify(entityset)
+    return EntitySetSerializer().serialize(entityset)
 
 
 @blueprint.route("/api/2/entitysets/<entityset_id>", methods=["GET"])
@@ -140,7 +140,7 @@ def view(entityset_id):
         return redirect(url_for("profiles_api.view", profile_id=entityset_id))
     data = entityset.to_dict()
     data["shallow"] = False
-    return EntitySetSerializer.jsonify(data)
+    return EntitySetSerializer().serialize(data)
 
 
 @blueprint.route("/api/2/entitysets/<entityset_id>", methods=["POST", "PUT"])
@@ -447,4 +447,4 @@ def item_update(entityset_id):
             "collection_id": entity["collection_id"],
             "judgement": Judgement.NO_JUDGEMENT,
         }
-    return EntitySetItemSerializer.jsonify(item)
+    return EntitySetItemSerializer().serialize(item)

--- a/aleph/views/exports_api.py
+++ b/aleph/views/exports_api.py
@@ -1,11 +1,10 @@
 import logging
 
-from flask import Blueprint, request
+from flask import Blueprint, request, abort
 
 from aleph.model import Export
 from aleph.search import DatabaseQueryResult
 from aleph.views.serializers import ExportSerializer
-from aleph.views.util import require
 
 log = logging.getLogger(__name__)
 blueprint = Blueprint("exports_api", __name__)
@@ -34,7 +33,8 @@ def index():
       tags:
         - Export
     """
-    require(request.authz.logged_in)
+    if not request.authz.logged_in:
+        abort(401)
     query = Export.by_role_id(request.authz.id)
     result = DatabaseQueryResult(request, query)
     return ExportSerializer.jsonify_result(result)

--- a/aleph/views/groups_api.py
+++ b/aleph/views/groups_api.py
@@ -1,9 +1,8 @@
 import logging
-from flask import Blueprint, request
+from flask import Blueprint, request, abort
 
 from aleph.model import Role
 from aleph.views.serializers import RoleSerializer
-from aleph.views.util import require, jsonify
 
 blueprint = Blueprint("groups_api", __name__)
 log = logging.getLogger(__name__)
@@ -35,8 +34,7 @@ def index():
       tags:
       - Role
     """
-    require(request.authz.logged_in)
+    if not request.authz.logged_in:
+        abort(401)
     q = Role.all_groups(request.authz)
-    return jsonify(
-        {"total": q.count(), "results": RoleSerializer().serialize_many(q.all())}
-    )
+    return {"total": q.count(), "results": RoleSerializer().serialize_many(q.all())}

--- a/aleph/views/groups_api.py
+++ b/aleph/views/groups_api.py
@@ -37,4 +37,7 @@ def index():
     if not request.authz.logged_in:
         abort(401)
     q = Role.all_groups(request.authz)
-    return {"total": q.count(), "results": RoleSerializer().serialize_many(q.all())}
+    return {
+        "total": q.count(), 
+        "results": RoleSerializer().serialize_many(q.all())
+    }

--- a/aleph/views/mappings_api.py
+++ b/aleph/views/mappings_api.py
@@ -1,7 +1,7 @@
 import logging
 from banal import first
 from followthemoney import model
-from flask import Blueprint, request
+from flask import Blueprint, request, abort
 from werkzeug.exceptions import BadRequest
 
 from aleph.core import db
@@ -10,7 +10,7 @@ from aleph.search import QueryParser, DatabaseQueryResult
 from aleph.queues import queue_task, OP_FLUSH_MAPPING, OP_LOAD_MAPPING
 from aleph.views.serializers import MappingSerializer
 from aleph.views.util import get_db_collection, get_entityset, parse_request, get_nested
-from aleph.views.util import get_index_entity, get_session_id, obj_or_404, require
+from aleph.views.util import get_index_entity, get_session_id, obj_or_404
 
 
 blueprint = Blueprint("mappings_api", __name__)
@@ -76,7 +76,8 @@ def index(collection_id):
         - Collection
         - Mapping
     """
-    require(request.authz.can_browse_anonymous)
+    if not request.authz.can_browse_anonymous:
+        abort(403, description="Anonymous browsing disabled")
     collection = get_db_collection(collection_id)
     parser = QueryParser(request.args, request.authz)
     table_id = first(parser.filters.get("table"))

--- a/aleph/views/mappings_api.py
+++ b/aleph/views/mappings_api.py
@@ -127,7 +127,7 @@ def create(collection_id):
         entityset_id=get_entityset_id(data),
     )
     db.session.commit()
-    return MappingSerializer.jsonify(mapping)
+    return MappingSerializer().serialize(mapping)
 
 
 @blueprint.route("/<int:collection_id>/mappings/<int:mapping_id>", methods=["GET"])
@@ -166,7 +166,7 @@ def view(collection_id, mapping_id):
     """
     get_db_collection(collection_id, request.authz.WRITE)
     mapping = obj_or_404(Mapping.by_id(mapping_id))
-    return MappingSerializer.jsonify(mapping)
+    return MappingSerializer().serialize(mapping)
 
 
 @blueprint.route(
@@ -220,7 +220,7 @@ def update(collection_id, mapping_id):
         entityset_id=get_entityset_id(data),
     )
     db.session.commit()
-    return MappingSerializer.jsonify(mapping)
+    return MappingSerializer().serialize(mapping)
 
 
 @blueprint.route(
@@ -265,7 +265,7 @@ def trigger(collection_id, mapping_id):
     job_id = get_session_id()
     queue_task(collection, OP_LOAD_MAPPING, job_id=job_id, mapping_id=mapping.id)
     mapping = obj_or_404(Mapping.by_id(mapping_id))
-    return MappingSerializer.jsonify(mapping, status=202)
+    return MappingSerializer().serialize(mapping), 202
 
 
 @blueprint.route(

--- a/aleph/views/notifications_api.py
+++ b/aleph/views/notifications_api.py
@@ -1,9 +1,7 @@
-from flask import Blueprint, request
+from flask import Blueprint, request, abort
 
 from aleph.search import NotificationsQuery
 from aleph.views.serializers import NotificationSerializer
-from aleph.views.util import require
-
 
 blueprint = Blueprint("notifications_api", __name__)
 
@@ -32,6 +30,7 @@ def index():
       tags:
       - Notification
     """
-    require(request.authz.logged_in)
+    if not request.authz.logged_in:
+        abort(401)
     result = NotificationsQuery.handle(request)
     return NotificationSerializer.jsonify_result(result)

--- a/aleph/views/permissions_api.py
+++ b/aleph/views/permissions_api.py
@@ -8,7 +8,7 @@ from aleph.logic.roles import check_visible
 from aleph.logic.permissions import update_permission
 from aleph.logic.collections import update_collection
 from aleph.views.serializers import PermissionSerializer
-from aleph.views.util import get_db_collection, jsonify, parse_request
+from aleph.views.util import get_db_collection, parse_request
 
 blueprint = Blueprint("permissions_api", __name__)
 
@@ -76,7 +76,7 @@ def index(collection_id):
         )
 
     permissions = PermissionSerializer().serialize_many(permissions)
-    return jsonify({"total": len(permissions), "results": permissions})
+    return {"total": len(permissions), "results": permissions}
 
 
 @blueprint.route("/<int:collection_id>/permissions", methods=["POST", "PUT"])

--- a/aleph/views/profiles_api.py
+++ b/aleph/views/profiles_api.py
@@ -1,5 +1,5 @@
 import logging
-from flask import Blueprint, request
+from flask import Blueprint, request, abort
 from followthemoney import model
 from followthemoney.compare import compare
 
@@ -11,9 +11,8 @@ from aleph.queues import queue_task, OP_UPDATE_ENTITY
 from aleph.search import MatchQuery, QueryParser
 from aleph.views.serializers import ProfileSerializer, SimilarSerializer
 from aleph.views.context import tag_request
-from aleph.views.util import obj_or_404, jsonify, parse_request, get_session_id
+from aleph.views.util import obj_or_404, parse_request, get_session_id
 from aleph.views.util import get_index_entity, get_db_collection
-from aleph.views.util import require
 
 blueprint = Blueprint("profiles_api", __name__)
 log = logging.getLogger(__name__)
@@ -44,7 +43,8 @@ def view(profile_id):
       - Profile
     """
     profile = obj_or_404(get_profile(profile_id, authz=request.authz))
-    require(request.authz.can(profile.get("collection_id"), request.authz.READ))
+    if not request.authz.can(profile.get("collection_id"), request.authz.READ):
+        abort(403, description="No read access on collection")
     return ProfileSerializer.jsonify(profile)
 
 
@@ -80,10 +80,11 @@ def tags(profile_id):
       - Profile
     """
     profile = obj_or_404(get_profile(profile_id, authz=request.authz))
-    require(request.authz.can(profile.get("collection_id"), request.authz.READ))
+    if not request.authz.can(profile.get("collection_id"), request.authz.READ):
+        abort(403, description="No read access on collection")
     tag_request(collection_id=profile.get("collection_id"))
     results = entity_tags(profile["merged"], request.authz)
-    return jsonify({"status": "ok", "total": len(results), "results": results})
+    return {"status": "ok", "total": len(results), "results": results}
 
 
 @blueprint.route("/api/2/profiles/<profile_id>/similar", methods=["GET"])
@@ -124,7 +125,8 @@ def similar(profile_id):
     """
     # enable_cache()
     profile = obj_or_404(get_profile(profile_id, authz=request.authz))
-    require(request.authz.can(profile.get("collection_id"), request.authz.READ))
+    if not request.authz.can(profile.get("collection_id"), request.authz.READ):
+        abort(403, description="No read access on collection")
     tag_request(collection_id=profile.get("collection_id"))
     exclude = [item["entity_id"] for item in profile["items"]]
     result = MatchQuery.handle(request, entity=profile["merged"], exclude=exclude)
@@ -184,7 +186,8 @@ def expand(profile_id):
       - Profile
     """
     profile = obj_or_404(get_profile(profile_id, authz=request.authz))
-    require(request.authz.can(profile.get("collection_id"), request.authz.READ))
+    if not request.authz.can(profile.get("collection_id"), request.authz.READ):
+        abort(403, description="No read access on collection")
     tag_request(collection_id=profile.get("collection_id"))
     parser = QueryParser(
         request.args, request.authz, max_limit=SETTINGS.MAX_EXPAND_ENTITIES
@@ -196,12 +199,11 @@ def expand(profile_id):
         authz=request.authz,
         limit=parser.limit,
     )
-    result = {
+    return {
         "status": "ok",
         "total": sum(result["count"] for result in results),
         "results": results,
     }
-    return jsonify(result)
 
 
 @blueprint.route("/api/2/profiles/_pairwise", methods=["POST"])
@@ -252,4 +254,4 @@ def pairwise():
     job_id = get_session_id()
     queue_task(collection, OP_UPDATE_ENTITY, job_id=job_id, entity_id=entity.get("id"))
     profile_id = profile.id if profile is not None else None
-    return jsonify({"status": "ok", "profile_id": profile_id}, status=200)
+    return {"status": "ok", "profile_id": profile_id}

--- a/aleph/views/profiles_api.py
+++ b/aleph/views/profiles_api.py
@@ -45,7 +45,7 @@ def view(profile_id):
     profile = obj_or_404(get_profile(profile_id, authz=request.authz))
     if not request.authz.can(profile.get("collection_id"), request.authz.READ):
         abort(403, description="No read access on collection")
-    return ProfileSerializer.jsonify(profile)
+    return ProfileSerializer().serialize(profile)
 
 
 @blueprint.route("/api/2/profiles/<profile_id>/tags", methods=["GET"])

--- a/aleph/views/roles_api.py
+++ b/aleph/views/roles_api.py
@@ -147,7 +147,7 @@ def create():
     # Let the serializer return more info about this user
     request.authz = Authz.from_role(role)
     tag_request(role_id=role.id)
-    return RoleSerializer.jsonify(role, status=201)
+    return RoleSerializer().serialize(role), 201
 
 
 @blueprint.route("/api/2/roles/<int:id>", methods=["GET"])
@@ -183,7 +183,7 @@ def view(id):
     data = role.to_dict()
     if request.authz.can_write_role(role.id):
         data.update(get_deep_role(role))
-    return RoleSerializer.jsonify(data)
+    return RoleSerializer().serialize(data)
 
 
 @blueprint.route("/api/2/roles/<int:id>", methods=["POST", "PUT"])
@@ -234,4 +234,4 @@ def update(id):
     db.session.add(role)
     db.session.commit()
     update_role(role)
-    return RoleSerializer.jsonify(role)
+    return RoleSerializer().serialize(role)

--- a/aleph/views/status_api.py
+++ b/aleph/views/status_api.py
@@ -1,10 +1,9 @@
 import logging
-from flask import Blueprint, request
+from flask import Blueprint, request, abort
 
 from aleph.model import Collection
 from aleph.queues import get_active_dataset_status, get_dataset_collection_id
 from aleph.views.serializers import CollectionSerializer
-from aleph.views.util import jsonify, require
 
 log = logging.getLogger(__name__)
 blueprint = Blueprint("status_api", __name__)
@@ -28,7 +27,8 @@ def status():
       tags:
       - System
     """
-    require(request.authz.logged_in)
+    if not request.authz.logged_in:
+        abort(401)
     request.rate_limit = None
     status = get_active_dataset_status()
     datasets = status.pop("datasets", {})
@@ -46,4 +46,4 @@ def status():
         if collection is not None:
             status["collection"] = serializer.serialize(collection.to_dict())
         results.append(status)
-    return jsonify({"results": results, "total": len(results)})
+    return {"results": results, "total": len(results)}

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -1,6 +1,5 @@
-import string
 import logging
-from banal import as_bool, ensure_dict, is_mapping, is_listish
+from banal import as_bool, ensure_dict
 from normality import stringify
 from flask import request, jsonify
 from flask_babel import gettext
@@ -16,8 +15,6 @@ from aleph.index.entities import get_entity as _get_index_entity
 from aleph.index.collections import get_collection as _get_index_collection
 
 log = logging.getLogger(__name__)
-CALLBACK_VALID = string.ascii_letters + string.digits + "_"
-
 
 
 def obj_or_404(obj):
@@ -73,24 +70,6 @@ def validate(data, schema):
     raise BadRequest(response=resp)
 
 
-def clean_object(data):
-    """Remove unset values from the response to save some bandwidth."""
-    if is_mapping(data):
-        out = {}
-        for k, v in data.items():
-            v = clean_object(v)
-            if v is not None:
-                out[k] = v
-        return out if len(out) else None
-    elif is_listish(data):
-        data = [clean_object(d) for d in data]
-        data = [d for d in data if d is not None]
-        return data if len(data) else None
-    elif isinstance(data, str):
-        return data if len(data) else None
-    return data
-
-
 def is_permitted_or_403(*predicates):
     """Check if a user is allowed a set of predicates."""
     for predicate in predicates:
@@ -137,3 +116,4 @@ def get_url_path(url):
         return url_parse(url).replace(netloc="", scheme="").to_url() or "/"
     except Exception:
         return "/"
+

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -4,7 +4,7 @@ import string
 import logging
 from banal import as_bool, ensure_dict, is_mapping, is_listish
 from normality import stringify
-from flask import Response, request, render_template
+from flask import Response, request, render_template, jsonify
 from flask_babel import gettext
 from werkzeug.urls import url_parse
 from werkzeug.exceptions import Forbidden
@@ -139,19 +139,6 @@ def get_url_path(url):
         return url_parse(url).replace(netloc="", scheme="").to_url() or "/"
     except Exception:
         return "/"
-
-
-def jsonify(obj, status=200, headers=None, encoder=JSONEncoder):
-    """Serialize to JSON and also dump from the given schema."""
-    data = encoder().encode(obj)
-    mimetype = "application/json"
-    if "callback" in request.args:
-        cb = request.args.get("callback")
-        cb = "".join((c for c in cb if c in CALLBACK_VALID))
-        data = "%s && %s(%s)" % (cb, cb, data)
-        # mime cf. https://stackoverflow.com/questions/24528211/
-        mimetype = "application/javascript"
-    return Response(data, headers=headers, status=status, mimetype=mimetype)
 
 
 def stream_ijson(iterable, encoder=JSONEncoder):

--- a/aleph/views/xref_api.py
+++ b/aleph/views/xref_api.py
@@ -7,12 +7,7 @@ from aleph.logic.profiles import pairwise_judgements
 from aleph.logic.export import create_export
 from aleph.views.serializers import XrefSerializer
 from aleph.queues import queue_task, OP_XREF, OP_EXPORT_XREF
-from aleph.views.util import (
-    get_db_collection,
-    get_index_collection,
-    get_session_id,
-    jsonify,
-)
+from aleph.views.util import get_db_collection, get_index_collection, get_session_id
 
 blueprint = Blueprint("xref_api", __name__)
 log = logging.getLogger(__name__)
@@ -94,7 +89,7 @@ def generate(collection_id):
     """
     collection = get_db_collection(collection_id, request.authz.WRITE)
     queue_task(collection, OP_XREF)
-    return jsonify({"status": "accepted"}, status=202)
+    return {"status": "accepted"}, 202
 
 
 @blueprint.route("/api/2/collections/<int:collection_id>/xref.xlsx", methods=["POST"])

--- a/contrib/play/tripler.py
+++ b/contrib/play/tripler.py
@@ -68,8 +68,6 @@ def export_collection(collection):
     ctx = URIRef("%s/collections/%s" % (HOST, collection["id"]))
     g.add((ctx, RDFS.label, Literal(collection["label"]), domain))
     g.add((ctx, ALEPH.foreignId, Literal(collection["foreign_id"]), domain))
-    # print g.serialize(format='nquads')
-    # pprint(collection)
 
     q = {
         "query": {"term": {"collection_id": collection["id"]}},


### PR DESCRIPTION
This PR refactors some of the view logic to more closely follow the flask documentation / defaults.

It looks like a lot, but not much is going on:

- [`require`](https://github.com/alephdata/aleph/blob/eac98ec386944a82183ed5fd3816958e4ed5da17/aleph/views/util.py#L25) was dropped in favor of [`abort`](https://flask.palletsprojects.com/en/2.3.x/api/#flask.abort)
- Some HTTP 403 codes were changed to HTTP 403 where that made sense.
- [`jsonify`](https://github.com/alephdata/aleph/blob/eac98ec386944a82183ed5fd3816958e4ed5da17/aleph/views/util.py#L144) and related calls were dropped in favor of a [`JSONProvider`](https://flask.palletsprojects.com/en/2.2.x/api/#flask.json.provider.JSONProvider)
- A test was added for JSONP functionality
- Code was localized from general utils to local files where possible
- Unused code was removed

This was done with the intention of reducing coupling, side-effects, and making the code more understandable for newcomers.