### PR TITLE
Remove query_string_query function, remove fields from highlight query

### DIFF
--- a/aleph/index/util.py
+++ b/aleph/index/util.py
@@ -116,19 +116,6 @@ def none_query(query=None):
     return query
 
 
-def query_string_query(field, query):
-    """Default config for querying the entity text."""
-    return {
-        "query_string": {
-            "query": query,
-            "lenient": True,
-            "fields": ensure_list(field),
-            "default_operator": "AND",
-            "minimum_should_match": "66%",
-        }
-    }
-
-
 def field_filter_query(field, values):
     """Need to define work-around for full-text fields."""
     values = ensure_list(values)

--- a/aleph/logic/alerts.py
+++ b/aleph/logic/alerts.py
@@ -6,7 +6,7 @@ from aleph.authz import Authz
 from aleph.core import db, es
 from aleph.model import Alert, Events, Entity
 from aleph.index.indexes import entities_read_index
-from aleph.index.util import unpack_result, authz_query, query_string_query
+from aleph.index.util import unpack_result, authz_query
 from aleph.logic.notifications import publish
 
 log = logging.getLogger(__name__)
@@ -74,7 +74,15 @@ def alert_query(alert, authz):
         "_source": {"includes": ["collection_id"]},
         "query": {
             "bool": {
-                "should": [query_string_query("text", alert.query)],
+                "should": [{
+                    "query_string": {
+                        "query": alert.query,
+                        "lenient": True,
+                        "fields": ["text"],
+                        "default_operator": "AND",
+                        "minimum_should_match": "66%",
+                    }
+                }],
                 "filter": filters,
                 "minimum_should_match": 1,
             }

--- a/aleph/search/query.py
+++ b/aleph/search/query.py
@@ -10,7 +10,6 @@ from aleph.index.util import (
     field_filter_query,
     DATE_FORMAT,
     range_filter_query,
-    query_string_query,
     filter_text,
 )
 from aleph.search.result import SearchQueryResult
@@ -47,7 +46,15 @@ class Query(object):
     def get_text_query(self):
         query = []
         if self.parser.text:
-            qs = query_string_query(self.TEXT_FIELDS, self.parser.text)
+            qs = {
+                "query_string": {
+                    "query": self.parser.text,
+                    "lenient": True,
+                    "fields": self.TEXT_FIELDS,
+                    "default_operator": "AND",
+                    "minimum_should_match": "66%",
+                }
+            }
             query.append(qs)
         if self.parser.prefix:
             query.append(
@@ -219,12 +226,18 @@ class Query(object):
     def get_highlight(self):
         if not self.parser.highlight:
             return {}
-        query = query_string_query(self.HIGHLIGHT_FIELD, self.parser.highlight_text)
         return {
             "encoder": "html",
             "fields": {
                 self.HIGHLIGHT_FIELD: {
-                    "highlight_query": query,
+                    "highlight_query": {
+                        "query_string": {
+                            "query": self.parser.highlight_text,
+                            "lenient": True,
+                            "default_operator": "AND",
+                            "minimum_should_match": "66%",
+                        }
+                    },
                     "require_field_match": False,
                     "number_of_fragments": self.parser.highlight_count,
                     "fragment_size": self.parser.highlight_length,


### PR DESCRIPTION
As passing the `fields` parameter to the ES highlight query breaks highlights https://github.com/alephdata/aleph/issues/3275, i propose removing this `query_string_query` function completely, as these dictionaries differ a bit, only occur in 3 locations, and just creating the query_string dictionaries on the spot is more understandable.