### PR TITLE
#2998 autoscaling/v2 apiVersion for HorizontalPodAutoscaler

### DIFF
--- a/helm/charts/aleph/templates/api.yaml
+++ b/helm/charts/aleph/templates/api.yaml
@@ -133,7 +133,7 @@ spec:
         - name: home-volume
           emptyDir: {}
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Values.global.namingPrefix }}-api

--- a/helm/charts/aleph/templates/ingest-file.yaml
+++ b/helm/charts/aleph/templates/ingest-file.yaml
@@ -90,7 +90,7 @@ spec:
           emptyDir:
             medium: Memory
 ---
-apiVersion: autoscaling/v2beta1
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ .Values.global.namingPrefix }}-ingest-file

--- a/helm/charts/aleph/values.yaml
+++ b/helm/charts/aleph/values.yaml
@@ -85,7 +85,9 @@ api:
       - type: Resource
         resource:
           name: cpu
-          targetAverageUtilization: 60
+          target:
+            type: Utilization
+            averageUtilization: 60
 
 # Aleph Upgrade Job - templates/aleph-upgrade-job.yaml
 upgrade:
@@ -140,7 +142,9 @@ ingestfile:
       - type: Resource
         resource:
           name: cpu
-          targetAverageUtilization: 100
+          target:
+            averageUtilization: 100
+            type: Utilization
 
 # Aleph UI - templates/ui.yaml
 ui:


### PR DESCRIPTION
Updates:
* the apiVersion used for HorizontalPodAutoscaler from `autoscaling/v2beta1` to `autoscaling/v2`
* default Helm values configuration for API and Ingest-file HPAs

