### PR TITLE
Add note to signup guide

### DIFF
--- a/docs/src/pages/users/faq/account/index.mdx
+++ b/docs/src/pages/users/faq/account/index.mdx
@@ -5,6 +5,10 @@ title: Account & Recovery
 
 # Account creation and password recovery
 
+<Callout>
+  This page answers common questions about accounts on [aleph.occrp.org](https://aleph.occrp.org), an Aleph instance operated by the OCCRP. If your organization runs its own in-house Aleph instance, the information on this page may not apply.
+</Callout>
+
 ## When I enter the code from my 2FA app to log in to Aleph, it says it is incorrect. I tried several times and it did not work. What should I do?
 
 If you are receiving an error message after putting in your one time password, this issue is most likely caused by the current time on your phone or laptop. Follow the troubleshooting steps below:

--- a/docs/src/pages/users/getting-started/account/index.mdx
+++ b/docs/src/pages/users/getting-started/account/index.mdx
@@ -9,6 +9,10 @@ title: Manage your account
 
 <p class="lead">On this page, you will find instructions on how to create an account for OCCRP Aleph and how to reset your password.</p>
 
+<Callout>
+  This page describes how to create an account on [aleph.occrp.org](https://aleph.occrp.org), an Aleph instance operated by the OCCRP. If your organization runs its own in-house Aleph instance, the process might be different.
+</Callout>
+
 {/*TODO Add warning: Sign up / sign in may be different for in-house instances*/}
 
 <VideoTutorial youtubeId="asIh-pMApts" />


### PR DESCRIPTION
I have added notes at the top of the following two pages as they contain information specific to the Aleph instances operated by OCCRP. All other documentation pages should be generic.

<img width="784" alt="Screen Shot 2023-10-03 at 11 02 24" src="https://github.com/alephdata/aleph/assets/1512805/e011236f-1a22-41ba-9860-72824bf78679">

<img width="769" alt="Screen Shot 2023-10-04 at 10 36 38" src="https://github.com/alephdata/aleph/assets/1512805/4aa238d3-fcdb-4d9b-8802-280a0ed30fe6">
