### PR TITLE
Limit concurrency of the deploy job only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,10 +8,6 @@ on:
       - "**"
   workflow_dispatch: {}
 
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -33,6 +29,10 @@ jobs:
     if: ${{ github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch' }}
     needs: build
     runs-on: ubuntu-latest
+
+    concurrency:
+      group: pages
+      cancel-in-progress: true
 
     permissions:
       pages: write


### PR DESCRIPTION
We actually want individual docs PRs to trigger the build job. And we don’t care if there are multiple build jobs running at the same time. But we want there to be only one deploy job at the same time (in addition to the deploy job only being triggered manually or by pushes to the main branch).