### PR TITLE
Remove urllib3 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,6 @@ python-frontmatter==1.0.0
 pyjwt >= 2.0.1, < 2.9.0
 cryptography >= 36.0.0, < 42.0.0
 requests[security] >= 2.25.1, < 3.0.0
-urllib3==1.26.14
 tabulate==0.9.0
 zipstream-new==1.1.8
 sentry-sdk[flask]==1.30.0


### PR DESCRIPTION
I’m not really sure if we still need this as a direct dependency. Looking at the git history, it might have been added (years ago) in order to fix an incorrect dependency constraint in a dependency (probably the Elasticsearch Python client).

Removing it doesn’t seem to cause any problems and the latest version of `urllib3<2` gets installed as a transitive dependency (because it is required by `elasticsearch`.