### PR TITLE
Add document pages to main search, show them with documents

### DIFF
--- a/ui/src/components/EntitySearch/EntitySearchResults.jsx
+++ b/ui/src/components/EntitySearch/EntitySearchResults.jsx
@@ -24,7 +24,7 @@ class EntitySearchResults extends Component {
     );
   }
 
-  renderHeaderCell = (field) => {
+  renderHeaderCell(field) {
     const { query } = this.props;
     const { field: sortedField, direction } = query.getSort();
     const fieldName = field.isProperty
@@ -46,6 +46,25 @@ class EntitySearchResults extends Component {
       </SortableTH>
     );
   };
+
+  /**
+   * Group Page entities into their respective "Pages" entity
+   */ 
+  groupPageResults(entities) {
+    const pages = entities
+      .filter(entity => entity.schema.name === 'Page')
+
+    return entities
+      // Return only non-page entities
+      .filter(entity => entity.schema.name !== "Page")
+      // Embed pages in `Pages` entities
+      .map(entity => {
+        if(entity.schema.name === 'Pages') {
+          entity.pages = pages.filter(page => page.getFirst('document').id == entity.id)
+        }
+        return entity
+      })
+  }
 
   render() {
     const {
@@ -75,11 +94,12 @@ class EntitySearchResults extends Component {
             <thead>
               <tr>
                 {writeable && updateSelection && <th className="select" />}
-                {columns.map(this.renderHeaderCell)}
+                {columns.map(this.renderHeaderCell.bind(this))}
               </tr>
             </thead>
+
             <tbody className={c({ updating: result.isPending })}>
-              {result.results.map((entity) => (
+              {this.groupPageResults(result.results).map(entity => (
                 <EntitySearchResultsRow
                   key={entity.id}
                   entity={entity}

--- a/ui/src/components/EntitySearch/EntitySearchResultsRow.jsx
+++ b/ui/src/components/EntitySearch/EntitySearchResultsRow.jsx
@@ -123,6 +123,7 @@ class EntitySearchResultsRow extends Component {
       updateSelection,
       selection,
       writeable,
+      showPreview,
     } = this.props;
 
     if (isPending) {
@@ -132,6 +133,7 @@ class EntitySearchResultsRow extends Component {
     const selectedIds = _.map(selection || [], 'id');
     const isSelected = selectedIds.indexOf(entity.id) > -1;
     const parsedHash = queryString.parse(location.hash);
+    const pages = !entity.pages ? [] : entity.pages;
     const highlights = !entity.highlight ? [] : entity.highlight;
     // Select the current row if the ID of the entity matches the ID of the
     // current object being previewed. We do this so that if a link is shared
@@ -139,7 +141,7 @@ class EntitySearchResultsRow extends Component {
     // highlighted automatically.
     const isActive =
       parsedHash['preview:id'] && parsedHash['preview:id'] === entity.id;
-    const isPrefix = !!highlights.length;
+    const isPrefix = highlights.length > 0 || pages.length > 0;
     const resultClass = c(
       'EntitySearchResultsRow',
       { active: isActive },
@@ -177,6 +179,17 @@ class EntitySearchResultsRow extends Component {
             </td>
           </tr>
         )}
+
+        {!!pages.length && pages.map(page => {
+          return <tr key={`${entity.id}-page-${page.index}`} className={`${highlightsClass} prefix`}>
+            <td colSpan="100%" className="highlights">
+              <Entity.Link preview={showPreview} entity={page}>
+                Page {page.getFirst('index')}
+              </Entity.Link>
+              <SearchHighlight highlight={page.highlight} />
+            </td>
+          </tr>
+        })}
       </>
     );
   }

--- a/ui/src/queries.js
+++ b/ui/src/queries.js
@@ -14,7 +14,7 @@ export function entitiesQuery(location) {
   // We normally only want Things, not Intervals (relations between things).
   const context = {
     highlight: true,
-    'filter:schemata': 'Thing',
+    'filter:schemata': ['Thing', 'Page'],
   };
   return Query.fromLocation('entities', location, context, '');
 }


### PR DESCRIPTION
![image](https://github.com/alephdata/aleph/assets/86304937/5eca7c92-bc4f-4510-bb9e-08316bdf6df8)

This is a solution to the highlights problem. It adds `Page` to the queried entity schemas when searching. `Page` entities are added to the `Pages` entities to get to a nice per page highlights overview.

As a work in progress, some questions remain:
1. Page entities don't show their `bodyText` in the preview, as it is marked as `hidden` in the FTM definitions. Why is it marked as hidden? Can we not do that so the preview shows `bodyText`? 
2. On the left we have facets that allow us to filter on `Page` and `Document` now. I don't think it makes sense to filter on Page, do we just want to hide that, and also filte on `Page` when filtering on `Document`?