### PR TITLE
Display an error message for blocked users

### DIFF
--- a/aleph/model/__init__.py
+++ b/aleph/model/__init__.py
@@ -1,5 +1,5 @@
 from aleph.core import db  # noqa
-from aleph.model.role import Role, PasswordCredentialsError  # noqa
+from aleph.model.role import Role, PasswordCredentialsError, RoleBlockedError  # noqa
 from aleph.model.alert import Alert  # noqa
 from aleph.model.permission import Permission  # noqa
 from aleph.model.entity import Entity  # noqa

--- a/aleph/model/__init__.py
+++ b/aleph/model/__init__.py
@@ -1,5 +1,5 @@
 from aleph.core import db  # noqa
-from aleph.model.role import Role  # noqa
+from aleph.model.role import Role, PasswordCredentialsError  # noqa
 from aleph.model.alert import Alert  # noqa
 from aleph.model.permission import Permission  # noqa
 from aleph.model.entity import Entity  # noqa

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -24,6 +24,10 @@ class PasswordCredentialsError(Exception):
     pass
 
 
+class RoleBlockedError(Exception):
+    pass
+
+
 class Role(db.Model, IdModel, SoftDeleteModel):
     """A user, group or other access control subject."""
 
@@ -274,11 +278,15 @@ class Role(db.Model, IdModel, SoftDeleteModel):
     def login(cls, email, password):
         """Attempt to log a user in via an email/password method."""
         role = cls.by_email(email)
-        if role is None or not role.is_actor or not role.has_password:
+        if role is None:
             raise PasswordCredentialsError()
-        if role.check_password(password):
-            return role
-        raise PasswordCredentialsError()
+        if not role.check_password(password):
+            raise PasswordCredentialsError()
+        if role.is_blocked:
+            raise RoleBlockedError()
+        if not role.is_actor:
+            raise PasswordCredentialsError()
+        return role
 
     def __repr__(self):
         return "<Role(%r,%r)>" % (self.id, self.foreign_id)

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -20,6 +20,10 @@ membership = db.Table(
 )
 
 
+class PasswordCredentialsError(Exception):
+    pass
+
+
 class Role(db.Model, IdModel, SoftDeleteModel):
     """A user, group or other access control subject."""
 
@@ -271,9 +275,10 @@ class Role(db.Model, IdModel, SoftDeleteModel):
         """Attempt to log a user in via an email/password method."""
         role = cls.by_email(email)
         if role is None or not role.is_actor or not role.has_password:
-            return
+            raise PasswordCredentialsError()
         if role.check_password(password):
             return role
+        raise PasswordCredentialsError()
 
     def __repr__(self):
         return "<Role(%r,%r)>" % (self.id, self.foreign_id)

--- a/aleph/oauth.py
+++ b/aleph/oauth.py
@@ -81,7 +81,7 @@ def _get_groups(provider, oauth_token, id_token):
 
 
 def handle_oauth(provider, oauth_token):
-    from aleph.model import Role
+    from aleph.model import Role, RoleBlockedError
 
     token = provider.parse_id_token(oauth_token)
     if token is None:
@@ -99,6 +99,8 @@ def handle_oauth(provider, oauth_token):
         role = Role.load_or_create(
             role_id, Role.USER, name, email=email, is_admin=is_auto_admin(email)
         )
+    if role.is_blocked:
+        raise RoleBlockedError()
     if not role.is_actor:
         raise OAuthError()
     role.clear_roles()

--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -114,6 +114,14 @@ class Settings:
         # Roles that haven't logged in since X months will stop receiving notifications.
         self.ROLE_INACTIVE = timedelta(days=env.to_int("ALEPH_ROLE_INACTIVE", 6 * 30))
 
+        # Displayed when a blocked user tries to log in
+        self.ROLE_BLOCKED_MESSAGE = env.get(
+            "ALEPH_ROLE_BLOCKED_MESSAGE",
+            "Your account has been blocked.",
+        )
+        self.ROLE_BLOCKED_LINK = env.get("ALEPH_ROLE_BLOCKED_LINK", None)
+        self.ROLE_BLOCKED_LINK_LABEL = env.get("ALEPH_ROLE_BLOCKED_LINK_LABEL", None)
+
         # Delete notifications after N days.
         self.NOTIFICATIONS_DELETE = timedelta(
             days=env.to_int("ALEPH_NOTIFICATIONS_DELETE", 3 * 30)

--- a/aleph/tests/test_sessions_api.py
+++ b/aleph/tests/test_sessions_api.py
@@ -1,15 +1,21 @@
+from contextlib import contextmanager
+import unittest.mock as mock
+from urllib.parse import urlparse, parse_qs
+from requests import Response
+
 from aleph.core import db
 from aleph.settings import SETTINGS
-from aleph.model import Collection
+from aleph.model import Collection, Role
 from aleph.logic.collections import update_collection
 from aleph.views.base_api import _metadata_locale
 from aleph.tests.util import TestCase
 from aleph.tests.factories.models import RoleFactory
+from aleph.oauth import oauth
 
 
 class SessionsApiTestCase(TestCase):
     def setUp(self):
-        super(SessionsApiTestCase, self).setUp()
+        super().setUp()
         self.role = RoleFactory.create()
 
     def test_admin_all_access(self):
@@ -26,6 +32,7 @@ class SessionsApiTestCase(TestCase):
 
     def test_metadata_get_with_password_registration_enabled(self):
         _metadata_locale.cache_clear()
+        SETTINGS.OAUTH = False
         res = self.client.get("/api/2/metadata")
         assert res.status_code == 200, res
         auth = res.json["auth"]
@@ -35,6 +42,7 @@ class SessionsApiTestCase(TestCase):
     def test_metadata_get_without_password_login(self):
         _metadata_locale.cache_clear()
         SETTINGS.PASSWORD_LOGIN = False
+        SETTINGS.OAUTH = False
         res = self.client.get("/api/2/metadata")
         assert res.status_code == 200, res
         auth = res.json["auth"]
@@ -55,10 +63,165 @@ class SessionsApiTestCase(TestCase):
         SETTINGS.PASSWORD_LOGIN = True
         secret = self.fake.password()
         self.role.set_password(secret)
-        data = dict(email=self.role.email, password=secret)
+        data = {"email": self.role.email, "password": secret}
         res = self.client.post("/api/2/sessions/login", data=data)
         assert res.status_code == 200, res
         headers = {"Authorization": "Token %s" % res.json["token"]}
         res = self.client.get("/api/2/roles/%s" % self.role.id, headers=headers)
         assert res.status_code == 200, res
         assert res.json["id"] == str(self.role.id), res
+
+    def test_password_login_incorrect_email_and_password(self):
+        SETTINGS.PASSWORD_LOGIN = True
+        secret = self.fake.password()
+        self.role.set_password(secret)
+        data = {"email": self.role.email, "password": "this is not the password"}
+        res = self.client.post("/api/2/sessions/login", data=data)
+        assert res.status_code == 400, res
+        assert res.json["message"] == "Invalid user or password."
+
+    def test_password_login_post_blocked_user(self):
+        SETTINGS.PASSWORD_LOGIN = True
+        secret = self.fake.password()
+        self.role.set_password(secret)
+        self.role.is_blocked = True
+        db.session.add(self.role)
+        db.session.commit()
+
+        data = {"email": self.role.email, "password": secret}
+        res = self.client.post("/api/2/sessions/login", data=data)
+        assert res.status_code == 400, res
+        assert res.json["message"] == "Invalid user or password."
+
+
+class SessionsApiOAuthTestCase(TestCase):
+    def setUp(self):
+        super().setUpClass()
+
+        SETTINGS.OAUTH = True
+        SETTINGS.OAUTH_HANDLER = "test-oidc"
+        SETTINGS.OAUTH_KEY = "test-client"
+        SETTINGS.OAUTH_SECRET = "test-secret"
+
+        # Depending on the value of the `OAUTH_*` settings, an OAuth provider is initialized
+        # when initializing the Flask app, so we need to recreate it after setting the setting
+        self.init_app()
+
+        # Usually, this setting is discovered automatically by fetching the identity
+        # provider’s metadata endpoint
+        oauth.provider.authorize_url = "https://example.org/oauth/authorize"
+        oauth.provider.access_token_url = "https://example.org/oauth/token"
+
+    def test_oauth_init(self):
+        res = self.client.get("/api/2/sessions/oauth")
+        assert res.status_code == 302
+
+        # After starting the OAuth flow, the user is redirected to the identity provider...
+        location = urlparse(res.headers["Location"])
+        assert location.netloc == "example.org"
+        assert location.path == "/oauth/authorize"
+
+        query = parse_qs(location.query)
+        assert query["response_type"] == ["code"]
+        assert query["client_id"] == ["test-client"]
+
+    def test_oauth_callback(self):
+        res = self.client.get("/api/2/sessions/oauth")
+        location = urlparse(res.headers["Location"])
+        query = parse_qs(location.query)
+
+        state = query["state"]
+
+        # Once the user has been authenticated, the identity provider redirects the user back and
+        # includes multiple query parameters, including an authorization code. Aleph then uses
+        # the auth code and sends another request to the identity provider to exchange the auth code
+        # for OAuth tokens (including an ID token that contains information about the users identity).
+        # In a test environment, we need to mock the request to the identity provider and the
+        # validation of the returned ID token.
+        with mock_oauth_token_exchange(name="John Doe", email="john.doe@example.org"):
+            res = self.client.get(
+                "/api/2/sessions/callback",
+                query_string={
+                    "code": "example-auth-code",
+                    "state": state,
+                },
+            )
+
+        # After a successful auth flow the users is redirected to the frontend and the users API auth token
+        # is included in the URL fragment
+        location = urlparse(res.headers["Location"])
+        query = parse_qs(location.fragment)
+        auth_token = query["token"][0]
+
+        role_id, _ = auth_token.split(".")
+        res = self.client.get(
+            f"/api/2/roles/{role_id}",
+            headers={"Authorization": f"Token {auth_token}"},
+        )
+
+        assert res.json["name"] == "John Doe"
+        assert res.json["email"] == "john.doe@example.org"
+
+    def test_oauth_callback_incorrect_state(self):
+        with mock_oauth_token_exchange(name="John Doe", email="john.doe@example.org"):
+            res = self.client.get(
+                "/api/2/sessions/callback",
+                query_string={
+                    "code": "example-auth-code",
+                    # This is a random value usually returned from the `oauth_init` method as
+                    # a query parameter in the redirect
+                    "state": "random123",
+                },
+            )
+
+        assert res.status_code == 401
+
+    def test_oauth_callback_blocked_user(self):
+        role = Role.load_or_create(
+            foreign_id="test-oidc:john.doe@example.org",
+            type_=Role.USER,
+            name="John Doe",
+        )
+        role.is_blocked = True
+        role.email = "john.doe@example.org"
+        db.session.add(role)
+        db.session.commit()
+
+        res = self.client.get("/api/2/sessions/oauth")
+        location = urlparse(res.headers["Location"])
+        query = parse_qs(location.query)
+
+        state = query["state"]
+
+        with mock_oauth_token_exchange(name="John Doe", email="john.doe@example.org"):
+            res = self.client.get(
+                "/api/2/sessions/callback",
+                query_string={
+                    "code": "example-auth-code",
+                    "state": state,
+                },
+            )
+
+        assert res.status_code == 401
+
+
+@contextmanager
+def mock_oauth_token_exchange(name: str, email: str):
+    patch_send = mock.patch("requests.sessions.Session.send")
+    patch_parse = mock.patch(
+        "authlib.integrations.flask_client.remote_app.FlaskRemoteApp.parse_id_token"
+    )
+
+    with patch_send as send_mock, patch_parse as parse_mock:
+        send_mock.return_value = mock.Mock(
+            spec=Response,
+            json=lambda: {"id_token": "fake_token"},
+        )
+
+        # https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+        parse_mock.return_value = {
+            "name": "John Doe",
+            "email": "john.doe@example.org",
+        }
+
+        yield

--- a/aleph/tests/util.py
+++ b/aleph/tests/util.py
@@ -87,7 +87,6 @@ class TestCase(unittest.TestCase):
         SETTINGS.TESTING = True
         SETTINGS.DEBUG = True
         SETTINGS.CACHE = True
-        SETTINGS.OAUTH = False
         SETTINGS.SECRET_KEY = "batman"
         SETTINGS.APP_UI_URL = UI_URL
         SETTINGS.ARCHIVE_TYPE = "file"

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -30,13 +30,25 @@ def _metadata_locale(locale):
     # This is cached in part because latency on this endpoint is
     # particularly relevant to the first render being shown to a
     # user.
-    auth = {"oauth": SETTINGS.OAUTH, "require_logged_in": SETTINGS.REQUIRE_LOGGED_IN}
+    auth = {
+        "oauth": SETTINGS.OAUTH,
+        "require_logged_in": SETTINGS.REQUIRE_LOGGED_IN,
+        "role_blocked": {
+            "message": SETTINGS.ROLE_BLOCKED_MESSAGE,
+            "link": SETTINGS.ROLE_BLOCKED_LINK,
+            "link_label": SETTINGS.ROLE_BLOCKED_LINK_LABEL,
+        },
+    }
+
     if SETTINGS.PASSWORD_LOGIN:
         auth["password_login_uri"] = url_for("sessions_api.password_login")
+
     if SETTINGS.PASSWORD_LOGIN and not SETTINGS.MAINTENANCE:
         auth["registration_uri"] = url_for("roles_api.create_code")
+
     if SETTINGS.OAUTH:
         auth["oauth_uri"] = url_for("sessions_api.oauth_init")
+
     locales = SETTINGS.UI_LANGUAGES
     locales = {loc: Locale(loc).get_language_name(loc) for loc in locales}
 

--- a/aleph/views/sessions_api.py
+++ b/aleph/views/sessions_api.py
@@ -10,7 +10,7 @@ from aleph.settings import SETTINGS
 from aleph.core import db, url_for, cache
 from aleph.authz import Authz
 from aleph.oauth import oauth, handle_oauth, OAuthError
-from aleph.model import Role, PasswordCredentialsError
+from aleph.model import Role, PasswordCredentialsError, RoleBlockedError
 from aleph.logic.util import ui_url
 from aleph.logic.roles import update_role
 from aleph.views.util import get_url_path, parse_request
@@ -67,7 +67,20 @@ def password_login():
         role = Role.login(data.get("email"), data.get("password"))
     except PasswordCredentialsError:
         AUTH_ATTEMPS.labels(method="password", result="failed").inc()
+        # Raising a 400 error in this and the following case is technically
+        # not 100% correct. This seems to have been introduced in order to simplify
+        # error handling in the frontend. Raising a 401 error triggers a
+        # hard page reload and state invalidation etc.
         raise BadRequest(gettext("Invalid user or password."))
+    except RoleBlockedError:
+        AUTH_ATTEMPS.labels(method="password", result="failed").inc()
+        return jsonify(
+            {
+                "status": "error",
+                "message": "Your account has been blocked.",
+            },
+            status=403,
+        )
 
     role.touch()
     db.session.commit()
@@ -126,6 +139,9 @@ def oauth_callback():
     except OAuthError:
         AUTH_ATTEMPS.labels(method="oauth", result="failed").inc()
         raise err
+    except RoleBlockedError:
+        error_url = ui_url("oauth", status="error", code=403)
+        return redirect(error_url)
 
     db.session.commit()
     update_role(role)

--- a/ui/src/components/common/RoleBlockedMessage.tsx
+++ b/ui/src/components/common/RoleBlockedMessage.tsx
@@ -1,0 +1,27 @@
+import { FC } from 'react';
+import { AnchorButton, Intent } from '@blueprintjs/core';
+
+type RoleBlockedMessageProps = {
+  message: string;
+  link?: string;
+  linkLabel?: string;
+};
+
+const RoleBlockedMessage: FC<RoleBlockedMessageProps> = ({
+  message,
+  link,
+  linkLabel,
+}) => {
+  return (
+    <>
+      <p>{message}</p>
+      {link && linkLabel && (
+        <AnchorButton href={link} intent={Intent.PRIMARY} rel="noreferrer">
+          {linkLabel}
+        </AnchorButton>
+      )}
+    </>
+  );
+};
+
+export default RoleBlockedMessage;

--- a/ui/src/components/common/index.jsx
+++ b/ui/src/components/common/index.jsx
@@ -53,6 +53,7 @@ import WidthBoundary from './WidthBoundary';
 import DeleteDialog from './DeleteDialog';
 import FeedbackButton from './FeedbackButton';
 import HintPopover from './HintPopover';
+import RoleBlockedMessage from './RoleBlockedMessage';
 
 export {
   AnimatedCount,
@@ -110,6 +111,7 @@ export {
   DeleteDialog,
   FeedbackButton,
   HintPopover,
+  RoleBlockedMessage,
 };
 
 export * from './types';

--- a/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.jsx
+++ b/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.jsx
@@ -113,8 +113,7 @@ export class AuthenticationDialog extends Component {
   render() {
     const { metadata, intl, isOpen, toggleDialog } = this.props;
     const { auth } = metadata;
-    const { submitted, firstSection, secondSection } = this.state;
-    const passwordLogin = auth.password_login_uri;
+    const { firstSection } = this.state;
 
     if (!isOpen) {
       return null;
@@ -138,71 +137,105 @@ export class AuthenticationDialog extends Component {
         }
       >
         <div className={Classes.DIALOG_BODY}>
-          <section className={firstSection}>
-            {passwordLogin && (
-              <PasswordAuthLogin
-                buttonClassName="signin-button"
-                onSubmit={this.onLogin}
-              />
-            )}
-            {passwordLogin && (
-              <div className="link-box">
-                <a key="oauth" href="/" onClick={this.onRegisterClick}>
-                  <FormattedMessage
-                    id="signup.register.question"
-                    defaultMessage="Don't have account? Register!"
-                  />
-                </a>
-              </div>
-            )}
-          </section>
-          <section className={secondSection}>
-            {submitted ? (
-              <Callout
-                intent={Intent.SUCCESS}
-                icon="tick"
-                title={
-                  <FormattedMessage
-                    id="signup.inbox.title"
-                    defaultMessage="Check your inbox"
-                  />
-                }
-              >
-                <FormattedMessage
-                  id="signup.inbox.desc"
-                  defaultMessage="We've sent you an email, please follow the link to complete your registration"
-                />
-              </Callout>
-            ) : (
-              <span>
-                <PasswordAuthSignup
-                  buttonClassName="signin-button"
-                  onSubmit={this.onSignup}
-                />
-              </span>
-            )}
-            <div className="link-box">
-              <a key="oauth" href="/" onClick={this.onSignInClick}>
-                <FormattedMessage
-                  id="signup.login"
-                  defaultMessage="Already have account? Sign in!"
-                />
-              </a>
-            </div>
-          </section>
-          {auth.oauth_uri && (
-            <>
-              <MenuDivider className="menu-divider" />
-              <Button icon="log-in" large fill onClick={this.onOAuthLogin}>
-                <FormattedMessage
-                  id="login.oauth"
-                  defaultMessage="Sign in via OAuth"
-                />
-              </Button>
-            </>
-          )}
+          {this.renderContent()}
         </div>
       </Dialog>
+    );
+  }
+
+  renderContent() {
+    const { metadata } = this.props;
+    const { auth } = metadata;
+
+    return (
+      <>
+        {this.renderFirstSection()}
+        {this.renderSecondSection()}
+        {auth.oauth_uri && this.renderOAuthButton()}
+      </>
+    );
+  }
+
+  renderFirstSection() {
+    const { metadata } = this.props;
+    const { auth } = metadata;
+    const { firstSection } = this.state;
+    const passwordLogin = auth.password_login_uri;
+
+    return (
+      <section className={firstSection}>
+        {passwordLogin && (
+          <PasswordAuthLogin
+            buttonClassName="signin-button"
+            onSubmit={this.onLogin}
+          />
+        )}
+        {passwordLogin && (
+          <div className="link-box">
+            <a key="oauth" href="/" onClick={this.onRegisterClick}>
+              <FormattedMessage
+                id="signup.register.question"
+                defaultMessage="Don't have account? Register!"
+              />
+            </a>
+          </div>
+        )}
+      </section>
+    );
+  }
+
+  renderSecondSection() {
+    const { submitted, secondSection } = this.state;
+
+    return (
+      <section className={secondSection}>
+        {submitted ? (
+          <Callout
+            intent={Intent.SUCCESS}
+            icon="tick"
+            title={
+              <FormattedMessage
+                id="signup.inbox.title"
+                defaultMessage="Check your inbox"
+              />
+            }
+          >
+            <FormattedMessage
+              id="signup.inbox.desc"
+              defaultMessage="We've sent you an email, please follow the link to complete your registration"
+            />
+          </Callout>
+        ) : (
+          <span>
+            <PasswordAuthSignup
+              buttonClassName="signin-button"
+              onSubmit={this.onSignup}
+            />
+          </span>
+        )}
+        <div className="link-box">
+          <a key="oauth" href="/" onClick={this.onSignInClick}>
+            <FormattedMessage
+              id="signup.login"
+              defaultMessage="Already have account? Sign in!"
+            />
+          </a>
+        </div>
+      </section>
+    );
+  }
+
+  renderOAuthButton() {
+    return (
+      <>
+        <MenuDivider className="menu-divider" />
+        <Button icon="log-in" large fill onClick={this.onOAuthLogin}>
+          <FormattedMessage
+            id="login.oauth"
+            defaultMessage="Sign in via OAuth"
+          />
+        </Button>
+      </>
     );
   }
 }

--- a/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.jsx
+++ b/ui/src/dialogs/AuthenticationDialog/AuthenticationDialog.jsx
@@ -16,6 +16,7 @@ import {
   PasswordAuthLogin,
   PasswordAuthSignup,
 } from 'components/auth/PasswordAuth';
+import { RoleBlockedMessage } from 'components/common';
 import {
   loginWithPassword as loginWithPasswordAction,
   loginWithToken as loginWithTokenAction,
@@ -167,14 +168,15 @@ export class AuthenticationDialog extends Component {
   }
 
   renderBlockedMessage() {
+    const { metadata } = this.props;
+    const { message, link, link_label } = metadata.auth.role_blocked;
+
     return (
-      <p>
-        Your user account has been deactivated and you cannot sign in until it
-        is reactivated. We deactivate accounts if they have been inactive for
-        more than 24 months or violate our terms of service. In order to
-        reactivate your account please contact us using{' '}
-        <a href="#">this form</a>.
-      </p>
+      <RoleBlockedMessage
+        message={message}
+        link={link}
+        linkLabel={link_label}
+      />
     );
   }
 

--- a/ui/src/screens/OAuthScreen/OAuthScreen.jsx
+++ b/ui/src/screens/OAuthScreen/OAuthScreen.jsx
@@ -5,7 +5,8 @@ import { FormattedMessage } from 'react-intl';
 import { loginWithToken } from 'actions/sessionActions';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
-import { Dialog, DialogBody } from '@blueprintjs/core';
+import { Dialog, DialogBody, AnchorButton, Intent } from '@blueprintjs/core';
+import { RoleBlockedMessage } from 'components/common';
 
 import withRouter from 'app/withRouter';
 
@@ -20,7 +21,8 @@ class OAuthScreen extends React.Component {
   }
 
   render() {
-    const { location, navigate } = this.props;
+    const { location, navigate, metadata } = this.props;
+    const { message, link, link_label } = metadata.auth.role_blocked;
     const query = queryString.parse(location.search);
 
     if (query.status === 'error' && query.code === '403') {
@@ -38,13 +40,11 @@ class OAuthScreen extends React.Component {
           canOutsideClickClose={false}
         >
           <DialogBody>
-            <p>
-              Your user account has been deactivated and you cannot sign in
-              until it is reactivated. We deactivate accounts if they have been
-              inactive for more than 24 months or violate our terms of service.
-              In order to reactivate your account please contact us using{' '}
-              <a href="#">this form</a>.
-            </p>
+            <RoleBlockedMessage
+              message={message}
+              link={link}
+              linkLabel={link_label}
+            />
           </DialogBody>
         </Dialog>
       );
@@ -55,7 +55,7 @@ class OAuthScreen extends React.Component {
   }
 }
 
-const mapStateToProps = ({ session }) => ({ session });
+const mapStateToProps = ({ metadata }) => ({ metadata });
 
 const mapDispatchToProps = { loginWithToken };
 

--- a/ui/src/screens/OAuthScreen/OAuthScreen.jsx
+++ b/ui/src/screens/OAuthScreen/OAuthScreen.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import queryString from 'query-string';
 import { Navigate } from 'react-router-dom';
+import { FormattedMessage } from 'react-intl';
 import { loginWithToken } from 'actions/sessionActions';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
+import { Dialog, DialogBody } from '@blueprintjs/core';
 
 import withRouter from 'app/withRouter';
 
@@ -15,12 +17,39 @@ class OAuthScreen extends React.Component {
       this.props.loginWithToken(parsedHash.token);
       return null;
     }
-    return undefined;
   }
 
   render() {
-    const { location } = this.props;
+    const { location, navigate } = this.props;
     const query = queryString.parse(location.search);
+
+    if (query.status === 'error' && query.code === '403') {
+      return (
+        <Dialog
+          title={
+            <FormattedMessage
+              id="oauth.role_blocked.dialog.title"
+              defaultMessage="User account deactivated"
+            />
+          }
+          icon="warning-sign"
+          isOpen={true}
+          onClose={() => navigate('/')}
+          canOutsideClickClose={false}
+        >
+          <DialogBody>
+            <p>
+              Your user account has been deactivated and you cannot sign in
+              until it is reactivated. We deactivate accounts if they have been
+              inactive for more than 24 months or violate our terms of service.
+              In order to reactivate your account please contact us using{' '}
+              <a href="#">this form</a>.
+            </p>
+          </DialogBody>
+        </Dialog>
+      );
+    }
+
     const nextPath = query.next || '/';
     return <Navigate to={nextPath} replace />;
   }


### PR DESCRIPTION
Aleph includes an option to block individual users. Blocking users effectively makes it impossible for them to sign in. Right now, a generic authentication failure message is displayed when a blocked user tries to sign in. As we’re considering blocking user accounts that have been inactive for some time, we want to display a specific error message (incl. instructions on how to reactivate the account) when a user has been blocked.

### Implementation considerations

* Most of the diff in this PR comes from new tests for the existing password and OAuth authentication flows.
* The new test cases for the OAuth flow are as close the the real flow as possible, only mocking one request to the identity provider to fetch OAuth tokens.
* The main change in the actual authentication logic is a refactoring: Before, both the password login handler and he OAuth handler returned either a `Role` record in case of successful authentication or `None` in case of an authentication error. This makes it difficult to handle different authentication errors at a higher level in the actual API routes. Now, these handlers raise different exceptions depending on the authentication error so we can handle them differently in the API routes. Also take a look at the individual commit messages which have a few more details.

### How to test this locally

In order to test the password flow, just create a password user in your development environment and manually set the `is_blocked` column in the `role` table.

Testing the OAuth flow is slightly more complex and requires running an OpenID Connection provider in your development environment. Here’s a draft of a guide on how to set up a Keycloak instance for testing in your development environment:

<details>
<summary>
Expand
</summary>

# How to Set Up an Identity Provider for Development

<p class="lead">When making changes to the OAuth authentication flow in Aleph, it can be helpful to test changes against a real identity provider. This guide describes how to run the Keycloak identity provider in your local development environment and how to configure Aleph accordingly.</p>

<Callout theme="danger">This guide describes how to set up Keycloak in a development environment. If you want to configure a production Aleph instance to use Keycloak as an identity provider, please refer to [our operations guide](/developers/how-to/operations/identity-provider).</Callout>

## Run and configure Keycloak

The official [Keycloak documentation](https://www.keycloak.org/getting-started/getting-started-docker) provides detailed instructions on how to run Keycloak using Docker. You can follow these instructions for the most part. However, you will have to make a few minor changes:

The default port used in the Keycloak documentation is `8080`. In an Aleph development environment that port is already in use for the Aleph UI. Adjust the port mapping for the Keycloak container to use a different port:

```bash
docker run -p "8888:8080" -e "KEYCLOAK_ADMIN=admin" -e "KEYCLOAK_ADMIN_PASSWORD=admin" quay.io/keycloak/keycloak:23.0.1 start-dev
```

After creating a new realm in the Keycloak admin console, set the "Frontend URL" setting to `http://localhost:8888`. This is necessary to ensure that Aleph redirects you to the correct URL during the authentication flow.

When creating a new client using the Keycloak admin console, change the following settings:

| Setting | Value |
| --- | --- |
| Client authentication | Enabled |
| Valid redirect URIs | `http://localhost:8080/api/2/sessions/callback` |
| Valid post logout redirect URIs | `http://localhost:8080/` |

After creating a new client using the Keycloak admin console, switch to the "Credentials" tab and take note of the client secret.

## Configure Aleph

Finally, you need to adjust Aleph’s configuration to use your local Keycloak instance instead of the default password authentication flow.

Set the following Aleph configuration options:

| Configuration option | Value |
| --- | --- |
| `ALEPH_OAUTH` | `true` |
| `ALEPH_OAUTH_KEY` | `myrealm` |
| `ALEPH_OAUTH_SECRET` | Client secret from previous step |
| `ALEPH_OAUTH_METADATA_URL` | `http://host.docker.internal:8888/realms/myrealm/.well-known/openid-configuration` |
| `ALEPH_PASSWORD_LOGIN` | `false` |

Restart Aleph, visit the Aleph UI at `http://localhost:8080`, and click on the "Sign in" button in the navigation bar to test the authentication flow.

</details>

## Todos

- [x] Make blocked message and link configurable via environment variables

## Configuration options

This PR adds three new configuration options to customize the contents of the error message per instance:

* `ALEPH_ROLE_BLOCKED_MESSAGE` (This defaults to just "Your user account has been deactivated")
* `ALEPH_ROLE_BLOCKED_LINK` (Defaults to `None`, i.e. no link is displayed.)
* `ALEPH_ROLE_BLOCKED_LINK_LABEL`

## Screenshot

Here’s an example of the popup displayed when a user is redirected back from the identity provider. The message, button label and button link are configurable (see above).

<img width="540" alt="Screen Shot 2024-01-09 at 11 41 57" src="https://github.com/alephdata/aleph/assets/1512805/1feca0fa-d422-494e-9dad-8975e9e7a605">
