### PR TITLE
Stringify sanitized HTML as HTML (not XML)

### DIFF
--- a/aleph/logic/html.py
+++ b/aleph/logic/html.py
@@ -57,7 +57,7 @@ def sanitize_html(html_text, base_url, encoding=None):
             if el.tag == "a":
                 el.set("target", "_blank")
                 el.set("rel", "nofollow noreferrer external noopener")
-        return tostring(doc)
+        return tostring(doc, method="html", encoding="unicode")
     except Exception as exc:
         log.warning("HTML sanitizer failure [%s]: %s", type(exc), exc)
         return gettext("[HTML removed: could not be sanitized]")

--- a/aleph/tests/test_view_util.py
+++ b/aleph/tests/test_view_util.py
@@ -36,6 +36,11 @@ class ViewUtilTest(TestCase):
         assert html.find(".//a").get("target") == "_blank", html
         assert "nofollow" in html.find(".//a").get("rel"), html
 
+    def test_sanitize_html_no_self_closing_tags(self):
+        html_str = '<html><body><noscript><script src="https://example.org></script></noscript></body></html>'
+        processed = sanitize_html(html_str, "https://example.org")
+        assert processed == "<html><body><div><noscript></noscript></div></body></html>"
+
     def test_validate_returns_errors_for_paths(self):
         # given
         schema = "RoleCreate"  # name min length 4, password min length 6


### PR DESCRIPTION
This fixes a bug where Aleph doesn’t correctly preview HTML pages (see #3334).

The `etree.ElementTree.tostring` method stringifies as valid XML by default. While XML allows self-closing tags by default, only some tags can be self-closing in HTML.

This causes problems when rendering the sanitized HTML. Consider this example:

```html
<noscript><script src="..."></script></noscript>
<h1>Page title</h1>
<p>Some text</p>
```

When converting the sanitized element tree to XML, this would result in something like this:

```html
<noscript />
<h1>Page title</h1>
<p>Some text</p>
```

`noscript` is not a valid void element which results in browsers treating all following elements as children of the `noscript` tag, parsing the HTML into an effective DOM structure like this:

```html
<noscript>
  <h1>Page title</h1>
  <p>Some text</p>
</noscript>
```

As a result the actual page contents are hidden when rendered in a browser (if JavaScript is enabled).