### PR TITLE
Upgrade to latest ingest-file release

### DIFF
--- a/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
+++ b/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   ingest-file:
-    image: ghcr.io/alephdata/ingest-file:3.19.3
+    image: ghcr.io/alephdata/ingest-file:3.20.0
     tmpfs:
       - /tmp:mode=777
     volumes:

--- a/contrib/keycloak/docker-compose.dev-keycloak.yml
+++ b/contrib/keycloak/docker-compose.dev-keycloak.yml
@@ -35,7 +35,7 @@ services:
   ingest-file:
     build:
       context: services/ingest-file
-    image: ghcr.io/alephdata/ingest-file:3.19.3
+    image: ghcr.io/alephdata/ingest-file:3.20.0
     hostname: ingest
     tmpfs: /tmp
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - redis-data:/data
 
   ingest-file:
-    image: ghcr.io/alephdata/ingest-file:3.19.3
+    image: ghcr.io/alephdata/ingest-file:3.20.0
     tmpfs:
       - /tmp:mode=777
     volumes:

--- a/helm/charts/aleph/values.yaml
+++ b/helm/charts/aleph/values.yaml
@@ -123,7 +123,7 @@ ingestfile:
 
   image:
     repository: ghcr.io/alephdata/ingest-file
-    tag: "3.19.2"
+    tag: "3.20.0"
     pullPolicy: Always
 
   containerSecurityContext:


### PR DESCRIPTION
This PR upgrades ingest-file to version 3.20.0 in Docker Compose and Helm config files.