### PR TITLE
Fix link target in user guide

### DIFF
--- a/docs/src/pages/users/faq/account/index.mdx
+++ b/docs/src/pages/users/faq/account/index.mdx
@@ -73,7 +73,7 @@ Your Aleph account’s username is the e-mail address you used to register. If y
 
 ## I removed my 2FA app/lost my phone and I cannot log in to Aleph. What should I do?
 
-In either of the above situations, you will have to reset the password to your Aleph account. Please follow the instructions to [reset your password](http://localhost:3000/users/getting-started/account#reset-your-password).
+In either of the above situations, you will have to reset the password to your Aleph account. Please follow the instructions to [reset your password](/users/getting-started/account#reset-your-password).
 
 ## I tried everything and I can’t log in to Aleph? How do I get in touch with OCCRP to ask for assistance?
 


### PR DESCRIPTION
Fixes a broken link in the user guide on this page: https://docs.aleph.occrp.org/users/faq/account/. We do automatically check for broken internal links in CI. While this link was supposed to be targeting another documentation page, it was an absolute URL and thus not detected by the broken link checker.