### PR TITLE
Fix default Dockerfile command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,4 @@ ENV ALEPH_ELASTICSEARCH_URI=http://elasticsearch:9200/ \
 RUN mkdir /run/prometheus
 
 # Run the green unicorn
-CMD gunicorn --config /aleph/gunicorn.conf.py --workers 5 --log-level info --log-file - aleph.manage:app
+CMD gunicorn --config /aleph/gunicorn.conf.py --workers 6 --log-level debug --log-file -

--- a/docs/src/pages/developers/alephclient.mdx
+++ b/docs/src/pages/developers/alephclient.mdx
@@ -54,7 +54,7 @@ Using the `write-entities` command, users can load JSON-formatted entities forma
 A typical use might look this:
 
 ```bash
-curl -o md_companies.yml https://raw.githubusercontent.com/alephdata/aleph/master/mappings/md_companies.yml
+curl -o md_companies.yml https://raw.githubusercontent.com/alephdata/aleph/main/mappings/md_companies.yml
 ftm map md_companies.yml | ftm aggregate | alephclient write-entities -f md_companies
 ```
 
@@ -81,7 +81,7 @@ alephclient stream-entities -f us_ofac | ftm validate | ftm export-excel -o OFAC
 The `bulkload` command executes an [entity mapping](/developers/mappings) within the Aleph system. Its only argument is a YAML mapping file:
 
 ```
-curl -o md_companies.yml https://raw.githubusercontent.com/alephdata/aleph/master/mappings/md_companies.yml
+curl -o md_companies.yml https://raw.githubusercontent.com/alephdata/aleph/main/mappings/md_companies.yml
 alephclient bulkload md_companies.yml
 ```
 

--- a/docs/src/pages/developers/followthemoney/ftm.mdx
+++ b/docs/src/pages/developers/followthemoney/ftm.mdx
@@ -51,7 +51,7 @@ pip install pyicu
 Probably the most common task for ftm is to generate FtM entities from some structured data source. This is done using a YAML-formatted mapping file, [described here](/developers/mappings). With such a YAML file in hand, you can generate FtM entities like this:
 
 ```bash
-curl -o md_companies.yml https://raw.githubusercontent.com/alephdata/aleph/master/mappings/md_companies.yml
+curl -o md_companies.yml https://raw.githubusercontent.com/alephdata/aleph/main/mappings/md_companies.yml
 ftm map md_companies.yml
 ```
 
@@ -66,7 +66,7 @@ This will yield a line-based JSON stream of every company in Moldova, their dire
 You might note, however, that this actually generates multiple entity fragments for each company (i.e. multiple entities with the same ID). This is due to the way the md_companies mapping is written: each query section generates a partial company record. In order to mitigate this, you will need to perform entity aggregation:
 
 ```bash
-curl -o md_companies.yml https://raw.githubusercontent.com/alephdata/aleph/master/mappings/md_companies.yml
+curl -o md_companies.yml https://raw.githubusercontent.com/alephdata/aleph/main/mappings/md_companies.yml
 ftm map md_companies.yml | ftm aggregate >moldova.ijson
 ```
 

--- a/docs/src/pages/developers/installation.mdx
+++ b/docs/src/pages/developers/installation.mdx
@@ -193,7 +193,7 @@ Aleph is distributed as a set of Docker containers, which can be run on any serv
 
 To begin a production deployment:
 
-- Obtain a copy of Aleph's [docker-compose](https://github.com/alephdata/aleph/blob/master/docker-compose.yml) file and [base configurations](https://github.com/alephdata/aleph/blob/master/aleph.env.tmpl) (named `aleph.env.tmpl`).
+- Obtain a copy of Aleph's [docker-compose](https://github.com/alephdata/aleph/blob/main/docker-compose.yml) file and [base configurations](https://github.com/alephdata/aleph/blob/main/aleph.env.tmpl) (named `aleph.env.tmpl`).
 - Make a copy of the configurations file named `aleph.env` and define settings for your production instance. Check the [section on configuration](/developers/installation#configuration) for more information regarding the available options.
 
 <Callout>


### PR DESCRIPTION
I broke the default Dockerfile command in `7cfcb5`. While the Dockerfile did always specify the WSGI app `aleph.manage:app`, this has been incorrect for some time and it should have always been `aleph.wsgi:app`. Previously we never actually ran a container with the default command though and instead specified the command in the `docker-compose.yml` file. I removed the "duplicate" command in the `docker-compose.yml` in the referenced commit and thus the default command in the Dockerfile is now used.

I’ve now changed the default command specified in `Dockerfile` to be in line with the command previously set in `docker-compose.yml` (https://github.com/alephdata/aleph/blob/3.15.5/docker-compose.yml#L76).

* The WSGI app is now `aleph.wsgi:app` (this is specified in `gunicorn.py` not via a CLI option).
* Uses 6 workers by default (instead of 5).
* Log level set to `debug` (instead of `info`).

Additionally, the installation guide in the docs referenced the configuration templates on the `develop` branch instead of `main`. We recently renamed `main` to `master` and changed the default branch to `develop`. GitHub now redirects any links that still use the old `master` branch to the default branch. I’ve fixed this too.

Closes #3606