### PR TITLE
Add mimetype inclusion/exclusion flags to reingest command

### DIFF
--- a/aleph/logic/collections.py
+++ b/aleph/logic/collections.py
@@ -131,13 +131,21 @@ def index_aggregator(
 
 
 def reingest_collection(
-    collection, job_id=None, index=False, flush=True, include_ingest=False
+    collection,
+    job_id=None,
+    index=False,
+    flush=True,
+    include_ingest=False,
+    include_mimetypes=[],
+    exclude_mimetypes=[],
 ):
     """Trigger a re-ingest for all documents in the collection."""
     job_id = job_id or Job.random_id()
     if flush:
         ingest_flush(collection, include_ingest=include_ingest)
-    for document in Document.by_collection(collection.id):
+    for document in Document.by_collection_and_mimetype(
+        collection.id, include_mimetypes, exclude_mimetypes
+    ):
         proxy = document.to_proxy(ns=collection.ns)
         ingest_entity(collection, proxy, job_id=job_id, index=index)
 

--- a/aleph/manage.py
+++ b/aleph/manage.py
@@ -205,11 +205,37 @@ def reindex_casefiles(flush=False):
 @click.option("--index", is_flag=True, default=False)
 @click.option("--include_ingest", is_flag=True, default=False)
 @click.option("--flush/--no-flush", default=True)
-def reingest(foreign_id, index=False, flush=True, include_ingest=False):
+@click.option(
+    "--include-mimetype",
+    "include_mimetypes",
+    multiple=True,
+    default=[],
+    help="Only include documents with these mimetypes (multiple mentions possible)",
+)
+@click.option(
+    "--exclude-mimetype",
+    "exclude_mimetypes",
+    multiple=True,
+    default=[],
+    help="Exclude documents with these mimetypes (multiple mentions possible)",
+)
+def reingest(
+    foreign_id,
+    index=False,
+    flush=True,
+    include_ingest=False,
+    include_mimetypes=[],
+    exclude_mimetypes=[],
+):
     """Process documents and database entities and index them."""
     collection = get_collection(foreign_id)
     reingest_collection(
-        collection, index=index, flush=flush, include_ingest=include_ingest
+        collection,
+        index=index,
+        flush=flush,
+        include_ingest=include_ingest,
+        include_mimetypes=include_mimetypes,
+        exclude_mimetypes=exclude_mimetypes,
     )
 
 

--- a/aleph/model/document.py
+++ b/aleph/model/document.py
@@ -178,6 +178,19 @@ class Document(db.Model, DatedModel):
         q = q.yield_per(5000)
         return q
 
+    @classmethod
+    def by_collection_and_mimetype(
+        cls, collection_id=None, include_mimetypes=[], exclude_mimetypes=[]
+    ):
+        q = cls.all()
+        q = q.filter(cls.collection_id == collection_id)
+        if include_mimetypes:
+            q = q.filter(cls.meta["mime_type"].astext.in_(include_mimetypes))
+        if exclude_mimetypes:
+            q = q.filter(~cls.meta["mime_type"].astext.in_(exclude_mimetypes))
+        q = q.yield_per(5000)
+        return q
+
     def to_proxy(self, ns=None):
         ns = ns or self.collection.ns
         proxy = model.get_proxy(

--- a/aleph/model/document.py
+++ b/aleph/model/document.py
@@ -6,6 +6,7 @@ from followthemoney import model
 from followthemoney.types import registry
 from followthemoney.namespace import Namespace
 from followthemoney.util import sanitize_text
+from pantomime import normalize_mimetype
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -182,6 +183,8 @@ class Document(db.Model, DatedModel):
     def by_collection_and_mimetype(
         cls, collection_id=None, include_mimetypes=[], exclude_mimetypes=[]
     ):
+        include_mimetypes = [normalize_mimetype(mt) for mt in include_mimetypes or []]
+        exclude_mimetypes = [normalize_mimetype(mt) for mt in exclude_mimetypes or []]
         q = cls.all()
         q = q.filter(cls.collection_id == collection_id)
         if include_mimetypes:

--- a/aleph/tests/test_ingest_api.py
+++ b/aleph/tests/test_ingest_api.py
@@ -48,6 +48,22 @@ class IngestApiTestCase(TestCase):
         assert doc.schema == Document.SCHEMA, doc.schema
         assert doc.meta["countries"] == ["de", "us"], doc.meta
         assert doc.meta["languages"] == ["eng"], doc.meta
+        assert doc.meta["mime_type"] == "text/csv", doc.meta
+
+        assert (
+            Document.by_collection_and_mimetype(
+                collection_id=1, include_mimetypes=["text/csv"], exclude_mimetypes=None
+            ).count()
+            == 1
+        )
+        assert (
+            Document.by_collection_and_mimetype(
+                collection_id=1,
+                include_mimetypes=None,
+                exclude_mimetypes=["text/csv"],
+            ).count()
+            == 0
+        )
 
         status = get_status(self.col)
         assert status.get("pending") == 1, status


### PR DESCRIPTION
# Problem statement

Reingesting collections is sometimes necessary, either for data consistency reasons or for the sake of using newer versions of the processing agent (typically `ingest-file`). This operation can take a considerable amount of time and it can also do a lot of unnecessary work, because only some of the files should be reingested.

# Proposal

The `aleph reingest` command gets these two new flags:

```
  --include-mimetype TEXT  Only include documents with these mimetypes
                           (multiple mentions possible)
  --exclude-mimetype TEXT  Exclude documents with these mimetypes (multiple
                           mentions possible)
```

which can be mixed and reused to narrow down documents to be reingest by their mimetype.

As an example one would reingest only images with:

```
aleph reingest foreign_id --include-mimetype "image/*"
```

or exclude pdf files with:

```
aleph reingest foreign_id --exclude-mimetype "application/pdf"
```

# Known limitations

* one can shoot themselves in their limbs by not being careful mixing these. For instance 

```
aleph reingest foreign_id --include-mimetype "image/jpeg" --exclude-mimetype "image/*"
```

does **not** reingest only JPEG images, but rather excludes all images :/