### PR TITLE
Fix documentation links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,9 @@ If you're trying to install Aleph and need help, or if you are running Aleph and
 
 1. [Read the Aleph Support Policy](https://github.com/alephdata/aleph/blob/main/SUPPORT.md) and understand under what
    rules we provide support to others. If you feel you fall within that
-   group, please [get in touch](https://docs.alephdata.org/get-in-touch).
+   group, please [get in touch](https://docs.aleph.occrp.org/get-in-touch).
 
-2. Make sure you've [read the documentation](https://docs.alephdata.org),
+2. Make sure you've [read the documentation](https://docs.aleph.occrp.org),
    especially the technical troubleshooting sections.
 
 3. Only once you're **certain that the problem you are seeing is a bug**
@@ -30,7 +30,7 @@ If you're trying to install Aleph and need help, or if you are running Aleph and
 
 A great place to start when looking for something to work on is our [project board](https://github.com/orgs/alephdata/projects/10). For experienced Aleph developers feel free to check our the [workboard](https://github.com/orgs/alephdata/projects/10/views/1). If this is your first time working on Aleph then it's probably a good idea to pick [something easy to work on](https://github.com/orgs/alephdata/projects/10/views/10). You can also find these issues on our [contribute page](https://github.com/alephdata/aleph/contribute). Regardless, once you've selected an issue please take a moment to assign it to yourself, this will stop anyone else from working on your issue.
 
-If, after reviewing the list (or selecting an issue to work on) you'd like to reach out and talk to us then [get in touch](https://docs.alephdata.org/get-in-touch).
+If, after reviewing the list (or selecting an issue to work on) you'd like to reach out and talk to us then [get in touch](https://docs.aleph.occrp.org/get-in-touch).
 
 ### Forking and Branching
 

--- a/README.rst
+++ b/README.rst
@@ -15,9 +15,8 @@ companies) against watchlists, e.g. from prior research or public datasets.
 For further details on the software, how to use it, install it or manage data
 imports, please check the documentation at: 
 
-* https://docs.alephdata.org
-* Installation: https://docs.alephdata.org/developers/installation
-* Changes: https://docs.alephdata.org/developers/changelog
+* https://docs.aleph.occrp.org
+* Installation: https://docs.aleph.occrp.org/developers/installation
 
 
 Support
@@ -28,7 +27,7 @@ If you're interested in participating in this process, please read the support
 policy (`SUPPORT.md`), the contribution rules (`CONTRIBUTING.md`), and the code of conduct (`CODE_OF_CONDUCT.md`) and then get
 in touch:
 
-* https://docs.alephdata.org/get-in-touch
+* https://docs.aleph.occrp.org/get-in-touch
 
 Release process
 ---------------

--- a/aleph/pages/about.en.md
+++ b/aleph/pages/about.en.md
@@ -6,4 +6,4 @@ menu: true
 
 Aleph is a powerful tool for people who follow the money. It helps investigators to securely access and search large amounts of data - no matter whether they are a government database or a leaked email archive.
 
-Please refer to the [documentation](https://docs.alephdata.org/) for more details.
+Please refer to the [documentation](https://docs.aleph.occrp.org/) for more details.

--- a/aleph/validation/spec.py
+++ b/aleph/validation/spec.py
@@ -58,7 +58,7 @@ spec_info = {
 
 spec_docs = {
     "description": "Find out more about Aleph, a suite of data analysis tools for investigators.",  # noqa
-    "url": "https://docs.alephdata.org/",
+    "url": "https://docs.aleph.occrp.org/",
 }
 
 spec_tags = [

--- a/docs/src/pages/developers/mappings.mdx
+++ b/docs/src/pages/developers/mappings.mdx
@@ -11,7 +11,7 @@ title: Importing structured data
 
 Aleph is commonly used to import data tables \(like a companies registry, list of persons of interest, or a set of government contracts\) that a user wants to search and browse.
 
-It does this by mapping tabular source data to the [Follow the Money](https://docs.alephdata.org/developers/followthemoney) \(FtM\) data model. Aleph defines entities \(such as `People`, `Companies`, `Assets` or `Court Cases`\), and the relationships between them \(such as `Family`relations, or business interests – `Ownership` or `Directorship`, or other links like `Sanctions`, `Payments` \).
+It does this by mapping tabular source data to the [Follow the Money](/developers/followthemoney) \(FtM\) data model. Aleph defines entities \(such as `People`, `Companies`, `Assets` or `Court Cases`\), and the relationships between them \(such as `Family`relations, or business interests – `Ownership` or `Directorship`, or other links like `Sanctions`, `Payments` \).
 
 To load structured data into Aleph, an entity mapping file needs to be created. A mapping file uses YAML syntax to describe how information from a table can be projected to FtM entities.
 
@@ -474,7 +474,7 @@ Mapping files can be loaded in two different ways — either from an aleph shell
 aleph bulkload mapping.yml
 ```
 
-or by using a combination of [`followthemoney-util`](https://docs.alephdata.org/developers/ftm) and [`alephclient`](https://docs.alephdata.org/developers/alephclient) command-line tools:
+or by using a combination of [`followthemoney-util`](/developers/followthemoney/ftm) and [`alephclient`](/developers/alephclient) command-line tools:
 
 ```
 ftm map mapping.yml | ftm aggregate | alephclient write-entities -f dataset_name

--- a/helm/charts/aleph/README.md
+++ b/helm/charts/aleph/README.md
@@ -37,4 +37,4 @@ Helm chart for Aleph
 | global.env.ELASTICSEARCH_TIMEOUT | string | `"600"` | Default elasticsearch timeout |
 | global.env.REDIS_URL | string | `"redis://aleph-redis-master.default.svc.cluster.local:6379/0"` | Redis url |
 
-Checkout [https://docs.alephdata.org/developers/installation#configuration](https://docs.alephdata.org/developers/installation#configuration) for all available options.
+Checkout [https://docs.aleph.occrp.org/developers/installation#configuration](https://docs.aleph.occrp.org/developers/installation#configuration) for all available options.

--- a/mappings/Makefile
+++ b/mappings/Makefile
@@ -17,7 +17,7 @@ md_companies: md_companies.load
 # (balkhash) for aggregation. When loaded from the cache, all partial entities
 # are combined into one JSON object and ready to be indexed.
 #
-# See also: https://docs.alephdata.org/developers/mappings
+# See also: https://docs.aleph.occrp.org/developers/mappings
 %.load:
 	ftm store delete -d $* -o etl
 	ftm map $*.yml | ftm store write -o etl -d $*
@@ -29,7 +29,7 @@ md_companies: md_companies.load
 # This data is already provided in Follow the Money format and can be loaded into the
 # search index straight from a normal curl call.
 #
-# See also: https://docs.alephdata.org/data-commons/sanctions
+# See also: https://docs.aleph.occrp.org/developers/datacommons/#opensanctions
 peps: \
 	everypolitician \
 	eu_meps \

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     ],
     author="OCCRP Data Team",
     author_email="data@occrp.org",
-    url="https://docs.alephdata.org",
+    url="https://docs.aleph.occrp.org",
     license="MIT",
     packages=find_packages(exclude=["ez_setup", "examples", "test"]),
     namespace_packages=[],

--- a/site/aleph.occrp.org/pages/faq.en.md
+++ b/site/aleph.occrp.org/pages/faq.en.md
@@ -29,7 +29,7 @@ Please file a request with [OCCRP ID](https://id.occrp.org) to suggest a dataset
 
 Yes! Much of the software we’re building at OCCRP is open source, and we invest a lot of time in making sure other organizations can benefit from this technology as well.
 
-Please visit the [Aleph software documentation](https://docs.alephdata.org/developers/installation) page for information on how to install and operate the software.
+Please visit the [Aleph software documentation](/developers/installation) page for information on how to install and operate the software.
 
 ### Can I use the Aleph API?
 
@@ -41,6 +41,6 @@ Using the Aleph API is not a valid approach to “know your customer” (KYC) ch
 
 ### How do I get access to bulk data?
 
-We publish a selection of [open datasets](https://docs.alephdata.org/data-commons/sanctions) as part of the Aleph project. We’re also happy to [work with](https://requests.occrp.org/datadesk) other journalists or media organizations to provide bulk exports for specific datasets for your data project.
+A number of datasets that are available in OCCRP’s Aleph instance can also be downloaded in the FollowTheMoney format. Please check out the [Data Commons](/developers/datacommons) page for more information. We’re also happy to [work with](https://requests.occrp.org/datadesk) other journalists or media organizations to provide bulk exports for specific datasets for your data project.
 
 It is our policy not to provide bulk exports to non-journalists. This specifically includes banks, due diligence firms, and machine learning researchers.

--- a/ui/src/components/Collection/CollectionMappingsMode.jsx
+++ b/ui/src/components/Collection/CollectionMappingsMode.jsx
@@ -40,7 +40,7 @@ class CollectionMappingsMode extends React.Component {
           <p>
             <FormattedMessage
               id="collection.mappings.create_docs_link"
-              defaultMessage="For more information, please refer to the {link}"
+              defaultMessage="For more information, please refer to the {link}."
               values={{
                 link: (
                   <a
@@ -50,7 +50,7 @@ class CollectionMappingsMode extends React.Component {
                   >
                     <FormattedMessage
                       id="mapping.docs.link"
-                      defaultMessage="Aleph entity mapping documentation"
+                      defaultMessage="Aleph user guide"
                     />
                   </a>
                 ),

--- a/ui/src/components/Collection/CollectionMappingsMode.jsx
+++ b/ui/src/components/Collection/CollectionMappingsMode.jsx
@@ -44,7 +44,7 @@ class CollectionMappingsMode extends React.Component {
               values={{
                 link: (
                   <a
-                    href="https://docs.alephdata.org/guide/building-out-your-investigation/generating-multiple-entities-from-a-list"
+                    href="https://docs.aleph.occrp.org/users/investigations/cross-referencing/#generating-entities-from-yourspreadsheet"
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/ui/src/components/Entity/EntityMappingMode.jsx
+++ b/ui/src/components/Entity/EntityMappingMode.jsx
@@ -124,7 +124,7 @@ export class EntityMappingMode extends Component {
               values={{
                 link: (
                   <a
-                    href="https://docs.alephdata.org/developers/mappings"
+                    href="https://docs.aleph.occrp.org/developers/mappings"
                     target="_blank"
                     rel="noopener noreferrer"
                   >

--- a/ui/src/components/Entity/EntityMappingMode.jsx
+++ b/ui/src/components/Entity/EntityMappingMode.jsx
@@ -120,17 +120,17 @@ export class EntityMappingMode extends Component {
           <p className="text-page-subtitle">
             <FormattedMessage
               id="mapping.info"
-              defaultMessage="Follow the steps below to map items in this investigation to structured Follow the Money entites. For more information, please refer to the {link}"
+              defaultMessage="Follow the steps below to map items in this investigation to structured entites. For more information, please refer to the {link}."
               values={{
                 link: (
                   <a
-                    href="https://docs.aleph.occrp.org/developers/mappings"
+                    href="https://docs.aleph.occrp.org/users/investigations/cross-referencing/#generating-entities-from-yourspreadsheet"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
                     <FormattedMessage
                       id="mapping.info.link"
-                      defaultMessage="Aleph data mapping documentation"
+                      defaultMessage="Aleph user guide"
                     />
                   </a>
                 ),

--- a/ui/src/components/Investigation/InvestigationOverview.jsx
+++ b/ui/src/components/Investigation/InvestigationOverview.jsx
@@ -13,8 +13,7 @@ import { selectCollection, selectNotificationsResult } from 'selectors';
 
 import './InvestigationOverview.scss';
 
-const guidesURLPrefix =
-  'https://docs.alephdata.org/guide/building-out-your-investigation/';
+const guidesURLPrefix = 'https://docs.aleph.occrp.org/users/investigations';
 
 class InvestigationOverview extends React.Component {
   render() {
@@ -92,7 +91,7 @@ class InvestigationOverview extends React.Component {
                 alignText="left"
                 icon="people"
                 target="_blank"
-                href={`${guidesURLPrefix}creating-an-investigation#managing-access-to-your-investigation`}
+                href={`${guidesURLPrefix}/manage-access/`}
               >
                 <FormattedMessage
                   id="investigation.overview.guides.access"
@@ -105,7 +104,7 @@ class InvestigationOverview extends React.Component {
                 alignText="left"
                 icon="upload"
                 target="_blank"
-                href={`${guidesURLPrefix}uploading-documents`}
+                href={`${guidesURLPrefix}/uploading-documents/`}
               >
                 <FormattedMessage
                   id="investigation.overview.guides.documents"
@@ -118,7 +117,7 @@ class InvestigationOverview extends React.Component {
                 alignText="left"
                 icon="graph"
                 target="_blank"
-                href={`${guidesURLPrefix}network-diagrams`}
+                href={`${guidesURLPrefix}/network-diagrams/`}
               >
                 <FormattedMessage
                   id="investigation.overview.guides.diagrams"
@@ -131,7 +130,7 @@ class InvestigationOverview extends React.Component {
                 alignText="left"
                 icon="new-object"
                 target="_blank"
-                href={`${guidesURLPrefix}using-the-table-editor`}
+                href={`${guidesURLPrefix}/entity-editor/`}
               >
                 <FormattedMessage
                   id="investigation.overview.guides.entities"
@@ -144,7 +143,7 @@ class InvestigationOverview extends React.Component {
                 alignText="left"
                 icon="table"
                 target="_blank"
-                href={`${guidesURLPrefix}generating-multiple-entities-from-a-list`}
+                href={`${guidesURLPrefix}/cross-referencing/`}
               >
                 <FormattedMessage
                   id="investigation.overview.guides.mappings"

--- a/ui/src/components/Investigation/InvestigationOverview.jsx
+++ b/ui/src/components/Investigation/InvestigationOverview.jsx
@@ -150,19 +150,6 @@ class InvestigationOverview extends React.Component {
                   defaultMessage="Generating entities from a spreadsheet"
                 />
               </AnchorButton>
-              <AnchorButton
-                minimal
-                intent={Intent.PRIMARY}
-                alignText="left"
-                icon="comparison"
-                target="_blank"
-                href={`${guidesURLPrefix}cross-referencing`}
-              >
-                <FormattedMessage
-                  id="investigation.overview.guides.xref"
-                  defaultMessage="Cross-referencing your data"
-                />
-              </AnchorButton>
             </div>
           </div>
         </div>

--- a/ui/src/components/common/AppItem.jsx
+++ b/ui/src/components/common/AppItem.jsx
@@ -36,13 +36,13 @@ class AppItem extends PureComponent {
           className={Classes.TEXT_DISABLED}
           icon="code"
           text={message}
-          href="https://docs.alephdata.org"
+          href="https://docs.aleph.occrp.org"
         />
         <MenuItem
           className={Classes.TEXT_DISABLED}
           icon="code"
           text={ftmMessage}
-          href="https://docs.alephdata.org/developers/followthemoney"
+          href="https://followthemoney.tech"
         />
       </>
     );


### PR DESCRIPTION
When we updated the docs site, we set up redirects for all of these links, so they were still working, but it is time to properly update the links everywhere.

This also updates a few links to the user guide from within the Aleph UI, so I won’t merge this directly into `main` as I usually do with documentation changes, but instead follow the normal release process for code changes.

One of the CI workflows is currently failing -- I’ve fixed this in https://github.com/alephdata/aleph/pull/3670 and will rebase this branch as soon as the fix is merged.