### PR TITLE
Update workflows to use `docker compose` instead of `docker-compose`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
           sudo echo "ALEPH_SECRET=batman\n" >> aleph.env
           echo "${GITHUB_REF}"
           docker --version
-          docker-compose --version
+          docker compose --version
 
       - name: Docker pull services
         run: |
-          docker-compose pull --quiet elasticsearch ingest-file
+          docker compose pull --quiet elasticsearch ingest-file
           make ALEPH_TAG=${GITHUB_SHA} services
 
       - name: Build docker image

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
           sudo echo "ALEPH_SECRET_KEY=batman\n" >> aleph.env
           echo "${GITHUB_REF}"
           docker --version
-          docker-compose --version
+          docker compose --version
 
       - name: Run tests
         run: make e2e


### PR DESCRIPTION
It seems like GitHub Actions runners do not ship docker-compose v1 anymore, so builds started failing. Fixing this is as easy as replacing `docker-compose` with `docker compose` (and a good idea anyway).