### PR TITLE
Change label for email address facets and statistics to remove ambiguity

### DIFF
--- a/ui/src/components/SearchField/util.js
+++ b/ui/src/components/SearchField/util.js
@@ -35,7 +35,8 @@ const messages = defineMessages({
   },
   facet_emails: {
     id: 'facet.emails',
-    defaultMessage: '{count, plural, one {E-Mail} other {E-Mails}}',
+    defaultMessage:
+      '{count, plural, one {Email address} other {Email addresses}}',
   },
   facet_phones: {
     id: 'facet.phones',


### PR DESCRIPTION
Previously, the label for both email addresses and email entities was "Email" which could be confusing when both were displayed next to each other (for example on the dataset overview screen).

I’ve also updated the spelling from "E-Mail" to "Email" which seems to be the prevalent spelling of the term nowadays (and in other places in the UI).

Fixes #3668

<img width="1079" alt="Screen Shot 2024-04-02 at 21 35 08" src="https://github.com/alephdata/aleph/assets/1512805/a6291dd3-4c78-47e4-98f8-2f32703b7440">

<img width="1083" alt="Screen Shot 2024-04-02 at 21 33 49" src="https://github.com/alephdata/aleph/assets/1512805/6bb96aab-c83e-4f5c-b5fd-e94f90169c24">
