### PR TITLE
Remove references to convert-document

### DIFF
--- a/docs/src/pages/developers/technical-faq/index.mdx
+++ b/docs/src/pages/developers/technical-faq/index.mdx
@@ -121,7 +121,15 @@ If you're encountering this issue in production mode, try to check the worker lo
 
 ## How can I make imports run faster?
 
-Please see the [Scaling Workers](/developers/installation.mdx#scaling-workers) section in the installation guide.
+The included `docker-compose` configuration for production mode has no understanding of how powerful your server is. It will run just a single instance of the services involved in data imports, `worker` and `ingest-file`. While by default, both workers will create as many threads as Python's [multiprocessing.cpu_count()](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.cpu_count) reports, this may not achieve the speed you desire.
+
+The easiest way to speed up processing is to scale up those services. Make a shell script to start docker-compose with a set of arguments like this:
+
+```bash
+docker-compose up --scale ingest-file=8 --scale worker=4
+```
+
+The number of `ingest-file` and `worker` processes could be the number of CPUs in your machine. Since performance and scaling depends a lot on types of workloads you are seeing you may need to review and adjust these settings accordingly. Please see the [Scaling Workers](/developers/installation.mdx#scaling-workers) section in the installation guide.
 
 ## ElasticSearch will not start. What's wrong?
 

--- a/docs/src/pages/developers/technical-faq/index.mdx
+++ b/docs/src/pages/developers/technical-faq/index.mdx
@@ -121,15 +121,7 @@ If you're encountering this issue in production mode, try to check the worker lo
 
 ## How can I make imports run faster?
 
-The included `docker-compose` configuration for production mode has no understanding of how powerful your server is. It will run just a single instance of the services involved in data imports, `worker` , `ingest-file` and `convert-document`.
-
-The easiest way to speed up processing is to scale up those services. Make a shell script to start docker-compose with a set of arguments like this:
-
-```bash
-docker-compose up --scale ingest-file=8 --scale convert-document=4 --scale worker=2
-```
-
-The number of `ingest-file` processes could be the number of CPUs in your machine, and `convert-document` needs to be scaled up for imports with many office documents, but never higher than `ingest-file`.
+Please see the [Scaling Workers](/developers/installation.mdx#scaling-workers) section in the installation guide.
 
 ## ElasticSearch will not start. What's wrong?
 
@@ -270,12 +262,12 @@ All of this said, we'd really love to hear about any experiments regarding this.
   We have well-defined graph semantics for FollowTheMoney data and you can export any data \(including documents like emails\) in Aleph [into various graph formats](/developers/followthemoney/ftm#exporting-data-to-a-network-graph) \(RDF, Neo4J, and GEXF for Gephi\).
 </Callout>
 
-## The document converter service keeps crashing on startup, what's wrong?
+## The `ingest-file` container keeps crashing on startup, what's wrong?
 
-You can find out specifically what went wrong with the document converter service by consulting the logs for that container:
+You can find out specifically what went wrong with the `ingest-file` container by consulting the logs for that container:
 
 ```bash
-docker-compose -f docker-compose.dev.yml logs convert-document
+docker-compose -f docker-compose.dev.yml logs ingest-file
 ```
 
 If `LibreOffice` keeps crashing on startup with `Fatal exception: Signal 11`, [AppArmor](https://help.ubuntu.com/community/AppArmor) can be one possible cause. `AppArmor` running on the host machine could be blocking `LibreOffice` from starting up. Try disabling the `AppArmor` profiles related to `LibreOffice` by following these instructions: [https://askubuntu.com/a/1214363](https://askubuntu.com/a/1214363)


### PR DESCRIPTION
Per https://github.com/alephdata/aleph/issues/3680#issuecomment-2057288614, I am attempting a pull request to remove references to the old `convert-document` container, which has since been consolidated into `ingest-file` (see https://github.com/alephdata/aleph/pull/2755).

This is my first pull request and I am open to learning! Please let me know if anything is wrong or if I need to make any adjustments.