### PR TITLE
Temporarily roll back changes to Docker Compose config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
 
   api:
     image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.15.5}
+    command: gunicorn -w 6 -b 0.0.0.0:8000 --timeout 3600 --log-level debug --log-file - aleph.wsgi:app
     expose:
       - 8000
     depends_on:


### PR DESCRIPTION
Something went wrong during the 3.15.5 release and as a consequence starting Aleph with the Docker Compose configuration from the main branch doesn’t work. Once we’ve published a fixed release we can remove this line again.

For context: The line was removed in [this commit](https://github.com/alephdata/aleph/commit/e5eba0d0a6d63ae5ff7b813b3e50fcad7b570e21#diff-e45e45baeda1c1e73482975a664062aa56f20c03dd9d64a827aba57775bed0d3) which is on the `main` branch. But the commit never ended up in the 3.15.5 release. That means that `docker-compose.yml` on `main` is currently not in line with the configuration required to run 3.15.5 (the most recent release).

This PR basically restores `docker-compose.yml` on `main` to be inline with the required configuration to run `3.15.5`: https://github.com/alephdata/aleph/blob/3.15.5/docker-compose.yml#L76