### PR TITLE
Keep Playwright versions in sync

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,19 @@ updates:
         patterns:
           - "bump2version"
           - "black"
-          - "playwright"
           - "pytest*"
           - "ruff"
+
+  - package-ecosystem: pip
+    directory: "/e2e"
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 99
+    target-branch: develop
+    groups:
+      e2e-dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: "/ui"
@@ -45,13 +55,6 @@ updates:
 
   - package-ecosystem: docker
     directory: "/ui"
-    schedule:
-      interval: monthly
-    open-pull-requests-limit: 99
-    target-branch: develop
-
-  - package-ecosystem: docker
-    directory: "/e2e"
     schedule:
       interval: monthly
     open-pull-requests-limit: 99

--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ build-ui:
 	docker build -t ghcr.io/alephdata/aleph-ui-production:$(ALEPH_TAG) -f ui/Dockerfile.production ui
 
 build-e2e:
-	$(COMPOSE_E2E) build
+	$(COMPOSE_E2E) build --build-arg PLAYWRIGHT_VERSION=$(shell awk -F'==' '/^playwright==/ { print $$2 }' e2e/requirements.txt)
 
 build-full: build build-ui build-e2e
 
@@ -115,6 +115,7 @@ e2e: services-e2e e2e/test-results
 	BASE_URL=http://ui:8080 $(COMPOSE_E2E) run --rm e2e pytest -s -v --output=/e2e/test-results/ --screenshot=only-on-failure --video=retain-on-failure e2e/
 
 e2e-local-setup: dev
+	python3 -m pip install -q -r e2e/requirements.txt
 	playwright install
 
 e2e-local:

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -1,9 +1,10 @@
-FROM mcr.microsoft.com/playwright/python:v1.42.0-focal
-COPY entrypoint.sh wait-for ./
+ARG PLAYWRIGHT_VERSION
+FROM mcr.microsoft.com/playwright/python:v${PLAYWRIGHT_VERSION}
+COPY entrypoint.sh wait-for requirements.txt ./
 RUN apt update -y \
     && apt install -y netcat wget \
     && apt-get -qq -y autoremove \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-RUN pip install pytest-playwright
+RUN pip install -r requirements.txt
 ENTRYPOINT ["./entrypoint.sh"]

--- a/e2e/requirements.txt
+++ b/e2e/requirements.txt
@@ -1,0 +1,2 @@
+playwright==1.43.0
+pytest-playwright==0.4.4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,4 @@
 bump2version==1.0.1
 Babel==2.12.1
 black==24.3.0
-playwright==1.42.0
-pytest-playwright==0.4.4
 ruff===0.3.5


### PR DESCRIPTION
So far the situation with e2e tests was that both the Dockerfile and the requirements mentioned playwright versions, but due to the way Dependabot works it can't update them atomically. Getting out-of-sync versions would result in failed e2e tests.

This change proposes keeping the version in one place and automatically pulling the corresponding container image version based on that.

It also moves e2e-related dependencies from `requirements-dev.txt` to `e2e/requirements.txt` and updates the dependabot configuration accordingly.