### PR TITLE
Don't tag RCs as latest

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -4,14 +4,14 @@ tag_name = {new_version}
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?
-serialize = 
+serialize =
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
 
 [bumpversion:part:release]
 optional_value = prod
 first_value = rc
-values = 
+values =
 	rc
 	prod
 
@@ -26,10 +26,6 @@ replace = version="{new_version}"
 search = "version": "{current_version}"
 replace = "version": "{new_version}"
 
-[bumpversion:file:docker-compose.yml]
-search = ALEPH_TAG:-{current_version}
-replace = ALEPH_TAG:-{new_version}
-
 [bumpversion:file:helm/charts/aleph/Chart.yaml]
 search = ersion: {current_version}
 replace = ersion: {new_version}
@@ -41,11 +37,3 @@ replace = tag: "{new_version}"
 [bumpversion:file:helm/charts/aleph/README.md]
 search = global.image.tag | string | `"{current_version}"`
 replace = global.image.tag | string | `"{new_version}"`
-
-[bumpversion:file:contrib/aleph-traefik-minio-keycloak/docker-compose.yml]
-search = ALEPH_TAG:-{current_version}
-replace = ALEPH_TAG:-{new_version}
-
-[bumpversion:file:contrib/keycloak/docker-compose.dev-keycloak.yml]
-search = ALEPH_TAG:-{current_version}
-replace = ALEPH_TAG:-{new_version}

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -51,7 +51,7 @@ jobs:
           docker push ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG};
 
       - name: Tag latest image
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/test-')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/test-') && !contains(github.ref, 'rc')
         run: |
           docker tag ghcr.io/alephdata/aleph-ui-production:${GITHUB_SHA} ghcr.io/alephdata/aleph-ui-production:latest;
           docker push ghcr.io/alephdata/aleph-ui-production:latest;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
           docker push ghcr.io/alephdata/aleph:${ALEPH_TAG};
 
       - name: Tag latest image
-        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/test-')
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags') && !startsWith(github.ref, 'refs/tags/test-') && !contains(github.ref, 'rc')
         run: |
           docker tag ghcr.io/alephdata/aleph:${GITHUB_SHA} ghcr.io/alephdata/aleph:latest;
           docker push ghcr.io/alephdata/aleph:latest;

--- a/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
+++ b/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   ingest-file:
-    image: ghcr.io/alephdata/ingest-file:3.20.0
+    image: ghcr.io/alephdata/ingest-file:latest
     tmpfs:
       - /tmp:mode=777
     volumes:
@@ -54,7 +54,7 @@ services:
       - "traefik.enable=false"
 
   worker:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.15.5}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-latest}
     command: aleph worker
     restart: on-failure
     links:
@@ -79,7 +79,7 @@ services:
       - "traefik.enable=false"
 
   shell:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.15.5}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-latest}
     command: /bin/bash
     depends_on:
       - postgres
@@ -99,7 +99,7 @@ services:
       - "traefik.enable=false"
 
   api:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.15.5}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-latest}
     command: gunicorn -w 6 -b 0.0.0.0:8000 --log-level debug --log-file - aleph.wsgi:app
     expose:
       - 8000
@@ -121,7 +121,7 @@ services:
       - "traefik.enable=false"
 
   ui:
-    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-3.15.5}
+    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-latest}
     depends_on:
       - api
       - traefik

--- a/contrib/keycloak/docker-compose.dev-keycloak.yml
+++ b/contrib/keycloak/docker-compose.dev-keycloak.yml
@@ -16,7 +16,7 @@ services:
   elasticsearch:
     build:
       context: services/elasticsearch
-    image: ghcr.io/alephdata/aleph-elasticsearch:${ALEPH_TAG:-3.15.5}
+    image: ghcr.io/alephdata/aleph-elasticsearch:${ALEPH_TAG:-latest}
     hostname: elasticsearch
     environment:
       - discovery.type=single-node
@@ -35,7 +35,7 @@ services:
   ingest-file:
     build:
       context: services/ingest-file
-    image: ghcr.io/alephdata/ingest-file:3.20.0
+    image: ghcr.io/alephdata/ingest-file:latest
     hostname: ingest
     tmpfs: /tmp
     volumes:
@@ -55,7 +55,7 @@ services:
   app:
     build:
       context: .
-    image: alephdata/aleph:${ALEPH_TAG:-3.15.5}
+    image: alephdata/aleph:${ALEPH_TAG:-latest}
     hostname: aleph
     command: /bin/bash
     links:
@@ -83,7 +83,7 @@ services:
   api:
     build:
       context: .
-    image: alephdata/aleph:${ALEPH_TAG:-3.15.5}
+    image: alephdata/aleph:${ALEPH_TAG:-latest}
     command: aleph run -h 0.0.0.0 -p 5000 --with-threads --reload --debugger
     ports:
       - "127.0.0.1:5000:5000"
@@ -117,7 +117,7 @@ services:
   ui:
     build:
       context: ui
-    image: alephdata/aleph-ui:${ALEPH_TAG:-3.15.5}
+    image: alephdata/aleph-ui:${ALEPH_TAG:-latest}
     links:
       - api
     command: npm run start

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,7 +37,7 @@ services:
       - redis-data:/data
 
   ingest-file:
-    image: ghcr.io/alephdata/ingest-file:3.20.0
+    image: ghcr.io/alephdata/ingest-file:latest
     hostname: ingest
     tmpfs: /tmp
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - redis-data:/data
 
   ingest-file:
-    image: ghcr.io/alephdata/ingest-file:3.20.0
+    image: ghcr.io/alephdata/ingest-file:latest
     tmpfs:
       - /tmp:mode=777
     volumes:
@@ -38,7 +38,7 @@ services:
       - aleph.env
 
   worker:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.15.5}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-latest}
     command: aleph worker
     restart: on-failure
     depends_on:
@@ -54,7 +54,7 @@ services:
       - aleph.env
 
   shell:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.15.5}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-latest}
     command: /bin/bash
     depends_on:
       - postgres
@@ -72,7 +72,7 @@ services:
       - aleph.env
 
   api:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-3.15.5}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-latest}
     expose:
       - 8000
     depends_on:
@@ -89,7 +89,7 @@ services:
       - aleph.env
 
   ui:
-    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-3.15.5}
+    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-latest}
     depends_on:
       - api
     ports:


### PR DESCRIPTION
This is a proposal which is supposed to minimize merge conflicts and make dependency management easier. By only tagging stable release container images with `latest` we are skipping the tedious work of updating references to the last stable release which often leads to merge conflicts.