### PR TITLE
Remove dash in docker compose

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
           sudo echo "ALEPH_SECRET=batman\n" >> aleph.env
           echo "${GITHUB_REF}"
           docker --version
-          docker-compose --version
+          docker compose --version
 
       - name: Docker pull services
         run: |
-          docker-compose pull --quiet elasticsearch ingest-file
+          docker compose pull --quiet elasticsearch ingest-file
           make ALEPH_TAG=${GITHUB_SHA} services
 
       - name: Build docker image

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,7 +28,7 @@ jobs:
           sudo echo "ALEPH_SECRET_KEY=batman\n" >> aleph.env
           echo "${GITHUB_REF}"
           docker --version
-          docker-compose --version
+          docker compose --version
 
       - name: Run tests
         run: make e2e

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-COMPOSE=docker-compose -f docker-compose.dev.yml
-COMPOSE_E2E=docker-compose -f docker-compose.dev.yml -f docker-compose.e2e.yml
+COMPOSE=docker compose -f docker-compose.dev.yml
+COMPOSE_E2E=docker compose -f docker-compose.dev.yml -f docker-compose.e2e.yml
 APPDOCKER=$(COMPOSE) run --rm app
 UIDOCKER=$(COMPOSE) run --no-deps --rm ui
 ALEPH_TAG=latest

--- a/aleph.env.tmpl
+++ b/aleph.env.tmpl
@@ -1,6 +1,6 @@
 # Aleph environment configuration
 #
-# This file is loaded by docker-compose and transformed into a set of
+# This file is loaded by docker compose and transformed into a set of
 # environment variables inside the containers. These are, in turn, parsed
 # by aleph and used to configure the system.
 

--- a/contrib/aleph-traefik-minio-keycloak/start.sh
+++ b/contrib/aleph-traefik-minio-keycloak/start.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
-#docker-compose -f docker-compose.yml up -d --scale worker=6
+#docker compose -f docker-compose.yml up -d --scale worker=6
 
-docker-compose -f docker-compose.yml up -d 
+docker compose -f docker-compose.yml up -d 

--- a/contrib/aleph-traefik-minio-keycloak/stop.sh
+++ b/contrib/aleph-traefik-minio-keycloak/stop.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-docker-compose -f docker-compose.yml down
+docker compose -f docker-compose.yml down

--- a/docs/src/pages/developers/adding-text-processors.mdx
+++ b/docs/src/pages/developers/adding-text-processors.mdx
@@ -42,6 +42,6 @@ You may need to restart the compose environment in order for the environment cha
 During development, you can restart the container like this:
 
 ```
-docker-compose -f docker-compose.dev.yml up \
+docker compose -f docker-compose.dev.yml up \
     --force-recreate --no-deps translate
 ```

--- a/docs/src/pages/developers/installation.mdx
+++ b/docs/src/pages/developers/installation.mdx
@@ -11,7 +11,7 @@ title: Installing Aleph
 
 ## Prerequisites
 
-Aleph requires multiple services to operate. It uses Docker containers to make it easier for development and deployments. Before we continue, you will need to have Docker and `docker-compose` installed. Please refer to their manual to learn how to set up [Docker](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install/).
+Aleph requires multiple services to operate. It uses Docker containers to make it easier for development and deployments. Before we continue, you will need to have Docker and `docker compose` installed. Please refer to their manual to learn how to set up [Docker](https://docs.docker.com/engine/installation/) and [docker compose](https://docs.docker.com/compose/install/).
 
 ## Developer setup
 
@@ -27,7 +27,7 @@ Developer mode is a docker configuration for Aleph which makes it easy to do sof
 - Both backend and frontend will operate in debug mode and give more verbose error messages when a problem occurs.
 - The host machine's file system will be accessible from within Aleph's docker container at `/host`.
 
-Developer mode overrides the configuration file for `docker-compose`, using `docker-compose.dev.yml` instead of `docker-compose.yml`. This is done by wrapping most developer mode commands using `make`.
+Developer mode overrides the configuration file for `docker compose`, using `docker-compose.dev.yml` instead of `docker-compose.yml`. This is done by wrapping most developer mode commands using `make`.
 
 ### Getting started
 
@@ -109,7 +109,7 @@ To also get a sample of (non-document) entity data, consider loading [sanctions 
 
 ### Running Tests
 
-To run the tests, assuming you already have the `docker-compose` up and ready, run:
+To run the tests, assuming you already have the `docker compose` up and ready, run:
 
 ```bash
 make test
@@ -187,13 +187,13 @@ The same can be done if you run an instance of the `shell` container in producti
 Aleph is distributed as a set of Docker containers, which can be run on any server that meets the following criteria:
 
 - 8GB (or more) of RAM. While the software will start with much less, we advise providing ample main memory for ideal performance.
-- A working install of [Docker](https://www.docker.com/) and `docker-compose`. See [the FAQ page](/developers/technical-faq#can-i-run-aleph-without-using-docker) for information on not using Docker.
+- A working install of [Docker](https://www.docker.com/) and `docker compose`. See [the FAQ page](/developers/technical-faq#can-i-run-aleph-without-using-docker) for information on not using Docker.
 - A domain name or IP address which can be used at the root via HTTPS (i.e. Aleph doesn't support running at a sub-path like `/aleph`). You are welcome to contribute fixes for this scenario.
 - An internet connection to download and install the package.
 
 To begin a production deployment:
 
-- Obtain a copy of Aleph's [docker-compose](https://github.com/alephdata/aleph/blob/main/docker-compose.yml) file and [base configurations](https://github.com/alephdata/aleph/blob/main/aleph.env.tmpl) (named `aleph.env.tmpl`).
+- Obtain a copy of Aleph's [docker compose](https://github.com/alephdata/aleph/blob/main/docker-compose.yml) file and [base configurations](https://github.com/alephdata/aleph/blob/main/aleph.env.tmpl) (named `aleph.env.tmpl`).
 - Make a copy of the configurations file named `aleph.env` and define settings for your production instance. Check the [section on configuration](/developers/installation#configuration) for more information regarding the available options.
 
 <Callout>
@@ -207,22 +207,22 @@ To begin a production deployment:
 sudo sysctl -w vm.max_map_count=262144
 ```
 
-- Finally, you can boot the docker-compose environment:
+- Finally, you can boot the `docker compose` environment:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 This will run Aleph in detached mode. You can shut down the system at any time by issuing the following command:
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 Before Aleph can process any requests or data, you need to make sure it sets up the database and search index correctly by executing an upgrade:
 
 ```bash
-docker-compose run --rm shell aleph upgrade
+docker compose run --rm shell aleph upgrade
 ```
 
 While the system is running, it will bind to to port `8080` of its host machine and accept incoming connections. You can check that the system is functional with a curl request:
@@ -260,13 +260,13 @@ For SQL database, Aleph uses PostgreSQL. PostgreSQL can be backed up and restore
 For example, here's how you can dump the database:
 
 ```
-docker-compose exec postgres pg_dumpall -c -U postgres > dump_`date +%Y-%m-%d"_"%H:%M:%S`.sql
+docker compose exec postgres pg_dumpall -c -U postgres > dump_`date +%Y-%m-%d"_"%H:%M:%S`.sql
 ```
 
 and then restore from the dump:
 
 ```
-cat dump_2021-11-03_18:03:54.sql | docker-compose exec -T postgres psql -U aleph -d aleph
+cat dump_2021-11-03_18:03:54.sql | docker compose exec -T postgres psql -U aleph -d aleph
 ```
 
 The commands will be slightly different depending on your specific set up. If you're running a separate database instance for FtM-Store, you should backup both the Aleph application database and the FtM-Store database. The data dump creation command should be put in a cron job to automate snapshot creation and those snapshots should be copied to a separate backup server.
@@ -277,12 +277,12 @@ Note: This works only for Aleph versions greater than 3.8.0.
 
 Here's how you can recreate the ElasticSearch index from the FtM-Store database:
 
-1. Run `docker-compose run --rm shell aleph upgrade` to recreate the indices in Elasticsearch
-2. Once that finishes running, run `docker-compose run --rm shell aleph reindex-full` to write data into Elasticsearch indices from the FtM-Store PostgreSQL database.This will take some time to run depending on how much data you have.
+1. Run `docker compose run --rm shell aleph upgrade` to recreate the indices in Elasticsearch
+2. Once that finishes running, run `docker compose run --rm shell aleph reindex-full` to write data into Elasticsearch indices from the FtM-Store PostgreSQL database.This will take some time to run depending on how much data you have.
 
 ## Configuration
 
-The main configuration file of Aleph is `aleph.env`, which is loaded by docker-compose and can modify many aspects of system behaviour. A template for the configuration with details regarding many of the options is available in the `aleph.env.tmpl` file.
+The main configuration file of Aleph is `aleph.env`, which is loaded by `docker compose` and can modify many aspects of system behaviour. A template for the configuration with details regarding many of the options is available in the `aleph.env.tmpl` file.
 
 ### Configuration options
 

--- a/docs/src/pages/developers/technical-faq/index.mdx
+++ b/docs/src/pages/developers/technical-faq/index.mdx
@@ -88,15 +88,15 @@ In **production mode,** make sure you perform a backup of the main database and 
 Then, make sure you are using the latest `docker-compose.yml` file. You can do this by checking out the source repo, but really you just need that one file \(and your config in `aleph.env`\). Then, run:
 
 ```bash
-docker-compose pull --parallel
+docker compose pull --parallel
 # Terminate the existing install (enter downtime!):
-docker-compose down
-docker-compose up -d redis postgres elasticsearch
+docker compose down
+docker compose up -d redis postgres elasticsearch
 # Wait a minute or so while services boot up...
 # Run upgrade:
-docker-compose run --rm shell aleph upgrade
+docker compose run --rm shell aleph upgrade
 # Restart prod system:
-docker-compose up -d
+docker compose up -d
 ```
 
 ## I get an error about missing tables. How do I fix it?
@@ -121,12 +121,12 @@ If you're encountering this issue in production mode, try to check the worker lo
 
 ## How can I make imports run faster?
 
-The included `docker-compose` configuration for production mode has no understanding of how powerful your server is. It will run just a single instance of the services involved in data imports, `worker` and `ingest-file`. While by default, both workers will create as many threads as Python's [multiprocessing.cpu_count()](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.cpu_count) reports, this may not achieve the speed you desire.
+The included `docker compose` configuration for production mode has no understanding of how powerful your server is. It will run just a single instance of the services involved in data imports, `worker` and `ingest-file`. While by default, both workers will create as many threads as Python's [multiprocessing.cpu_count()](https://docs.python.org/3/library/multiprocessing.html#multiprocessing.cpu_count) reports, this may not achieve the speed you desire.
 
-The easiest way to speed up processing is to scale up those services. Make a shell script to start docker-compose with a set of arguments like this:
+The easiest way to speed up processing is to scale up those services. Make a shell script to start `docker compose` with a set of arguments like this:
 
 ```bash
-docker-compose up --scale ingest-file=8 --scale worker=4
+docker compose up --scale ingest-file=8 --scale worker=4
 ```
 
 The number of `ingest-file` and `worker` processes could be the number of CPUs in your machine. Since performance and scaling depends a lot on types of workloads you are seeing you may need to review and adjust these settings accordingly. Please see the [Scaling Workers](/developers/installation/#scaling-workers) section in the installation guide.
@@ -138,7 +138,7 @@ Most problems arise when the ElasticSearch container doesn't startup properly, o
 You can find out specifically what went wrong with ES by consulting the logs for that container:
 
 ```
-docker-compose -f docker-compose.dev.yml logs elasticsearch
+docker compose -f docker-compose.dev.yml logs elasticsearch
 ```
 
 You will almost certainly need to run the following before you build:
@@ -185,7 +185,7 @@ make stop
 In production mode, the equivalent command is:
 
 ```bash
-docker-compose down --remove-orphans
+docker compose down --remove-orphans
 ```
 
 ## Something else is wrong, what do I do?
@@ -275,7 +275,7 @@ All of this said, we'd really love to hear about any experiments regarding this.
 You can find out specifically what went wrong with the `ingest-file` container by consulting the logs for that container:
 
 ```bash
-docker-compose -f docker-compose.dev.yml logs ingest-file
+docker compose -f docker-compose.dev.yml logs ingest-file
 ```
 
 If `LibreOffice` keeps crashing on startup with `Fatal exception: Signal 11`, [AppArmor](https://help.ubuntu.com/community/AppArmor) can be one possible cause. `AppArmor` running on the host machine could be blocking `LibreOffice` from starting up. Try disabling the `AppArmor` profiles related to `LibreOffice` by following these instructions: [https://askubuntu.com/a/1214363](https://askubuntu.com/a/1214363)


### PR DESCRIPTION
Pull request for issue raised [here](https://github.com/alephdata/aleph/pull/3681#issuecomment-2060553631).

New version of `docker compose` doesn't have a dash anymore. I left the compose files alone, but any uses of the command were changed from `docker-compose` to `docker compose`.