### PR TITLE
Disable blank issues and link to Discourse

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Aleph Community Discourse
+    url: https://aleph.discourse.group
+    about: Get support for running and developing Aleph and related projects here.


### PR DESCRIPTION
At the moment when someone wants to open a new issue in this repo they get this chooser:

<img width="1265" alt="Screenshot 2024-05-13 at 09 41 29" src="https://github.com/alephdata/aleph/assets/217554/b7a9950e-63f4-4ca3-8b5c-777e301312f8">

This is still the first place people come to when they need help with their Aleph setup, but we'd rather have support issues (and discussions in general) in our Discourse and only stick to having only the issues and feature requests we actively want to work on here on Github.

I propose two changes:

- disable the blank issue link
- link to our community Discourse and encourage people to get support over there

I made the changes based on [these docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser).