### PR TITLE
Fix end-to-end tests in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,9 @@ jobs:
           docker --version
           docker-compose --version
 
+      - name: Pull and start services
+        run: make services-e2e
+
       - name: Run tests
         run: make e2e
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,6 +30,9 @@ jobs:
           docker --version
           docker-compose --version
 
+      - name: Build e2e image
+        run: make build-e2e
+
       - name: Pull and start services
         run: make services-e2e
 

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ e2e: services-e2e e2e/test-results
 	$(COMPOSE_E2E) run --rm app aleph upgrade
 	$(COMPOSE_E2E) run --rm app aleph createuser --name="E2E Admin" --admin --password="admin" admin@admin.admin
 	$(COMPOSE_E2E) up -d api ui worker
-	BASE_URL=http://ui:8080 $(COMPOSE_E2E) run --rm --build-arg PLAYWRIGHT_VERSION=$(shell awk -F'==' '/^playwright==/ { print $$2 }' e2e/requirements.txt) e2e pytest -s -v --output=/e2e/test-results/ --screenshot=only-on-failure --video=retain-on-failure e2e/
+	BASE_URL=http://ui:8080 $(COMPOSE_E2E) run --rm e2e pytest -s -v --output=/e2e/test-results/ --screenshot=only-on-failure --video=retain-on-failure e2e/
 
 e2e-local-setup: dev
 	python3 -m pip install -q -r e2e/requirements.txt


### PR DESCRIPTION
The `docker compose run` command doesn’t support the `--build-arg` argument. Depending on the Docker Compose version installed, using the `--build-arg` argument would either exit with an error code or simply print the command help.

To achieve the desired outcome, we can first build the image with the build argument, then start the container. This has the additional advantage of separating the build logs from the logs of the actual command execution in the GitHub Actions UI.

Tested these changes: https://github.com/alephdata/aleph/actions/runs/9205541034/job/25321430312