### PR TITLE
Exit op_index early in Aleph Worker

### DIFF
--- a/aleph/worker.py
+++ b/aleph/worker.py
@@ -41,6 +41,10 @@ indexing_lock = threading.Lock()
 
 def op_index(collection_id: str, batch: List[Task], worker: Worker):
     collection = Collection.by_id(collection_id)
+
+    if not collection:
+        return
+
     sync = any(task.context.get("sync", False) for task in batch)
     index_many(collection, sync=sync, tasks=batch)
     for task in batch:


### PR DESCRIPTION
This hotfix addresses the following stacktrace:

```
Traceback (most recent call last):
  File "/aleph/aleph/worker.py", line 146, in periodic
    self.run_indexing_batches()
  File "/aleph/aleph/worker.py", line 208, in run_indexing_batches
    op_index(collection_id, batch, worker=self)
  File "/aleph/aleph/worker.py", line 45, in op_index
    index_many(collection, sync=sync, tasks=batch)
  File "/aleph/aleph/logic/processing.py", line 22, in index_many
    aggregator = get_aggregator(collection)
  File "/aleph/aleph/logic/aggregator.py", line 14, in get_aggregator
    dataset = get_aggregator_name(collection)
  File "/aleph/aleph/logic/aggregator.py", line 9, in get_aggregator_name
    return "collection_%s" % collection.id
AttributeError: 'NoneType' object has no attribute 'id'"
```