### PR TITLE
Display start and last updated timestamp on system status page

### DIFF
--- a/aleph/worker.py
+++ b/aleph/worker.py
@@ -138,7 +138,6 @@ class AlephWorker(Worker):
                     self.often.update()
                     log.info("Self-check...")
                     compute_collections()
-                    Dataset.cleanup_dataset_status(kv)
 
                 if self.daily.check():
                     self.daily.update()

--- a/aleph/worker.py
+++ b/aleph/worker.py
@@ -8,7 +8,7 @@ import copy
 from typing import Dict, Callable
 
 import structlog
-from servicelayer.taskqueue import Worker, Task, Dataset
+from servicelayer.taskqueue import Worker, Task
 from servicelayer import settings as sls
 
 from aleph import __version__

--- a/ui/src/screens/SystemStatusScreen/SystemStatusScreen.jsx
+++ b/ui/src/screens/SystemStatusScreen/SystemStatusScreen.jsx
@@ -1,18 +1,18 @@
 import React from 'react';
-import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
+import {
+  defineMessages,
+  FormattedDate,
+  FormattedMessage,
+  FormattedTime,
+  injectIntl,
+} from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
 import { Button, ProgressBar, Intent } from '@blueprintjs/core';
 import { Tooltip2 as Tooltip } from '@blueprintjs/popover2';
 
 import withRouter from 'app/withRouter';
-import {
-  Collection,
-  ErrorSection,
-  Numeric,
-  Skeleton,
-  RelativeTime,
-} from 'components/common';
+import { Collection, ErrorSection, Numeric, Skeleton } from 'components/common';
 import Screen from 'components/Screen/Screen';
 import Dashboard from 'components/Dashboard/Dashboard';
 import ErrorScreen from 'components/Screen/ErrorScreen';
@@ -121,6 +121,7 @@ export class SystemStatusScreen extends React.Component {
       res.start_time && convertUTCDateToLocalDate(res.start_time);
     const lastUpdatedAt =
       res.last_update && convertUTCDateToLocalDate(res.last_update);
+    const today = new Date();
 
     return (
       <tr key={collection?.id || 'null'}>
@@ -143,7 +144,12 @@ export class SystemStatusScreen extends React.Component {
                   defaultMessage="started"
                 />{' '}
                 <span title={intl.formatDate(startedAt, dateFormat)}>
-                  <RelativeTime date={startedAt} />
+                  {today.toDateString() !== startedAt.toDateString() && (
+                    <>
+                      <FormattedDate value={startedAt} />{' '}
+                    </>
+                  )}
+                  <FormattedTime value={startedAt} />
                 </span>
               </>
             )}
@@ -155,7 +161,12 @@ export class SystemStatusScreen extends React.Component {
                   defaultMessage="last updated"
                 />{' '}
                 <span title={intl.formatDate(lastUpdatedAt, dateFormat)}>
-                  <RelativeTime date={lastUpdatedAt} />
+                  {today.toDateString() !== lastUpdatedAt.toDateString() && (
+                    <>
+                      <FormattedDate value={lastUpdatedAt} />{' '}
+                    </>
+                  )}
+                  <FormattedTime value={lastUpdatedAt} />
                 </span>
               </>
             )}

--- a/ui/src/screens/SystemStatusScreen/SystemStatusScreen.jsx
+++ b/ui/src/screens/SystemStatusScreen/SystemStatusScreen.jsx
@@ -6,14 +6,30 @@ import { Button, ProgressBar, Intent } from '@blueprintjs/core';
 import { Tooltip2 as Tooltip } from '@blueprintjs/popover2';
 
 import withRouter from 'app/withRouter';
-import { Collection, ErrorSection, Numeric, Skeleton } from 'components/common';
+import {
+  Collection,
+  ErrorSection,
+  Numeric,
+  Skeleton,
+  RelativeTime,
+} from 'components/common';
 import Screen from 'components/Screen/Screen';
 import Dashboard from 'components/Dashboard/Dashboard';
 import ErrorScreen from 'components/Screen/ErrorScreen';
 import { triggerCollectionCancel, fetchSystemStatus } from 'actions';
 import { selectSystemStatus } from 'selectors';
+import convertUTCDateToLocalDate from 'util/convertUTCDateToLocalDate';
 
 import './SystemStatusScreen.scss';
+
+const dateFormat = {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+  weekday: 'short',
+  hour: 'numeric',
+  minute: 'numeric',
+};
 
 const messages = defineMessages({
   title: {
@@ -100,16 +116,50 @@ export class SystemStatusScreen extends React.Component {
     const active = res.pending + res.running;
     const total = active + res.finished;
     const progress = res.finished / total;
+
+    const startedAt =
+      res.start_time && convertUTCDateToLocalDate(res.start_time);
+    const lastUpdatedAt =
+      res.last_update && convertUTCDateToLocalDate(res.last_update);
+
     return (
       <tr key={collection?.id || 'null'}>
-        <td className="entity">
-          <Collection.Link collection={res.collection} />
-          {!res.collection && (
-            <FormattedMessage
-              id="status.no_collection"
-              defaultMessage="Other tasks"
-            />
-          )}
+        <td>
+          <strong>
+            <Collection.Link collection={res.collection} />
+            {!res.collection && (
+              <FormattedMessage
+                id="status.no_collection"
+                defaultMessage="Other tasks"
+              />
+            )}
+          </strong>
+          <br />
+          <span className="StatusTable__timestamps">
+            {startedAt && (
+              <>
+                <FormattedMessage
+                  id="status.started_at"
+                  defaultMessage="started"
+                />{' '}
+                <span title={intl.formatDate(startedAt, dateFormat)}>
+                  <RelativeTime date={startedAt} />
+                </span>
+              </>
+            )}
+            {lastUpdatedAt && (
+              <>
+                {' · '}
+                <FormattedMessage
+                  id="status.last_updated_at"
+                  defaultMessage="last updated"
+                />{' '}
+                <span title={intl.formatDate(lastUpdatedAt, dateFormat)}>
+                  <RelativeTime date={lastUpdatedAt} />
+                </span>
+              </>
+            )}
+          </span>
         </td>
         <td>
           <ProgressBar value={progress} intent={Intent.PRIMARY} />

--- a/ui/src/screens/SystemStatusScreen/SystemStatusScreen.scss
+++ b/ui/src/screens/SystemStatusScreen/SystemStatusScreen.scss
@@ -13,4 +13,8 @@
   td.text {
     @include rtlSupportInvertedProp(padding, left, 0, null);
   }
+
+  &__timestamps {
+    color: $aleph-greyed-text;
+  }
 }


### PR DESCRIPTION
This exposes the two timestamps (that are already returned per collection by the status API) in the UI. Times are relative (for example "45 seconds ago"), but hovering over them displays the full date/time (for example "Fri, Jun 28, 2024, 5:05 PM").

<img width="1128" alt="Screen Shot 2024-06-28 at 17 06 20" src="https://github.com/alephdata/aleph/assets/1512805/cfe8b5e6-1075-4280-bfb1-76177ab5b090">

**Todos:**

- [x] Figure out if there’s an issue with the start time, possibly related to #3787.