### PR TITLE
Do not allow duplicate role memberships

### DIFF
--- a/aleph/migrate/versions/131674bde902_add_primary_key_constraint_to_role_membership.py
+++ b/aleph/migrate/versions/131674bde902_add_primary_key_constraint_to_role_membership.py
@@ -1,0 +1,22 @@
+"""add primary key constraint to role_membership table
+
+Revision ID: 131674bde902
+Revises: c52a1f469ac7
+Create Date: 2024-07-17 14:37:25.269913
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "131674bde902"
+down_revision = "c52a1f469ac7"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.create_primary_key("role_membership_pkey", "role_membership", ["member_id", "group_id"])
+
+
+def downgrade():
+    pass

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -118,8 +118,11 @@ class Role(db.Model, IdModel, SoftDeleteModel):
 
     def add_role(self, role):
         """Adds an existing role as a membership of a group."""
-        self.roles.append(role)
-        db.session.add(role)
+        if role not in self.roles:
+            self.roles.append(role)
+            db.session.add(role)
+        else:
+            log.warning(f"Tried to add duplicate role membership: {self} {role}")
         db.session.add(self)
         self.updated_at = datetime.utcnow()
 

--- a/aleph/tests/test_sessions_api.py
+++ b/aleph/tests/test_sessions_api.py
@@ -102,7 +102,7 @@ class SessionsApiTestCase(TestCase):
 
 class SessionsApiOAuthTestCase(TestCase):
     def setUp(self):
-        super().setUpClass()
+        super().setUp()
 
         SETTINGS.OAUTH = True
         SETTINGS.OAUTH_HANDLER = "test-oidc"

--- a/aleph/tests/test_sessions_api.py
+++ b/aleph/tests/test_sessions_api.py
@@ -2,6 +2,7 @@ from contextlib import contextmanager
 import unittest.mock as mock
 from urllib.parse import urlparse, parse_qs
 from requests import Response
+from typing import List
 
 from aleph.core import db
 from aleph.settings import SETTINGS
@@ -236,8 +237,8 @@ def mock_oauth_token_exchange(name: str, email: str):
 
         # https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
         parse_mock.return_value = {
-            "name": "John Doe",
-            "email": "john.doe@example.org",
+            "name": name,
+            "email": email,
         }
 
         yield


### PR DESCRIPTION
Aleph users can be part of user groups. Users and groups are both modeled as "roles" in Aleph. To add a user to a group, a row is inserted into the `role_membership` table.

We’ve occasionally had issues with duplicate rows in this table, likely due to a race condition when Aleph handles parallel OAuth requests for the same user (https://github.com/alephdata/aleph/issues/3811#issuecomment-2232953036), but we haven’t been able to reproduce or pinpoint the exact root cause.

The effect of a duplicate role membership is that users are permanently blocked from authenticating until the duplicates are removed.

This PR adds a primary key constraint to the `role_membership` table. While this does not address the root cause of the problem, it prevents duplicates from being inserted into the table. In practice, this means that in rare cases, OAuth requests may fail when the constraint is violated, but users can simply retry the authentication in that case.

***

In addition, I’ve implemented two related changes:

* I have added tests covering the group sync during OAuth authentication as this was previously completely untested.
* I have added logging in case duplicate role memberships are added explicitly. While it’s unlikely this is the root cause of the issue, it’s helpful as it allows excluding this possibility with certainty if we see the issue again.

***

> [!IMPORTANT]  
> This PR contains a migration that adds a primary key constraint to an existing table. The migration will fail if the existing table violates the constraint. It is necessary to manually check and remove whether duplicates exist in this table before applying the migration. See https://github.com/alephdata/aleph/issues/3811#issuecomment-2223355962 for a query that returns duplicates.
