### PR TITLE
Fix user auto-suggest input / do not explicitly exclude group IDs 

### DIFF
--- a/ui/src/dialogs/CollectionAccessDialog/CollectionAccessDialog.jsx
+++ b/ui/src/dialogs/CollectionAccessDialog/CollectionAccessDialog.jsx
@@ -146,10 +146,11 @@ class CollectionAccessDialog extends Component {
       return null;
     }
 
-    const exclude = permissions.map((perm) => perm.role.id);
     const systemRoles = this.filterPermissions('system');
     const groupRoles = this.filterPermissions('group');
     const userRoles = this.filterPermissions('user');
+    const exclude = userRoles.map((perm) => perm.role.id);
+
     return (
       <FormDialog
         processing={blocking}


### PR DESCRIPTION
The reason behind excluding specific IDs is to not suggest users and groups that are already associated with the collection. However, the `/roles/_suggest` endpoint returns only users, never groups, so there is no point in explicitly excluding groups. Fixes #3820.

In case a collection is shared with a large (200+) number of individual users, this may cause the same error as reported in #3820. However, this would require explicitly sharing a collection with such a large number of users whereas #3820 affected any collection, even if it wasn’t shared with anyone. Also, I don’t think there has been a use case for sharing a collection with so many individual users, and probably using groups would be more appropriate in such a situation.

You can verify this by adding yourself to a few user groups:

```
aleph creategroup test1
aleph creategroup test2
aleph creategroup test3
aleph useradd test1 user@example.org
aleph useradd test2 user@example.org
aleph useradd test3 user@example.org
```

* Log out and in to recreate your session.
* Create a new investigation and open the share dialog.
* Open the network tab in the browser developer tools.
* Type something into the auto-suggest input.
* You should be able to see a request to `/roles/_suggest?exclude:id=123&prefix=test` (where `123` is the ID of your user). There shouldn’t be any additional `exclude:id` params.