### PR TITLE
New and updated Prometheus metrics

### DIFF
--- a/aleph/authz.py
+++ b/aleph/authz.py
@@ -26,6 +26,7 @@ class Authz(object):
     def __init__(self, role_id, roles, is_admin=False, token_id=None, expire=None):
         self.id = role_id
         self.logged_in = role_id is not None
+        self.auth_method = None
         self.roles = set(roles)
         self.is_admin = is_admin
         self.token_id = token_id

--- a/aleph/metrics/exporter.py
+++ b/aleph/metrics/exporter.py
@@ -1,7 +1,12 @@
 from prometheus_client import make_wsgi_app, PLATFORM_COLLECTOR
 from prometheus_client.core import CollectorRegistry
 
-from aleph.metrics.collectors import InfoCollector, DatabaseCollector, QueuesCollector
+from aleph.metrics.collectors import (
+    InfoCollector,
+    DatabaseCollector,
+    QueuesCollector,
+    StatisticsCollector,
+)
 
 
 def create_app():
@@ -10,6 +15,7 @@ def create_app():
     registry.register(InfoCollector())
     registry.register(DatabaseCollector())
     registry.register(QueuesCollector())
+    registry.register(StatisticsCollector())
 
     return make_wsgi_app(registry=registry)
 

--- a/aleph/tests/test_entities_api.py
+++ b/aleph/tests/test_entities_api.py
@@ -363,7 +363,7 @@ class EntitiesApiTestCase(TestCase):
             "collection_id": self.col_id,
             "properties": {
                 "name": "Blaaaa blubb",
-                "phone": ["+491769817271", "+491769817999"],
+                "phone": ["+4917698172710", "+4917698179990"],
             },
         }
         resa = self.client.post(
@@ -374,7 +374,7 @@ class EntitiesApiTestCase(TestCase):
             "collection_id": self.col_id,
             "properties": {
                 "name": "Nobody Man",
-                "phone": ["+491769817271", "+491769817777"],
+                "phone": ["+4917698172710", "+4917698177770"],
             },
         }
         resa = self.client.post(
@@ -385,7 +385,7 @@ class EntitiesApiTestCase(TestCase):
         assert res.status_code == 200, (res.status_code, res.json)
         results = res.json["results"]
         assert len(results) == 1, results
-        assert results[0]["value"] == "+491769817271", results
+        assert results[0]["value"] == "+4917698172710", results
         validate(res.json["results"][0], "EntityTag")
 
     def test_undelete(self):

--- a/aleph/views/context.py
+++ b/aleph/views/context.py
@@ -76,11 +76,15 @@ def _get_credential_authz(credential):
     if " " in credential:
         method, credential = credential.split(" ", 1)
         if method == "Token":
-            return Authz.from_token(credential)
+            authz = Authz.from_token(credential)
+            authz.auth_method = "session_token"
+            return authz
 
     role = Role.by_api_key(credential)
     if role is not None:
-        return Authz.from_role(role=role)
+        authz = Authz.from_role(role=role)
+        authz.auth_method = "api_key"
+        return authz
 
 
 def get_authz(request):

--- a/aleph/views/sessions_api.py
+++ b/aleph/views/sessions_api.py
@@ -19,8 +19,8 @@ from aleph.views.util import require, jsonify
 log = logging.getLogger(__name__)
 blueprint = Blueprint("sessions_api", __name__)
 
-AUTH_ATTEMPS = Counter(
-    "aleph_auth_attemps_total",
+AUTH_ATTEMPTS = Counter(
+    "aleph_auth_attempts_total",
     "Total number of successful/failed authentication attemps",
     ["method", "result"],
 )
@@ -65,12 +65,12 @@ def password_login():
     data = parse_request("Login")
     role = Role.login(data.get("email"), data.get("password"))
     if role is None:
-        AUTH_ATTEMPS.labels(method="password", result="failed").inc()
+        AUTH_ATTEMPTS.labels(method="password", result="failed").inc()
         raise BadRequest(gettext("Invalid user or password."))
 
     role.touch()
     db.session.commit()
-    AUTH_ATTEMPS.labels(method="password", result="success").inc()
+    AUTH_ATTEMPTS.labels(method="password", result="success").inc()
     update_role(role)
     authz = Authz.from_role(role)
     return jsonify({"status": "ok", "token": authz.to_token()})
@@ -104,7 +104,7 @@ def oauth_callback():
     err = Unauthorized(gettext("Authentication has failed."))
     state = cache.get_complex(_oauth_session(request.args.get("state")))
     if state is None:
-        AUTH_ATTEMPS.labels(method="oauth", result="failed").inc()
+        AUTH_ATTEMPTS.labels(method="oauth", result="failed").inc()
         raise err
 
     try:
@@ -112,22 +112,22 @@ def oauth_callback():
         uri = state.get("redirect_uri")
         oauth_token = oauth.provider.authorize_access_token(redirect_uri=uri)
     except AuthlibBaseError as err:
-        AUTH_ATTEMPS.labels(method="oauth", result="failed").inc()
+        AUTH_ATTEMPTS.labels(method="oauth", result="failed").inc()
         log.warning("Failed OAuth: %r", err)
         raise err
     if oauth_token is None or isinstance(oauth_token, AuthlibBaseError):
-        AUTH_ATTEMPS.labels(method="oauth", result="failed").inc()
+        AUTH_ATTEMPTS.labels(method="oauth", result="failed").inc()
         log.warning("Failed OAuth: %r", oauth_token)
         raise err
 
     role = handle_oauth(oauth.provider, oauth_token)
     if role is None:
-        AUTH_ATTEMPS.labels(method="oauth", result="failed").inc()
+        AUTH_ATTEMPTS.labels(method="oauth", result="failed").inc()
         raise err
 
     db.session.commit()
     update_role(role)
-    AUTH_ATTEMPS.labels(method="oauth", result="success").inc()
+    AUTH_ATTEMPTS.labels(method="oauth", result="success").inc()
     log.debug("Logged in: %r", role)
     request.authz = Authz.from_role(role)
     token = request.authz.to_token()

--- a/requirements.txt
+++ b/requirements.txt
@@ -45,6 +45,7 @@ factory-boy >=3.2.0, < 4.0.0
 Faker >= 5.6.0, < 26.0.0
 pytest==8.2.0
 pytest-cov==5.0.0
+time-machine==2.14.1
 
 # Development & debugging
 debugpy >= 1.3.0


### PR DESCRIPTION
This PR adds a few new metrics and extends existing metrics based on feedback. I’d recommend taking a look at the individual commits when reviewing this PR.

Corresponding documentation changes are in #3845 because the `release/4.0.0` branch doesn’t yet have the recently updated tech docs from `develop`.

### Users

I’ve added new `active` and `locale` labels to the `aleph_users` metric. This allows querying for the number of active users (e.g. within last 24h, 7d, 30d, …) and the number of users that use a specific UI locale.

```
# Number of all users
aleph_users{active="all"}

# Number of all users using the (default) English localization
aleph_users{locale="en", active="all"}

# Number of monthly active users using the German localization
aleph_users{active="30d", locale="de"}
```

### Collections

Previously, there was a single `aleph_collections` metric that allowed querying for the number of collections by category (e.g. "casefile", "leak", "gazette", …). I have renamed this metric to be consistent with two new metrics that expose the number of collections by country and language.

```
# Number of leaks
aleph_collection_categories{category="leak"}

# Number of datasets or investigations
aleph_collection_categories{type="dataset"}
aleph_collection_categories{type="investigation"}

# Number of datasets or investigations by country
aleph_collection_countries{type="dataset", country="fr"}
aleph_collection_countries{type="investigation", country="fr"}

# Number of datasets or investigations by language
aleph_collection_languages{type="dataset", language="fra"}
aleph_collection_languages{type="investigation", language="fra"}
```

### Entities

I’ve added a new metric to track the number of entities per schema type. This re-uses collection statistics that are pre-computed and cached in Redis, i.e. we do not send any (potentially expensive) ES aggregation queries during metrics collection.

```
# Number of `Person` entities
aleph_entities{schema="Person"}
```
### API HTTP requests

I have added a new label `auth_method` to the `aleph_http_requests_total`. This allows us to query for the number of API requests that used an API key vs. a UI session token.

```
# Number of requests to `/api/2/entities` using an API key
aleph_http_requests_total{api_endpoint="entities.index", auth_method="api_key"}
```
