### PR TITLE
Implements a first try at splitting xref into batches

### DIFF
--- a/aleph/settings.py
+++ b/aleph/settings.py
@@ -188,7 +188,7 @@ class Settings:
         self.ELASTICSEARCH_TLS_CLIENT_KEY = env.get("ELASTICSEARCH_TLS_CLIENT_KEY")
         self.ELASTICSEARCH_TIMEOUT = env.to_int("ELASTICSEARCH_TIMEOUT", 60)
         self.XREF_SCROLL = env.get("ALEPH_XREF_SCROLL", "5m")
-        self.XREF_SCROLL_SIZE = env.get("ALEPH_XREF_SCROLL_SIZE", "1000")
+        self.XREF_SCROLL_SIZE = env.to_int("ALEPH_XREF_SCROLL_SIZE", 1000)
 
         # Number of replicas to maintain. '2' means 3 overall copies.
         self.INDEX_REPLICAS = env.to_int("ALEPH_INDEX_REPLICAS", 0)
@@ -248,6 +248,7 @@ class Settings:
         self.STAGE_ANALYZE = "analyze"
         self.STAGE_INDEX = "index"
         self.STAGE_XREF = "xref"
+        self.STAGE_XREF_BATCH = "xref_batch"
         self.STAGE_REINGEST = "reingest"
         self.STAGE_REINDEX = "reindex"
         self.STAGE_LOAD_MAPPING = "loadmapping"
@@ -262,6 +263,7 @@ class Settings:
             [
                 self.STAGE_INDEX,
                 self.STAGE_XREF,
+                self.STAGE_XREF_BATCH,
                 self.STAGE_REINGEST,
                 self.STAGE_REINDEX,
                 self.STAGE_LOAD_MAPPING,

--- a/aleph/worker.py
+++ b/aleph/worker.py
@@ -23,7 +23,7 @@ from aleph.logic.notifications import generate_digest, delete_old_notifications
 from aleph.logic.roles import update_roles
 from aleph.logic.export import delete_expired_exports, export_entities
 from aleph.logic.processing import index_many
-from aleph.logic.xref import xref_collection, export_matches
+from aleph.logic.xref import xref_collection, export_matches, process_xref_batch
 from aleph.logic.entities import update_entity, prune_entity
 from aleph.logic.mapping import load_mapping, flush_mapping
 
@@ -90,6 +90,9 @@ def op_flush_mapping(collection, task):
 OPERATIONS: Dict[str, Callable] = {
     SETTINGS.STAGE_INDEX: op_index,
     SETTINGS.STAGE_XREF: lambda c, _: xref_collection(c),
+    SETTINGS.STAGE_XREF_BATCH: lambda c, t: process_xref_batch(
+        c, t.payload.get("entity_ids")
+    ),
     SETTINGS.STAGE_REINGEST: op_reingest,
     SETTINGS.STAGE_REINDEX: op_reindex,
     SETTINGS.STAGE_LOAD_MAPPING: lambda c, t: load_mapping(c, **t.payload),


### PR DESCRIPTION
- Changes the type of the XREF_SCROLL_SIZE setting to integer.
- Adds new setting for STAGE_XREF_BATCH
- Adds above setting to Worker
- Modifies xref_collection method to enqueue in batches determined by scroll size setting

> Note: I think I have made a mistake in accidentally removing a line, I added a TODO in the code. I have to quickly test things when I put it back, as I cannot guarantee things will remain in a working state if I put it back blindly now. However, I would love some feedback to understand if I am on the right track with all this :)