### PR TITLE
Fix active users metric

### DIFF
--- a/aleph/metrics/collectors.py
+++ b/aleph/metrics/collectors.py
@@ -72,7 +72,7 @@ class DatabaseCollector(Collector):
 
             if delta:
                 limit = now - delta
-                query = query.filter(Role.updated_at >= limit)
+                query = query.filter(Role.last_login_at >= limit)
             else:
                 label = "all"
 

--- a/aleph/migrate/versions/8adf50aadcb0_add_last_login_at_column.py
+++ b/aleph/migrate/versions/8adf50aadcb0_add_last_login_at_column.py
@@ -1,0 +1,22 @@
+"""Add last_login_at column
+
+Revision ID: 8adf50aadcb0
+Revises: c52a1f469ac7
+Create Date: 2024-08-16 13:01:45.366058
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "8adf50aadcb0"
+down_revision = "c52a1f469ac7"
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column("role", sa.Column("last_login_at", sa.DateTime(), nullable=True))
+
+
+def downgrade():
+    op.drop_column("role", "last_login_at")

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -52,6 +52,7 @@ class Role(db.Model, IdModel, SoftDeleteModel):
     password = None
     reset_token = db.Column(db.Unicode, nullable=True)
     locale = db.Column(db.Unicode, nullable=True)
+    last_login_at = db.Column(db.DateTime, nullable=True)
 
     permissions = db.relationship("Permission", backref="role")
 

--- a/aleph/tests/test_metrics.py
+++ b/aleph/tests/test_metrics.py
@@ -52,18 +52,18 @@ class MetricsTestCase(TestCase):
         users = list(Role.all_users())
         assert users[0].foreign_id == "system:aleph"
 
-        with time_machine.travel("2100-01-01T00:00:00Z"):
-            user_1 = self.create_user(foreign_id="user_1")
-            db.session.add(user_1)
-            db.session.commit()
+        user_1 = self.create_user(foreign_id="user_1")
+        user_1.last_login_at = "2024-01-01T00:00:00Z"
+        db.session.add(user_1)
+        db.session.commit()
 
-        with time_machine.travel("2100-01-08T00:00:00Z"):
-            user_2 = self.create_user(foreign_id="user_2")
-            user_2.locale = "de"
-            db.session.add(user_2)
-            db.session.commit()
+        user_2 = self.create_user(foreign_id="user_2")
+        user_2.last_login_at = "2024-01-08T00:00:00Z"
+        user_2.locale = "de"
+        db.session.add(user_2)
+        db.session.commit()
 
-        with time_machine.travel("2100-01-08T12:00:00Z"):
+        with time_machine.travel("2024-01-08T12:00:00Z"):
             reg.collect()
 
             de = reg.get_sample_value("aleph_users", {"active": "24h", "locale": "de"})

--- a/aleph/views/sessions_api.py
+++ b/aleph/views/sessions_api.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 from urllib.parse import urlencode
 from flask_babel import gettext
@@ -68,6 +69,7 @@ def password_login():
         AUTH_ATTEMPTS.labels(method="password", result="failed").inc()
         raise BadRequest(gettext("Invalid user or password."))
 
+    role.last_login_at = datetime.datetime.now(datetime.timezone.utc)
     role.touch()
     db.session.commit()
     AUTH_ATTEMPTS.labels(method="password", result="success").inc()
@@ -125,6 +127,7 @@ def oauth_callback():
         AUTH_ATTEMPTS.labels(method="oauth", result="failed").inc()
         raise err
 
+    role.last_login_at = datetime.datetime.now(datetime.timezone.utc)
     db.session.commit()
     update_role(role)
     AUTH_ATTEMPTS.labels(method="oauth", result="success").inc()


### PR DESCRIPTION
When implementing the active users metric (#3844), I noticed that Aleph currently updates the `role.updated_at` column every time a user logs in – so I took the shortcut and simply used that to count the number of users that logged in at least once within a specific period of time. But it turns out that `updated_at` is only updated on login when using password auth. It isn’t updated when signing in via OAuth, and consequently the active users metric is incorrect when OAuth is used for authentication.

I’m fixing this by adding a separate timestamp column that stores when a user last logged in. It’s probably a good idea to make the intent clear (Just reading the name updated_at, most people probably wouldn’t expect that timestamp to be set every time a user logs in.)

Note: This currently doesn’t include a test for the expected behavior when logging in via OAuth. There have been lots of changes to authentication testing on the `develop` branch that are not present in `release/4.0.0`, so any changes would lead to annoying merge conflicts later on. I have created a follow-up task to add a separate test for OAuth logins once the 4.0.0 release is out. You can manually test the behavior by [configuring your development environment to use an OAuth provider](https://docs.aleph.occrp.org/developers/how-to/development/identity-provider/).