### PR TITLE
Implement infinite scrolling for document search

### DIFF
--- a/ui/src/viewers/PdfViewerSearch.jsx
+++ b/ui/src/viewers/PdfViewerSearch.jsx
@@ -48,7 +48,7 @@ class PdfViewerSearch extends Component {
   }
 
   render() {
-    const { page, dir, result } = this.props;
+    const { result } = this.props;
 
     if (result.total === undefined) {
       return <SectionLoading />;
@@ -56,47 +56,55 @@ class PdfViewerSearch extends Component {
 
     return (
       <div className="pages">
-        {result.total === 0 && (
-          <>
-            <div
-              className={c(
-                Classes.CALLOUT,
-                Classes.INTENT_WARNING,
-                `${Classes.ICON}-search`
-              )}
-            >
-              <FormattedMessage
-                id="document.search.no_match"
-                defaultMessage="No single page within this document matches all your search terms."
-              />
-            </div>
-            {this.props.children}
-          </>
+        {result.total === 0 ? this.renderEmptyState() : this.renderResults()}
+      </div>
+    );
+  }
+
+  renderResults() {
+    const { page, dir, result } = this.props;
+
+    return (
+      <ul>
+        {result.results.map((res) => (
+          <li key={`page-${res.id}`}>
+            <p dir={dir}>
+              <Link
+                to={this.getResultLink(res)}
+                className={classNames({ active: page === res.index })}
+              >
+                <span
+                  className={c(Classes.ICON, `${Classes.ICON}-document`)}
+                />
+                <FormattedMessage
+                  id="document.pdf.search.page"
+                  defaultMessage="Page {page}"
+                  values={{
+                    page: res.getProperty('index'),
+                  }}
+                />
+              </Link>
+            </p>
+            <SearchHighlight highlight={res.highlight} />
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
+  renderEmptyState() {
+    return (
+      <div
+        className={c(
+          Classes.CALLOUT,
+          Classes.INTENT_WARNING,
+          `${Classes.ICON}-search`
         )}
-        <ul>
-          {result.results.map((res) => (
-            <li key={`page-${res.id}`}>
-              <p dir={dir}>
-                <Link
-                  to={this.getResultLink(res)}
-                  className={classNames({ active: page === res.index })}
-                >
-                  <span
-                    className={c(Classes.ICON, `${Classes.ICON}-document`)}
-                  />
-                  <FormattedMessage
-                    id="document.pdf.search.page"
-                    defaultMessage="Page {page}"
-                    values={{
-                      page: res.getProperty('index'),
-                    }}
-                  />
-                </Link>
-              </p>
-              <SearchHighlight highlight={res.highlight} />
-            </li>
-          ))}
-        </ul>
+      >
+        <FormattedMessage
+          id="document.search.no_match"
+          defaultMessage="No single page within this document matches all your search terms."
+        />
       </div>
     );
   }

--- a/ui/src/viewers/PdfViewerSearch.jsx
+++ b/ui/src/viewers/PdfViewerSearch.jsx
@@ -17,13 +17,13 @@ class PdfViewerSearch extends Component {
   }
 
   componentDidMount() {
-    this.fetchPage();
+    this.fetchSearchResults();
   }
 
   componentDidUpdate(prevProps) {
     const { query } = this.props;
     if (!query.sameAs(prevProps.query)) {
-      this.fetchPage();
+      this.fetchSearchResults();
     }
   }
 
@@ -40,7 +40,7 @@ class PdfViewerSearch extends Component {
     return `#${queryString.stringify(hashQuery)}`;
   }
 
-  fetchPage() {
+  fetchSearchResults() {
     const { query, result } = this.props;
     if (!!query.getString('q') && result.shouldLoad) {
       this.props.queryEntities({ query });

--- a/ui/src/viewers/PdfViewerSearch.jsx
+++ b/ui/src/viewers/PdfViewerSearch.jsx
@@ -4,7 +4,11 @@ import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
 import { connect } from 'react-redux';
 import queryString from 'query-string';
-import { SectionLoading, SearchHighlight } from 'components/common';
+import {
+  SectionLoading,
+  SearchHighlight,
+  QueryInfiniteLoad,
+} from 'components/common';
 import { Classes } from '@blueprintjs/core';
 import c from 'classnames';
 import { queryEntities } from 'actions';
@@ -62,33 +66,40 @@ class PdfViewerSearch extends Component {
   }
 
   renderResults() {
-    const { page, dir, result } = this.props;
+    const { page, dir, result, query } = this.props;
 
     return (
-      <ul>
-        {result.results.map((res) => (
-          <li key={`page-${res.id}`}>
-            <p dir={dir}>
-              <Link
-                to={this.getResultLink(res)}
-                className={classNames({ active: page === res.index })}
-              >
-                <span
-                  className={c(Classes.ICON, `${Classes.ICON}-document`)}
-                />
-                <FormattedMessage
-                  id="document.pdf.search.page"
-                  defaultMessage="Page {page}"
-                  values={{
-                    page: res.getProperty('index'),
-                  }}
-                />
-              </Link>
-            </p>
-            <SearchHighlight highlight={res.highlight} />
-          </li>
-        ))}
-      </ul>
+      <>
+        <ul>
+          {result.results.map((res) => (
+            <li key={`page-${res.id}`}>
+              <p dir={dir}>
+                <Link
+                  to={this.getResultLink(res)}
+                  className={classNames({ active: page === res.index })}
+                >
+                  <span
+                    className={c(Classes.ICON, `${Classes.ICON}-document`)}
+                  />
+                  <FormattedMessage
+                    id="document.pdf.search.page"
+                    defaultMessage="Page {page}"
+                    values={{
+                      page: res.getProperty('index'),
+                    }}
+                  />
+                </Link>
+              </p>
+              <SearchHighlight highlight={res.highlight} />
+            </li>
+          ))}
+        </ul>
+        <QueryInfiniteLoad
+          query={query}
+          result={result}
+          fetch={queryEntities}
+        />
+      </>
     );
   }
 

--- a/ui/src/viewers/PdfViewerSearch.jsx
+++ b/ui/src/viewers/PdfViewerSearch.jsx
@@ -66,7 +66,7 @@ class PdfViewerSearch extends Component {
   }
 
   renderResults() {
-    const { page, dir, result, query } = this.props;
+    const { dir, result, query } = this.props;
 
     return (
       <>
@@ -74,10 +74,7 @@ class PdfViewerSearch extends Component {
           {result.results.map((res) => (
             <li key={`page-${res.id}`}>
               <p dir={dir}>
-                <Link
-                  to={this.getResultLink(res)}
-                  className={classNames({ active: page === res.index })}
-                >
+                <Link to={this.getResultLink(res)}>
                   <span
                     className={c(Classes.ICON, `${Classes.ICON}-document`)}
                   />


### PR DESCRIPTION
When searching a large document in a dataset which has a significant number of results, only the first set of results are shown.

I’ve fixed this by implementing infinite scrolling in the same way we already implement this for other views (such as the main search view). Now, when a user has scrolled to the end of the search results list and if there are more results, the next page of results is automatically loaded.

In addition, I’ve used the opportunity to do some cleanup and remove dead code from the component responsible for displaying document search results.