### PR TITLE
Fix edge cases in custom metrics

### DIFF
--- a/aleph/metrics/collectors.py
+++ b/aleph/metrics/collectors.py
@@ -126,7 +126,8 @@ class DatabaseCollector(Collector):
         )
 
         for country, type_, count in query:
-            gauge.add_metric([country, type_], count)
+            if country is not None:
+                gauge.add_metric([country, type_], count)
 
         return gauge
 
@@ -149,7 +150,8 @@ class DatabaseCollector(Collector):
         )
 
         for lang, type_, count in query:
-            gauge.add_metric([lang, type_], count)
+            if lang is not None:
+                gauge.add_metric([lang, type_], count)
 
         return gauge
 


### PR DESCRIPTION
This bug occurred due to a combination of two edge cases:

1. The Python Prometheus client does allow `None` as a label value, except when implementing a custom collector[1] which we are doing in this case. If you try to use `None` as a label value when implementing a custom collector, everything will work fine just until the metrics are actually exposed (for example when Prometheus sends a request to the `/metrics` endpoint) which will raise an unhandled exception.

2. In Aleph, every collection can be assigned zero or more countries and languages. These are stored as array columns in Postgres. For example, if a collection contains data about Germany and Luxembourg, that would be stored as `{de,lu}`. However, in real-life, we also have a few collections with `{NULL}` (instead of just an empty array `{}`). The same is the case for languages.

That means we were trying to expose Prometheus metrics such as `aleph_collection_countries{country=None}` which fails due to 1). I’m not entirely sure why we have `{NULL}` values, but this seems to affect only collections that have been created quite some time ago, so it might be due to a bug in a previous version of Aleph.

I’ve adjusted the test cases to ensure that we try to expose the collected metrics in the Prometheus plaintext format (in the same way it would be done in production when requesting the `/metrics` endpoint) and fixed the metrics collector to ignore `NULL` values in the `countries` and `languages` columns.

[1]: https://github.com/prometheus/client_python/issues/270