### PR TITLE
Fix ES index upgrades when using index aliases

### DIFF
--- a/aleph/index/util.py
+++ b/aleph/index/util.py
@@ -289,7 +289,27 @@ def configure_index(index, mapping, settings):
             "timeout": MAX_TIMEOUT,
             "master_timeout": MAX_TIMEOUT,
         }
-        config = es.indices.get(index=index).get(index, {})
+        res = es.indices.get(index=index)
+
+        if len(res) == 0:
+            # This case should never occur.
+            raise AlephOperationalException(
+                f"ES response does not contain data for index {index}"
+            )
+
+        if len(res) > 1:
+            # This case should never occur.
+            log.error("ES response", res=res)
+            raise AlephOperationalException(
+                "ES response is ambiguous, contains data for multple indices"
+            )
+
+        # The ES response is an object with items for every requested index. As we only request
+        # a single index, we extract the first and only item from the response. We cannot simply
+        # extract the response data using the index name as the name we use to request the index
+        # may be an alias whereas the response will always contain the actual un-aliased name.
+        config = list(res.values())[0]
+
         settings.get("index").pop("number_of_shards")
         log.info(
             f"[{index}] Current settings.", index=index, settings=config.get("settings")


### PR DESCRIPTION
ES supports fetching the index config for multiple indices in a single request. We don’t make use of this, but for this reason the ES responses are an object with a key for each requested index. For example:

```json
{
  "aleph-entity-company-v1": {
    "settings": { ... },
    "mappings: { ... }
  }
}
```

In case an index is requested using an alias, the key will be the original index name and *not* the alias, i.e. we cannot rely on the key being the name that was used to request the index, as this would fail in case aliases are used.

However, as we’re always requesting only a single index at a time, the response should always contain data for one index, so we can extract that without relying on the name of the index.