### PR TITLE
Allow sharing of investigations

### DIFF
--- a/aleph/tests/test_permissions_api.py
+++ b/aleph/tests/test_permissions_api.py
@@ -1,0 +1,103 @@
+from aleph.tests.util import TestCase
+from aleph.logic.roles import create_group
+
+
+class PermissionsApiTestCase(TestCase):
+    def setUp(self):
+        super().setUp()
+        self.role, self.headers = self.login(
+            foreign_id="john",
+            name="John Doe",
+            email="john.doe@example.org",
+        )
+        self.col = self.create_collection(creator=self.role)
+
+    def test_update(self):
+        jane = self.create_user(
+            foreign_id="jane",
+            name="Jane Doe",
+            email="jane.doe@example.org",
+        )
+
+        url = f"/api/2/collections/{self.col.id}/permissions"
+        res = self.client.get(url, headers=self.headers)
+        assert len(res.json["results"]) == 1
+        assert res.json["results"][0]["role"]["id"] == str(self.role.id)
+
+        # Granting a new user access without providing their full email address is ignored
+        data = [
+            {"role_id": str(self.role.id), "read": True, "write": True},
+            {"role_id": str(jane.id), "read": True, "write": False},
+        ]
+        res = self.client.put(url, headers=self.headers, json=data)
+        assert res.status_code == 200
+        assert len(res.json["results"]) == 1
+        assert res.json["results"][0]["role"]["id"] == str(self.role.id)
+
+        # Granting a new user accces with an incorrect email address is ignored
+        data = [
+            {
+                "role_id": str(self.role.id),
+                "read": True,
+                "write": True,
+            },
+            {
+                "role_id": str(jane.id),
+                "email": "thisisnotjane@example.org",
+                "read": True,
+                "write": False,
+            },
+        ]
+        res = self.client.put(url, headers=self.headers, json=data)
+        assert res.status_code == 200
+        assert len(res.json["results"]) == 1
+        assert res.json["results"][0]["role"]["id"] == str(self.role.id)
+
+        # Granting a new user access updates permissions if full email address is provided
+        data = [
+            {
+                "role_id": str(self.role.id),
+                "read": True,
+                "write": False,
+            },
+            {
+                "role_id": str(jane.id),
+                "email": "jane.doe@example.org",
+                "read": True,
+                "write": False,
+            },
+        ]
+        res = self.client.put(url, headers=self.headers, json=data)
+        assert res.status_code == 200
+        assert len(res.json["results"]) == 2
+        assert res.json["results"][0]["role"]["id"] == str(self.role.id)
+        assert res.json["results"][1]["role"]["id"] == str(jane.id)
+        assert res.json["results"][1]["read"] is True
+        assert res.json["results"][1]["write"] is False
+
+    def test_update_groups(self):
+        group = create_group("group")
+
+        url = f"/api/2/collections/{self.col.id}/permissions"
+        res = self.client.get(url, headers=self.headers)
+        assert len(res.json["results"]) == 1
+        assert res.json["results"][0]["role"]["id"] == str(self.role.id)
+
+        # Updated permissions for a group the user is not a member of are ignored
+        data = [
+            {"role_id": str(self.role.id), "read": True, "write": True},
+            {"role_id": str(group.id), "read": True, "write": False},
+        ]
+        res = self.client.put(url, headers=self.headers, json=data)
+        assert res.status_code == 200
+        assert len(res.json["results"]) == 1
+        assert res.json["results"][0]["role"]["id"] == str(self.role.id)
+
+        self.role.add_role(group)
+        res = self.client.put(url, headers=self.headers, json=data)
+        assert res.status_code == 200
+        assert len(res.json["results"]) == 2
+        assert res.json["results"][0]["role"]["id"] == str(self.role.id)
+        assert res.json["results"][1]["role"]["id"] == str(group.id)
+        assert res.json["results"][1]["read"] is True
+        assert res.json["results"][1]["write"] is False

--- a/aleph/tests/test_roles_api.py
+++ b/aleph/tests/test_roles_api.py
@@ -20,7 +20,7 @@ class RolesApiTestCase(TestCase):
         _, headers = self.login(is_admin=True)
         res = self.client.get("/api/2/roles/_suggest?prefix=user", headers=headers)
         assert res.status_code == 200, res
-        assert res.json["total"] == 0, res.json
+        assert res.json["total"] >= 3, res.json
 
     def test_view(self):
         res = self.client.get("/api/2/roles/%s" % self.rolex)

--- a/aleph/validation/schema/permission.yml
+++ b/aleph/validation/schema/permission.yml
@@ -20,6 +20,8 @@ PermissionUpdate:
       type: boolean
     role_id:
       type: string
+    email:
+      type: string
     role:
       $ref: "#/components/schemas/Role"
 

--- a/aleph/views/permissions_api.py
+++ b/aleph/views/permissions_api.py
@@ -117,14 +117,27 @@ def update(collection_id):
       - Collection
     """
     collection = get_db_collection(collection_id, request.authz.WRITE)
+    current = Permission.all().where(Permission.collection_id == collection.id)
+    current = [permission.role_id for permission in current]
+
     for permission in parse_request("PermissionUpdateList"):
         role_obj = ensure_dict(permission.get("role"))
         role_id = permission.get("role_id", role_obj.get("id"))
         role = Role.by_id(role_id)
+
         if not check_visible(role, request.authz):
             continue
+
+        if (
+            role.type == Role.USER
+            and role.id not in current
+            and (not permission.get("email") or role.email != permission.get("email"))
+        ):
+            continue
+
         if role.is_public:
             permission["write"] = False
+
         if collection.casefile and role.is_public:
             permission["read"] = False
 
@@ -135,6 +148,7 @@ def update(collection_id):
             permission["write"],
             editor_id=request.authz.id,
         )
+
     collection.updated_at = datetime.utcnow()
     update_collection(collection)
     db.session.commit()

--- a/aleph/views/roles_api.py
+++ b/aleph/views/roles_api.py
@@ -55,7 +55,7 @@ def suggest():
     """
     require(request.authz.logged_in)
     parser = QueryParser(request.args, request.authz, limit=10)
-    if parser.prefix is None or len(parser.prefix) < 3:
+    if parser.prefix is None or len(parser.prefix) < 6:
         # Do not return 400 because it's a routine event.
         return jsonify(
             {

--- a/aleph/views/roles_api.py
+++ b/aleph/views/roles_api.py
@@ -4,6 +4,7 @@ from flask_babel import gettext
 from flask import Blueprint, request
 from itsdangerous import BadSignature
 from werkzeug.exceptions import BadRequest
+from sqlalchemy import func
 
 from aleph.core import db
 from aleph.authz import Authz
@@ -66,8 +67,12 @@ def suggest():
         )
     # this only returns users, not groups
     exclude = ensure_list(parser.excludes.get("id"))
-    q = Role.by_prefix(parser.prefix, exclude=exclude)
-    result = DatabaseQueryResult(request, q, parser=parser)
+    query = (
+        Role.all_users()
+        .where(Role.id.not_in(exclude))
+        .where(func.lower(Role.email) == parser.prefix.lower())
+    )
+    result = DatabaseQueryResult(request, query, parser=parser)
     return RoleSerializer.jsonify_result(result)
 
 

--- a/aleph/views/roles_api.py
+++ b/aleph/views/roles_api.py
@@ -1,4 +1,5 @@
 import logging
+from banal import ensure_list
 from flask_babel import gettext
 from flask import Blueprint, request
 from itsdangerous import BadSignature
@@ -6,6 +7,7 @@ from werkzeug.exceptions import BadRequest
 
 from aleph.core import db
 from aleph.authz import Authz
+from aleph.search import QueryParser, DatabaseQueryResult
 from aleph.model import Role
 from aleph.logic.roles import challenge_role, update_role, create_user, get_deep_role
 from aleph.util import is_auto_admin
@@ -51,12 +53,22 @@ def suggest():
       - Role
     """
     require(request.authz.logged_in)
-    return jsonify(
-        {
-            "results": [],
-            "total": 0,
-        }
-    )
+    parser = QueryParser(request.args, request.authz, limit=10)
+    if parser.prefix is None or len(parser.prefix) < 3:
+        # Do not return 400 because it's a routine event.
+        return jsonify(
+            {
+                "status": "error",
+                "message": gettext("prefix filter is too short"),
+                "results": [],
+                "total": 0,
+            }
+        )
+    # this only returns users, not groups
+    exclude = ensure_list(parser.excludes.get("id"))
+    q = Role.by_prefix(parser.prefix, exclude=exclude)
+    result = DatabaseQueryResult(request, q, parser=parser)
+    return RoleSerializer.jsonify_result(result)
 
 
 @blueprint.route("/api/2/roles/code", methods=["POST"])

--- a/ui/src/components/common/Role.jsx
+++ b/ui/src/components/common/Role.jsx
@@ -16,6 +16,10 @@ const messages = defineMessages({
     id: 'role.select.user',
     defaultMessage: 'Choose a user',
   },
+  placeholder: {
+    id: 'role.select.placeholder',
+    defaultMessage: 'Enter email address…',
+  },
 });
 
 class RoleLabel extends PureComponent {
@@ -94,13 +98,14 @@ class Select extends Component {
     const { exclude = [] } = this.props;
     const roles = await this.props.suggestRoles(query, exclude);
     this.setState({
+      query,
       suggested: roles.results,
     });
   }
 
   onSelectRole(role, event) {
     event.stopPropagation();
-    this.props.onSelect(role);
+    this.props.onSelect(role, this.state.query);
   }
 
   renderRole = (role, { handleClick, modifiers }) => (
@@ -130,6 +135,7 @@ class Select extends Component {
         }}
         inputProps={{
           fill: true,
+          placeholder: intl.formatMessage(messages.placeholder),
         }}
         activeItem={role}
         filterable={!isFixed}

--- a/ui/src/dialogs/CollectionAccessDialog/CollectionAccessDialog.jsx
+++ b/ui/src/dialogs/CollectionAccessDialog/CollectionAccessDialog.jsx
@@ -88,9 +88,9 @@ class CollectionAccessDialog extends Component {
     }
   }
 
-  onAddRole(role) {
+  onAddRole(role, query) {
     const { permissions } = this.state;
-    permissions.push({ role, read: true, write: false });
+    permissions.push({ role, email: query, read: true, write: false });
     this.setState({ permissions });
   }
 

--- a/ui/src/dialogs/CollectionAccessDialog/CollectionAccessDialog.jsx
+++ b/ui/src/dialogs/CollectionAccessDialog/CollectionAccessDialog.jsx
@@ -1,5 +1,5 @@
 import React, { Component, PureComponent } from 'react';
-import { Button, Classes, Checkbox, Intent } from '@blueprintjs/core';
+import { Button, Classes, Callout, Checkbox, Intent } from '@blueprintjs/core';
 import { defineMessages, FormattedMessage, injectIntl } from 'react-intl';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -149,6 +149,7 @@ class CollectionAccessDialog extends Component {
     const systemRoles = this.filterPermissions('system');
     const groupRoles = this.filterPermissions('group');
     const userRoles = this.filterPermissions('user');
+    const exclude = userRoles.map((perm) => perm.role.id);
 
     return (
       <FormDialog
@@ -222,6 +223,17 @@ class CollectionAccessDialog extends Component {
                     onToggle={this.onToggle}
                   />
                 ))}
+                <tr key="add">
+                  <td colSpan="3">
+                    <Role.Select onSelect={this.onAddRole} exclude={exclude} />
+                    <Callout intent={Intent.WARNING}>
+                      <FormattedMessage
+                        id="collection.edit.permissions_warning"
+                        defaultMessage="Note: User must already have an Aleph account in order to receive access."
+                      />
+                    </Callout>
+                  </td>
+                </tr>
               </tbody>
             </table>
           </div>


### PR DESCRIPTION
This enables sharing of investigations with individual users by providing their full email address. Main changes are in 7cced50eaa0ff09eca17dba5c977c9b6814ac6c7.

If you want to manually test cases including OAuth user groups, you can set up Keycloak in your development environment like this: https://docs.aleph.occrp.org/developers/how-to/development/identity-provider/