### PR TITLE
Multiple small UX enhancements related to investigation sharing/user suggestion component

### DIFF
--- a/aleph/tests/test_permissions_api.py
+++ b/aleph/tests/test_permissions_api.py
@@ -62,7 +62,7 @@ class PermissionsApiTestCase(TestCase):
             },
             {
                 "role_id": str(jane.id),
-                "email": "jane.doe@example.org",
+                "email": "JANE.DOE@EXAMPLE.ORG",  # email is normalized
                 "read": True,
                 "write": False,
             },

--- a/aleph/views/permissions_api.py
+++ b/aleph/views/permissions_api.py
@@ -131,7 +131,10 @@ def update(collection_id):
         if (
             role.type == Role.USER
             and role.id not in current
-            and (not permission.get("email") or role.email != permission.get("email"))
+            and (
+                not permission.get("email")
+                or role.email.lower() != permission.get("email", "").lower()
+            )
         ):
             continue
 

--- a/ui/src/components/common/Role.jsx
+++ b/ui/src/components/common/Role.jsx
@@ -92,7 +92,7 @@ class Select extends Component {
 
   async onSuggest(query) {
     const { isFixed } = this.state;
-    if (isFixed || query.length <= 3) {
+    if (isFixed || query.length < 6) {
       return;
     }
     const { exclude = [] } = this.props;

--- a/ui/src/components/common/Role.jsx
+++ b/ui/src/components/common/Role.jsx
@@ -91,8 +91,16 @@ class Select extends Component {
   }
 
   async onSuggest(query) {
+    this.setState({ query });
+
     const { isFixed } = this.state;
     if (isFixed) {
+      return;
+    }
+
+    if (this.state.query === query) {
+      // Prevent loading suggestions if the query hasn't changed.
+      // See https://github.com/palantir/blueprint/issues/2983
       return;
     }
 

--- a/ui/src/components/common/Role.jsx
+++ b/ui/src/components/common/Role.jsx
@@ -145,6 +145,7 @@ class Select extends Component {
           fill: true,
         }}
         inputProps={{
+          type: 'email',
           fill: true,
           placeholder: intl.formatMessage(messages.placeholder),
         }}

--- a/ui/src/components/common/Role.jsx
+++ b/ui/src/components/common/Role.jsx
@@ -92,15 +92,18 @@ class Select extends Component {
 
   async onSuggest(query) {
     const { isFixed } = this.state;
-    if (isFixed || query.length < 6) {
+    if (isFixed) {
       return;
     }
+
+    if (query.length < 6) {
+      this.setState({ suggested: [] });
+      return;
+    }
+
     const { exclude = [] } = this.props;
     const roles = await this.props.suggestRoles(query, exclude);
-    this.setState({
-      query,
-      suggested: roles.results,
-    });
+    this.setState({ suggested: roles.results });
   }
 
   onSelectRole(role, event) {


### PR DESCRIPTION
This PR fixes a few small UX bugs related to investigation sharing and user suggestions:

* Previously, when clearing the input field for user suggestions, the old suggestions for the previous value were still displayed.
* Email addresses weren’t properly normalized, so ` john.doe@example.org` (leading whitespace) or `JOHN.DOE@example.org` wouldn’t match `john.doe@example.org`.
* Due to a bug in the underlying Blueprint component library, we were sending duplicate calls to the suggestions API endpoint on every keystroke.