### PR TITLE
feat: Optimize helm templates to expose multiple secret values as env variables

### DIFF
--- a/helm/charts/aleph/templates/aleph-upgrade-job.yaml
+++ b/helm/charts/aleph/templates/aleph-upgrade-job.yaml
@@ -44,6 +44,9 @@ spec:
             {{- toYaml .Values.upgrade.containerSecurityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.upgrade.containerResources | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: aleph-secrets
           env:
             {{- range $key, $value := .Values.global.commonEnv }}
             - name: {{ $key }}
@@ -57,53 +60,9 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            - name: ALEPH_DATABASE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_DATABASE_URI
-            - name: ALEPH_OAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_OAUTH_SECRET
-            - name: ALEPH_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_SECRET_KEY
-            - name: FTM_STORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: FTM_STORE_URI
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: RABBITMQ_PASSWORD
-                  optional: true
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: SENTRY_DSN
-                  optional: true
             {{ if .Values.global.google }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/service-account.json
-            {{ end }}
-            {{ if .Values.global.amazon }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_ACCESS_KEY_ID
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_SECRET_ACCESS_KEY
             {{ end }}
       volumes:
         {{ if .Values.global.google }}

--- a/helm/charts/aleph/templates/api.yaml
+++ b/helm/charts/aleph/templates/api.yaml
@@ -56,6 +56,9 @@ spec:
             {{- toYaml .Values.api.containerSecurityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.api.containerResources | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: aleph-secrets
           env:
             {{- range $key, $value := .Values.global.commonEnv }}
             - name: {{ $key }}
@@ -69,53 +72,9 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            - name: ALEPH_DATABASE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_DATABASE_URI
-            - name: ALEPH_OAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_OAUTH_SECRET
-            - name: ALEPH_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_SECRET_KEY
-            - name: FTM_STORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: FTM_STORE_URI
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: RABBITMQ_PASSWORD
-                  optional: true
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: SENTRY_DSN
-                  optional: true
             {{ if .Values.global.google }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/service-account.json
-            {{ end }}
-            {{ if .Values.global.amazon }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_ACCESS_KEY_ID
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_SECRET_ACCESS_KEY
             {{ end }}
             {{ if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_ENABLED

--- a/helm/charts/aleph/templates/exporter.yaml
+++ b/helm/charts/aleph/templates/exporter.yaml
@@ -39,6 +39,9 @@ spec:
             {{- toYaml .Values.exporter.containerSecurityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.exporter.containerResources | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: aleph-secrets
           env:
             {{- range $key, $value := .Values.global.commonEnv }}
             - name: {{ $key }}
@@ -48,21 +51,6 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            - name: ALEPH_DATABASE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_DATABASE_URI
-            - name: ALEPH_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_SECRET_KEY
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: SENTRY_DSN
           readinessProbe:
             httpGet:
               path: /metrics

--- a/helm/charts/aleph/templates/ingest-file.yaml
+++ b/helm/charts/aleph/templates/ingest-file.yaml
@@ -40,6 +40,9 @@ spec:
             {{- toYaml .Values.ingestfile.containerSecurityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.ingestfile.containerResources | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: aleph-secrets
           env:
             {{- range $key, $value := .Values.global.commonEnv }}
             - name: {{ $key }}
@@ -49,38 +52,9 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            - name: FTM_STORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: FTM_STORE_URI
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: RABBITMQ_PASSWORD
-                  optional: true
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: SENTRY_DSN
-                  optional: true
             {{ if .Values.global.google }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/service-account.json
-            {{ end }}
-            {{ if .Values.global.amazon }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_ACCESS_KEY_ID
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_SECRET_ACCESS_KEY
             {{ end }}
             {{ if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_ENABLED

--- a/helm/charts/aleph/templates/worker-index.yaml
+++ b/helm/charts/aleph/templates/worker-index.yaml
@@ -38,6 +38,9 @@ spec:
             {{- toYaml .Values.workerindex.containerSecurityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.workerindex.containerResources | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: aleph-secrets
           env:
             {{- range $key, $value := .Values.global.commonEnv }}
             - name: {{ $key }}
@@ -51,53 +54,9 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            - name: ALEPH_DATABASE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_DATABASE_URI
-            - name: ALEPH_OAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_OAUTH_SECRET
-            - name: ALEPH_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_SECRET_KEY
-            - name: FTM_STORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: FTM_STORE_URI
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: RABBITMQ_PASSWORD
-                  optional: true
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: SENTRY_DSN
-                  optional: true
             {{ if .Values.global.google }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/service-account.json
-            {{ end }}
-            {{ if .Values.global.amazon }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_ACCESS_KEY_ID
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_SECRET_ACCESS_KEY
             {{ end }}
             {{ if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_ENABLED

--- a/helm/charts/aleph/templates/worker.yaml
+++ b/helm/charts/aleph/templates/worker.yaml
@@ -38,6 +38,9 @@ spec:
             {{- toYaml .Values.worker.containerSecurityContext | nindent 12 }}
           resources:
             {{- toYaml .Values.worker.containerResources | nindent 12 }}
+          envFrom:
+            - secretRef:
+                name: aleph-secrets
           env:
             {{- range $key, $value := .Values.global.commonEnv }}
             - name: {{ $key }}
@@ -51,53 +54,9 @@ spec:
             - name: {{ $key }}
               value: {{ $value | quote }}
             {{- end }}
-            - name: ALEPH_DATABASE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_DATABASE_URI
-            - name: ALEPH_OAUTH_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_OAUTH_SECRET
-            - name: ALEPH_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: ALEPH_SECRET_KEY
-            - name: FTM_STORE_URI
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: FTM_STORE_URI
-            - name: RABBITMQ_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: RABBITMQ_PASSWORD
-                  optional: true
-            - name: SENTRY_DSN
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: SENTRY_DSN
-                  optional: true
             {{ if .Values.global.google }}
             - name: GOOGLE_APPLICATION_CREDENTIALS
               value: /var/secrets/google/service-account.json
-            {{ end }}
-            {{ if .Values.global.amazon }}
-            - name: AWS_ACCESS_KEY_ID
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_ACCESS_KEY_ID
-            - name: AWS_SECRET_ACCESS_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: aleph-secrets
-                  key: AWS_SECRET_ACCESS_KEY
             {{ end }}
             {{ if .Values.global.prometheus.enabled }}
             - name: PROMETHEUS_ENABLED


### PR DESCRIPTION
Optimize helm templates to expose multiple secret values as environment variables, this has side effect that all values in `aleph-secrets` are exposed to deployment