### PR TITLE
Fix edge case in metrics collector

### DIFF
--- a/aleph/metrics/collectors.py
+++ b/aleph/metrics/collectors.py
@@ -283,6 +283,11 @@ class StatisticsCollector(Collector):
             collection_stats = get_collection_stats(collection.id)
             schemata = collection_stats["schema"]["values"]
 
+            # For some reason, the default/fallback value returned by `get_collection_stats`
+            # is a list, not an empty object, so we need to handle this explicitly.
+            if not schemata:
+                continue
+
             for schema, count in schemata.items():
                 stats[schema] += count
 

--- a/aleph/tests/test_metrics.py
+++ b/aleph/tests/test_metrics.py
@@ -347,7 +347,14 @@ class MetricsTestCase(TestCase):
         index_entity(entity_1)
         index_entity(entity_2)
 
-        # This is usually executed periodically by a worker
+        # Ensure that metric collection succeeds even if the stats for newly collections
+        # haven’t been computed yet
+        reg.collect()
+        generate_latest(reg)
+        persons = reg.get_sample_value("aleph_entities", {"schema": "Person"})
+        assert persons is None
+
+        # This is usually executed periodically by a worker or after collection contents are updated
         compute_collections()
 
         reg.collect()

--- a/aleph/tests/test_metrics.py
+++ b/aleph/tests/test_metrics.py
@@ -335,13 +335,13 @@ class MetricsTestCase(TestCase):
         collection_1 = self.create_collection()
         entity_1 = self.create_entity(
             collection=collection_1,
-            data={"schema": "Person", "properties": {}},
+            data={"schema": "Airplane", "properties": {}},
         )
 
         collection_2 = self.create_collection()
         entity_2 = self.create_entity(
             collection=collection_2,
-            data={"schema": "Person", "properties": {}},
+            data={"schema": "Airplane", "properties": {}},
         )
 
         index_entity(entity_1)
@@ -351,13 +351,13 @@ class MetricsTestCase(TestCase):
         # haven’t been computed yet
         reg.collect()
         generate_latest(reg)
-        persons = reg.get_sample_value("aleph_entities", {"schema": "Person"})
-        assert persons is None
+        planes = reg.get_sample_value("aleph_entities", {"schema": "Airplane"})
+        assert planes is None
 
         # This is usually executed periodically by a worker or after collection contents are updated
         compute_collections()
 
         reg.collect()
         generate_latest(reg)
-        persons = reg.get_sample_value("aleph_entities", {"schema": "Person"})
-        assert persons == 2
+        planes = reg.get_sample_value("aleph_entities", {"schema": "Airplane"})
+        assert planes == 2


### PR DESCRIPTION
For some reason, the default/fallback value returned by `get_collection_stats` is an empty list, not an empty object. This can trigger an edge case if Prometheus metrics are scraped after a collection has been created, but the stats for the new collection haven’t been computed yet.

To prevent unintended side effects, I haven’t changed the default/fallback value (as other parts of the code base might rely on it) and have instead explicitly handled empty values.