### PR TITLE
Add test to cover `last_login_at` timestamp in OAuth workflow

### DIFF
--- a/aleph/tests/test_sessions_api.py
+++ b/aleph/tests/test_sessions_api.py
@@ -124,7 +124,7 @@ class SessionsApiTestCase(TestCase):
 
 class SessionsApiOAuthTestCase(TestCase):
     def setUp(self):
-        super().setUpClass()
+        super().setUp()
 
         SETTINGS.OAUTH = True
         SETTINGS.OAUTH_HANDLER = "test-oidc"


### PR DESCRIPTION
This is a follow-up to https://github.com/alephdata/aleph/pull/3852. This PR above didn’t include a test for the expected behavior when logging in via OAuth. There have been a lot of changes to authentication testing on the develop branch that were not present in the 4.0 release branch, so any changes would have lead to annoying merge conflicts down the line.

But now that the 4.0 release is integrated, it’s time to add a proper test :)