### PR TITLE
Make document search available in entity preview

### DIFF
--- a/ui/src/components/Document/DocumentViewMode.scss
+++ b/ui/src/components/Document/DocumentViewMode.scss
@@ -6,7 +6,6 @@
 
   .outer {
     flex: 2;
-    padding: ($aleph-grid-size * 0.5);
 
     .inner {
       background: white;

--- a/ui/src/components/Entity/EntityPreview.scss
+++ b/ui/src/components/Entity/EntityPreview.scss
@@ -16,10 +16,6 @@ $preview-padding: $aleph-grid-size * 1.5;
     overflow: visible;
   }
 
-  .info-tabs-padding {
-    padding: $preview-padding 0;
-  }
-
   .#{$bp-ns}-drawer-header {
     padding: 0 $aleph-grid-size * 0.5;
     box-shadow: 0 1px 2px rgba(16, 22, 26, 0.15);

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -1,13 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import {
-  Callout,
-  Classes,
-  Tab,
-  Tabs,
-  Icon,
-  InputGroup,
-} from '@blueprintjs/core';
+import { Callout, Classes, Tab, Tabs, InputGroup } from '@blueprintjs/core';
 import queryString from 'query-string';
 import { compose } from 'redux';
 import { connect } from 'react-redux';
@@ -168,14 +161,8 @@ class EntityViews extends React.Component {
     return (
       <Tab
         id="info"
-        title={
-          <>
-            <Icon icon="info" className="left-icon" />
-            <span className="tab-padding">
-              <FormattedMessage id="entity.info.info" defaultMessage="Info" />
-            </span>
-          </>
-        }
+        icon="info"
+        title={<FormattedMessage id="entity.info.info" defaultMessage="Info" />}
         panel={<EntityProperties entity={entity} />}
       />
     );
@@ -198,12 +185,8 @@ class EntityViews extends React.Component {
     return (
       <Tab
         id="view"
-        title={
-          <>
-            <Icon icon="documentation" className="left-icon" />
-            <FormattedMessage id="entity.info.view" defaultMessage="View" />
-          </>
-        }
+        icon="documentation"
+        title={<FormattedMessage id="entity.info.view" defaultMessage="View" />}
         panel={<DocumentViewMode document={entity} activeMode={activeMode} />}
       />
     );
@@ -219,12 +202,8 @@ class EntityViews extends React.Component {
     return (
       <Tab
         id="text"
-        title={
-          <>
-            <Icon icon="plaintext" className="left-icon" />
-            <FormattedMessage id="entity.info.text" defaultMessage="Text" />
-          </>
-        }
+        icon="plaintext"
+        title={<FormattedMessage id="entity.info.text" defaultMessage="Text" />}
         panel={<DocumentViewMode document={entity} activeMode={activeMode} />}
       />
     );
@@ -241,9 +220,9 @@ class EntityViews extends React.Component {
       <Tab
         id="browse"
         disabled={children.total < 1}
+        icon="folder"
         title={
           <TextLoading loading={children.isPending}>
-            <Icon icon="folder" className="left-icon" />
             {entity.schema.isA('Email') && (
               <FormattedMessage
                 id="entity.info.attachments"
@@ -276,9 +255,9 @@ class EntityViews extends React.Component {
       <Tab
         id={ref.property.qname}
         key={ref.property.qname}
+        icon={<Schema.Icon schema={ref.schema} className="left-icon" />}
         title={
           <>
-            <Schema.Icon schema={ref.schema} className="left-icon" />
             <Property.Reverse prop={ref.property} />
             <Count count={ref.count} />
           </>
@@ -311,9 +290,9 @@ class EntityViews extends React.Component {
       <Tab
         id="tags"
         disabled={tags.total < 1}
+        icon="assessment"
         title={
           <TextLoading loading={tags.isPending}>
-            <Icon icon="assessment" className="left-icon" />
             <FormattedMessage id="entity.info.tags" defaultMessage="Mentions" />
             <ResultCount result={tags} />
           </TextLoading>
@@ -334,9 +313,9 @@ class EntityViews extends React.Component {
       <Tab
         id="similar"
         disabled={similar.total === 0}
+        icon="similar"
         title={
           <TextLoading loading={similar.total === undefined}>
-            <Icon icon="similar" className="left-icon" />
             <FormattedMessage
               id="entity.info.similar"
               defaultMessage="Similar"
@@ -363,14 +342,12 @@ class EntityViews extends React.Component {
     return (
       <Tab
         id="mapping"
+        icon="new-object"
         title={
-          <>
-            <Icon icon="new-object" className="left-icon" />
-            <FormattedMessage
-              id="entity.mapping.view"
-              defaultMessage="Generate entities"
-            />
-          </>
+          <FormattedMessage
+            id="entity.mapping.view"
+            defaultMessage="Generate entities"
+          />
         }
         panel={<EntityMappingMode document={entity} />}
       />

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -102,6 +102,7 @@ class EntityViews extends React.Component {
           selectedTabId={activeMode}
           renderActiveTabPanelOnly
           className="info-tabs-padding"
+          animate={false}
         >
           {this.renderInfoMode()}
           {this.renderViewMode()}

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -299,6 +299,7 @@ class EntityViews extends React.Component {
             <>
               <Tabs.Expander />
               <form
+                className="EntityViews__search"
                 onSubmit={(event) => {
                   event.preventDefault();
                   this.handleSearch(event.currentTarget.q.value);

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -111,14 +111,10 @@ class EntityViews extends React.Component {
           {this.renderTagsMode()}
           {this.renderSimilarMode()}
           {this.renderMappingMode()}
-          {this.hasPdfSearchMode() && (
-            <>
-              <Tabs.Expander />
-              {this.renderPdfSearchForm()}
-            </>
-          )}
+          {this.renderPdfSearchMode()}
+          <Tabs.Expander />
+          {this.renderPdfSearchForm()}
         </Tabs>
-        {this.renderPdfSearchMode()}
       </>
     );
   }
@@ -361,18 +357,18 @@ class EntityViews extends React.Component {
       return;
     }
 
-    if (activeMode !== 'search') {
-      return;
-    }
-
     return (
-      <div className={Classes.TAB_PANEL}>
-        <PdfViewerSearch
-          isPreview={isPreview}
-          document={entity}
-          activeMode={activeMode}
-        />
-      </div>
+      <Tab
+        id="search"
+        title={<span className="visually-hidden">Search results</span>}
+        panel={
+          <PdfViewerSearch
+            isPreview={isPreview}
+            document={entity}
+            activeMode={activeMode}
+          />
+        }
+      />
     );
   }
 

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -96,6 +96,7 @@ class EntityViews extends React.Component {
       children,
       reference,
       referenceQuery,
+      location,
     } = this.props;
     if (references.total === undefined || references.isPending) {
       return <SectionLoading />;
@@ -115,6 +116,8 @@ class EntityViews extends React.Component {
     const hasSearchMode =
       entity.schema.name == 'Pages' &&
       entity.getProperty('processingError')?.length == 0;
+    const parsedHash = queryString.parse(location.hash);
+    const searchQuery = isPreview ? parsedHash['preview:q'] : parsedHash['q'];
     const processingError = entity.getProperty('processingError');
     const entityParent = entity.getFirst('parent');
     const showWorkbookWarning =
@@ -309,6 +312,7 @@ class EntityViews extends React.Component {
                   name="q"
                   leftIcon="search"
                   placeholder="Search in this document"
+                  defaultValue={searchQuery}
                 />
               </form>
             </>

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { Callout, Classes, Tab, Tabs, InputGroup } from '@blueprintjs/core';
+import { Callout, Tab, Tabs, InputGroup } from '@blueprintjs/core';
 import queryString from 'query-string';
 import { compose } from 'redux';
 import { connect } from 'react-redux';

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -362,13 +362,7 @@ class EntityViews extends React.Component {
       <Tab
         id="search"
         title={<span className="visually-hidden">Search results</span>}
-        panel={
-          <PdfViewerSearch
-            isPreview={isPreview}
-            document={entity}
-            activeMode={activeMode}
-          />
-        }
+        panel={<PdfViewerSearch isPreview={isPreview} document={entity} />}
       />
     );
   }

--- a/ui/src/components/Entity/EntityViews.jsx
+++ b/ui/src/components/Entity/EntityViews.jsx
@@ -244,10 +244,6 @@ class EntityViews extends React.Component {
     const { entity, references, reference, referenceQuery, activeMode } =
       this.props;
 
-    if (!references.total && references.isPending) {
-      return <Tab id="loading" title={<TextLoading loading={true} />} />;
-    }
-
     return references.results.map((ref) => (
       <Tab
         id={ref.property.qname}

--- a/ui/src/components/Entity/EntityViews.scss
+++ b/ui/src/components/Entity/EntityViews.scss
@@ -5,4 +5,11 @@
     margin-bottom: $aleph-grid-size * 1.5;
     background-color: $light-gray5;
   }
+
+  &__search {
+    // The search input is placed inside of a Blueprint tab list which has has
+    // `overflow: hidden`. As a result, the outline would be partially clipped
+    // when the input is focused. This is a quick workaround.
+    padding: 2px;
+  }
 }

--- a/ui/src/components/common/ItemOverview.scss
+++ b/ui/src/components/common/ItemOverview.scss
@@ -52,6 +52,7 @@
   }
 
   &__content {
+    padding: 1.5 * $aleph-grid-size 0;
     border-top: 1px solid $aleph-border-color;
 
     .preview &,

--- a/ui/src/util/togglePreview.js
+++ b/ui/src/util/togglePreview.js
@@ -10,6 +10,7 @@ export default function togglePreview(navigate, location, entity, profile) {
   } else {
     parsed['preview:id'] = undefined;
     parsed['preview:profile'] = undefined;
+    parsed['preview:q'] = undefined;
     parsed.page = undefined;
   }
   navigate({

--- a/ui/src/viewers/PdfViewer.jsx
+++ b/ui/src/viewers/PdfViewer.jsx
@@ -13,7 +13,6 @@ import { queryEntities } from 'actions';
 import { selectEntitiesResult } from 'selectors';
 import normalizeDegreeValue from 'util/normalizeDegreeValue';
 import EntityActionBar from 'components/Entity/EntityActionBar';
-import PdfViewerSearch from 'viewers/PdfViewerSearch';
 import PdfViewerPage from 'viewers/PdfViewerPage';
 
 import './PdfViewer.scss';
@@ -238,26 +237,10 @@ export class PdfViewer extends Component {
     }
     return (
       <div className="PdfViewer">
-        <EntityActionBar
-          query={shouldRenderSearch ? searchQuery : pageQuery}
-          onSearchSubmit={this.onSearch}
-          searchPlaceholder={intl.formatMessage(messages.placeholder, {
-            label: document.getCaption(),
-          })}
-          searchDisabled={document.getProperty('processingError')?.length}
-        />
         <div className="outer">
           <div id="PdfViewer" className="inner">
             <div className="document">
-              {shouldRenderSearch && (
-                <PdfViewerSearch
-                  document={document}
-                  dir={dir}
-                  activeMode={activeMode}
-                  query={searchQuery}
-                />
-              )}
-              {activeMode === 'text' && !shouldRenderSearch && (
+              {activeMode === 'text' && (
                 <PdfViewerPage
                   document={document}
                   dir={dir}
@@ -266,7 +249,7 @@ export class PdfViewer extends Component {
                   query={pageQuery}
                 />
               )}
-              {activeMode === 'view' && !shouldRenderSearch && this.renderPdf()}
+              {activeMode === 'view' && this.renderPdf()}
             </div>
           </div>
         </div>

--- a/ui/src/viewers/PdfViewer.scss
+++ b/ui/src/viewers/PdfViewer.scss
@@ -18,60 +18,6 @@ $pagesWidth: 150px;
     overflow-x: hidden;
     overflow-y: visible;
 
-    .pages {
-      display: none;
-
-      .heading {
-        background: $aleph-table-heading-background;
-        padding: $aleph-grid-size;
-        border-bottom: 1px solid $aleph-border-color;
-      }
-    }
-
-    .pages {
-      display: block;
-
-      .ErrorSection {
-        padding-top: $aleph-grid-size * 2;
-      }
-
-      ul {
-        @include rtlSupportInvertedProp(padding, left, 0, null);
-        margin: 0;
-
-        li {
-          list-style: none;
-          padding: $aleph-grid-size;
-          border-bottom: 1px solid $aleph-border-color;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          width: 100%;
-
-          p {
-            margin-bottom: 0;
-
-            .#{$bp-ns}-icon {
-              @include rtlSupportInvertedProp(
-                margin,
-                right,
-                $aleph-icon-padding,
-                null
-              );
-            }
-
-            a {
-              text-decoration: none;
-            }
-          }
-
-          p:first-child {
-            margin-bottom: $aleph-grid-size;
-            font-weight: bold;
-          }
-        }
-      }
-    }
-
     .inner {
       flex: 1;
       width: auto;
@@ -108,17 +54,6 @@ $pagesWidth: 150px;
         font-size: 1.2em;
         width: 100%;
       }
-    }
-  }
-}
-
-/* Don't show padding between list of pages & doc in preview as space limited
- * This is included here and not in Preview just to make it easier follow
- */
-.Preview {
-  .PdfViewer {
-    .outer.with-search-results {
-      @include rtlSupportInvertedProp(padding, left, $pagesWidth, null);
     }
   }
 }

--- a/ui/src/viewers/PdfViewer.scss
+++ b/ui/src/viewers/PdfViewer.scss
@@ -15,8 +15,6 @@ $pagesWidth: 150px;
     height: 100%;
     width: 100%;
     flex: 1;
-    overflow-x: hidden;
-    overflow-y: visible;
 
     .inner {
       flex: 1;
@@ -25,6 +23,7 @@ $pagesWidth: 150px;
 
       .document {
         width: 100%;
+        overflow: hidden;
 
         pre {
           border: unset;

--- a/ui/src/viewers/PdfViewerSearch.jsx
+++ b/ui/src/viewers/PdfViewerSearch.jsx
@@ -2,17 +2,23 @@ import React, { Component } from 'react';
 import { Link } from 'react-router-dom';
 import { FormattedMessage } from 'react-intl';
 import classNames from 'classnames';
+import { compose } from 'redux';
 import { connect } from 'react-redux';
 import queryString from 'query-string';
 import {
   SectionLoading,
   SearchHighlight,
   QueryInfiniteLoad,
+  ResultText,
 } from 'components/common';
 import { Classes } from '@blueprintjs/core';
 import c from 'classnames';
+import Query from 'app/Query';
 import { queryEntities } from 'actions';
 import { selectEntitiesResult } from 'selectors';
+import withRouter from 'app/withRouter';
+
+import './PdfViewerSearch.scss';
 
 class PdfViewerSearch extends Component {
   constructor(props) {
@@ -32,16 +38,19 @@ class PdfViewerSearch extends Component {
   }
 
   getResultLink(result) {
-    const { activeMode, query } = this.props;
-    const page = result.getProperty('index').toString();
+    const { activeMode, query, document, location, isPreview } = this.props;
+    const parsedHash = queryString.parse(location.hash);
 
-    const hashQuery = {
-      page,
-      mode: activeMode,
-      q: query.getString('q'),
-    };
+    if (isPreview) {
+      parsedHash['preview:mode'] = 'view';
+    } else {
+      parsedHash['mode'] = 'view';
+    }
 
-    return `#${queryString.stringify(hashQuery)}`;
+    parsedHash['page'] = result.getProperty('index').toString();
+    parsedHash['q'] = query.getString('q');
+
+    return `#${queryString.stringify(parsedHash)}`;
   }
 
   fetchSearchResults() {
@@ -52,14 +61,18 @@ class PdfViewerSearch extends Component {
   }
 
   render() {
-    const { result } = this.props;
+    const { result, query } = this.props;
+
+    if (!query.getString('q')) {
+      return this.renderEmptyState();
+    }
 
     if (result.total === undefined) {
       return <SectionLoading />;
     }
 
     return (
-      <div className="pages">
+      <div className="PdfViewerSearch">
         {result.total === 0 ? this.renderEmptyState() : this.renderResults()}
       </div>
     );
@@ -70,13 +83,20 @@ class PdfViewerSearch extends Component {
 
     return (
       <>
-        <ul>
+        <div className="PdfViewerSearch__total">
+          <ResultText result={result} />
+        </div>
+        <ul className="PdfViewerSearch__results">
           {result.results.map((res) => (
-            <li key={`page-${res.id}`}>
+            <li key={`page-${res.id}`} className="PdfViewerSearch__result">
               <p dir={dir}>
-                <Link to={this.getResultLink(res)}>
+                <a href={this.getResultLink(res)}>
                   <span
-                    className={c(Classes.ICON, `${Classes.ICON}-document`)}
+                    className={c(
+                      Classes.ICON,
+                      `${Classes.ICON}-document`,
+                      'PdfViewerSearch__icon'
+                    )}
                   />
                   <FormattedMessage
                     id="document.pdf.search.page"
@@ -85,7 +105,7 @@ class PdfViewerSearch extends Component {
                       page: res.getProperty('index'),
                     }}
                   />
-                </Link>
+                </a>
               </p>
               <SearchHighlight highlight={res.highlight} />
             </li>
@@ -119,11 +139,25 @@ class PdfViewerSearch extends Component {
 }
 
 const mapStateToProps = (state, ownProps) => {
-  const { query } = ownProps;
+  const { isPreview, document, location } = ownProps;
+
+  const parsedHash = queryString.parse(location.hash);
+  const q = isPreview ? parsedHash['preview:q'] : parsedHash['q'];
+
+  const query = new Query('entities', {}, {}, 'search')
+    .setFilter('properties.document', document.id)
+    .setFilter('schema', 'Page')
+    .set('highlight', true)
+    .set('q', q)
+    .sortBy('properties.index', 'asc');
 
   return {
+    query,
     result: selectEntitiesResult(state, query),
   };
 };
 
-export default connect(mapStateToProps, { queryEntities })(PdfViewerSearch);
+export default compose(
+  withRouter,
+  connect(mapStateToProps, { queryEntities })
+)(PdfViewerSearch);

--- a/ui/src/viewers/PdfViewerSearch.jsx
+++ b/ui/src/viewers/PdfViewerSearch.jsx
@@ -38,7 +38,7 @@ class PdfViewerSearch extends Component {
   }
 
   getResultLink(result) {
-    const { activeMode, query, document, location, isPreview } = this.props;
+    const { query, document, location, isPreview } = this.props;
     const parsedHash = queryString.parse(location.hash);
 
     if (isPreview) {

--- a/ui/src/viewers/PdfViewerSearch.scss
+++ b/ui/src/viewers/PdfViewerSearch.scss
@@ -1,0 +1,33 @@
+@import 'app/variables.scss';
+@import 'app/mixins.scss';
+
+.PdfViewerSearch__total {
+  margin-bottom: $aleph-grid-size;
+}
+
+.PdfViewerSearch__results {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  box-shadow: $pt-elevation-shadow-2;
+}
+
+.PdfViewerSearch__result {
+  padding: $aleph-grid-size;
+  border-bottom: 1px solid $aleph-border-color;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 100%;
+}
+
+.PdfViewerSearch__result a {
+  font-weight: bold;
+}
+
+.PdfViewerSearch__icon {
+  @include rtlSupportInvertedProp(margin, right, $aleph-icon-padding, null);
+}
+
+.PdfViewerSearch__result p {
+  margin-bottom: 0;
+}


### PR DESCRIPTION
We frequently receive feedback about the search flow requiring too many clicks in the following use case:

1. User searches for a term.
2. User finds a document (e.g. PDF, Word) that might be relevant in the search results.
3. They click on the search results and the preview is displayed.
4. In case of documents that are longer than a few pages, most users don’t want to go over the entire document, instead they want to skim the relevant sections.
5. In order to find relevant sections, users currently need to click on the "Expand" button in the entity preview. After clicking expand, the document search is available.
7. Users then need to enter the search term again in the document search input.

This PR simplifies this flow as the document search is now available from within the entity previews. That means users can click on a search results, search within the document inside of the preview, and can easily return to the search results.

In a follow-up PR, I plan to prefill the search input for the document search with the value of the previous search or provide another easy way to reuse the search query so users don’t have to retype the entire query.

https://github.com/user-attachments/assets/b17f0712-5c0e-439d-a980-989a2141a3b1

From an implementation perspective, the main changes are in https://github.com/alephdata/aleph/pull/3879/commits/52c706c3a45ccac662a8601c86d6bd701fbb6fe7. In addition to these changes, I’ve used the opportunity to refactor the `EntityViews` component as it was quite big and slightly confusing.

For this reason, I’d recommend reviewing the commits individually. The commit messages also provide additional details.