### PR TITLE
Python 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
-FROM ubuntu:20.04
+FROM python:3.9
 ENV DEBIAN_FRONTEND noninteractive
 
 # build-essential
 RUN apt-get -qq -y update \
-    && apt-get -qq --no-install-recommends -y install locales \
-    ca-certificates postgresql-client libpq-dev curl jq \
-    python3-pip python3-icu python3-psycopg2 \
-    python3-lxml python3-crypto git \
-    && apt-get -qq -y autoremove \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+  && apt-get -qq --no-install-recommends -y install locales \
+  ca-certificates postgresql-client libpq-dev curl jq git \
+  libxml2-dev libxslt1-dev python3-dev \
+  && apt-get -qq -y autoremove \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+  && localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
 
 ENV LANG='en_US.UTF-8'
 
 RUN groupadd -g 1000 -r app \
-    && useradd -m -u 1000 -s /bin/false -g app app
+  && useradd -m -u 1000 -s /bin/false -g app app
 
 # Install Python dependencies
 RUN pip3 install --no-cache-dir -q -U pip setuptools six
@@ -32,19 +31,19 @@ RUN pip install --no-cache-dir -q -e /aleph
 ENV ALEPH_WORD_FREQUENCY_URI=https://public.data.occrp.org/develop/models/word-frequencies/word_frequencies-v0.4.1.zip
 ENV ALEPH_FTM_COMPARE_MODEL_URI=https://public.data.occrp.org/develop/models/xref/glm_bernoulli_2e_wf-v0.4.1.pkl
 RUN mkdir -p /opt/ftm-compare/word-frequencies/ && \
-    curl -L -o "/opt/ftm-compare/word-frequencies/word-frequencies.zip" "$ALEPH_WORD_FREQUENCY_URI" && \
-    python3 -m zipfile --extract /opt/ftm-compare/word-frequencies/word-frequencies.zip /opt/ftm-compare/word-frequencies/ && \
-    curl -L -o "/opt/ftm-compare/model.pkl" "$ALEPH_FTM_COMPARE_MODEL_URI"
+  curl -L -o "/opt/ftm-compare/word-frequencies/word-frequencies.zip" "$ALEPH_WORD_FREQUENCY_URI" && \
+  python3 -m zipfile --extract /opt/ftm-compare/word-frequencies/word-frequencies.zip /opt/ftm-compare/word-frequencies/ && \
+  curl -L -o "/opt/ftm-compare/model.pkl" "$ALEPH_FTM_COMPARE_MODEL_URI"
 
 # Configure some docker defaults:
 ENV ALEPH_ELASTICSEARCH_URI=http://elasticsearch:9200/ \
-    ALEPH_DATABASE_URI=postgresql://aleph:aleph@postgres/aleph \
-    FTM_STORE_URI=postgresql://aleph:aleph@postgres/aleph \
-    REDIS_URL=redis://redis:6379/0 \
-    ARCHIVE_TYPE=file \
-    ARCHIVE_PATH=/data \
-    FTM_COMPARE_FREQUENCIES_DIR=/opt/ftm-compare/word-frequencies/ \
-    FTM_COMPARE_MODEL=/opt/ftm-compare/model.pkl
+  ALEPH_DATABASE_URI=postgresql://aleph:aleph@postgres/aleph \
+  FTM_STORE_URI=postgresql://aleph:aleph@postgres/aleph \
+  REDIS_URL=redis://redis:6379/0 \
+  ARCHIVE_TYPE=file \
+  ARCHIVE_PATH=/data \
+  FTM_COMPARE_FREQUENCIES_DIR=/opt/ftm-compare/word-frequencies/ \
+  FTM_COMPARE_MODEL=/opt/ftm-compare/model.pkl
 
 RUN mkdir /run/prometheus
 

--- a/aleph/__init__.py
+++ b/aleph/__init__.py
@@ -1,9 +1,9 @@
 import logging
 import warnings
 from sqlalchemy.exc import SAWarning
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
-__version__ = get_distribution("aleph").version
+__version__ = version("aleph")
 
 # shut up useless SA warning:
 warnings.filterwarnings(

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -3,4 +3,4 @@
 psql -c "DROP DATABASE IF EXISTS aleph_test;" $ALEPH_DATABASE_URI
 psql -c "CREATE DATABASE aleph_test;" $ALEPH_DATABASE_URI
 
-pytest aleph/ --cov=aleph --cov-report html --cov-report term $@
+PYTHONDEVMODE=1 PYTHONTRACEMALLOC=1 pytest aleph/ --cov=aleph --cov-report html --cov-report term $@

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,6 +38,8 @@ zipstream-new==1.1.8
 pika==1.3.2
 sentry-sdk[flask]==2.10.0
 prometheus-client==0.17.1
+lxml==5.3.0
+lxml_html_clean==0.3.1
 
 
 # Testing dependencies


### PR DESCRIPTION
This includes the following changes:

- changes the base image from `ubuntu:20.04` to `python:3.9`, which is Debian based ([Python 3.9 release notes](https://docs.python.org/3/whatsnew/3.9.html))
- runs tests in [dev mode](https://docs.python.org/3/library/devmode.html) and enables tracemalloc to allow us to see deperecation warnings and resource misusage. This slows down test runs a little bit (maybe 10s on top of the 150s on my machine), but allows us to catch some warnings much earlier.
- updates a deprecated way to get the current version

> [!NOTE]
> Up for discussion: should we have a feature flag which allows us to turn on dev mode for the application? This way we could get deprecation and resource usage warnings from the real application in the staging env.