### PR TITLE
Update Prometheus exporter probes so they do not actually generate all metrics

### DIFF
--- a/helm/charts/aleph/templates/exporter.yaml
+++ b/helm/charts/aleph/templates/exporter.yaml
@@ -65,12 +65,14 @@ spec:
                   key: SENTRY_DSN
           readinessProbe:
             httpGet:
-              path: /metrics
+              # Unselect all metrics as generating them can take multiple seconds
+              path: /metrics?name[]=None
               port: 9100
             initialDelaySeconds: 5
           livenessProbe:
             httpGet:
-              path: /metrics
+              # Unselect all metrics as generating them can take multiple seconds
+              path: /metrics?name[]=None
               port: 9100
             initialDelaySeconds: 5
       volumes:

--- a/helm/charts/aleph/values.yaml
+++ b/helm/charts/aleph/values.yaml
@@ -332,7 +332,7 @@ exporter:
 
   containerResources:
     requests:
-      memory: 250Mi
-      cpu: 10m
+      memory: 300Mi
+      cpu: 150m
     limits:
-      memory: 500Mi
+      memory: 1Gi


### PR DESCRIPTION
Generating all metrics can take multiple seconds for large Aleph instances, which can make the liveness/readiness probe fail. The `name[]` query parameter can be used to select a subset of metrics the exporter should return (or no metrics as all in this case). That way, we can check that the exporter is up and running without actually generating any metrics.