### PR TITLE
Show login popup or redirect to OAuth provider when session token has expired

### DIFF
--- a/ui/src/app/Router.jsx
+++ b/ui/src/app/Router.jsx
@@ -61,7 +61,10 @@ class Router extends Component {
   fetchIfNeeded() {
     const { metadata, messages } = this.props;
 
-    if (metadata.shouldLoad && !metadata.isError) {
+    if (
+      metadata.shouldLoad &&
+      (!metadata.isError || metadata.error?.response?.status === 401)
+    ) {
       this.props.fetchMetadata();
     }
 


### PR DESCRIPTION
Fixes #3999.

This is related to #3948 in which I fixed the infinite request loop in case requests to the metadata API fail. This works as intended, but has one unintended side effect: We were actually kind of relying on the previous behavior to handle expired session tokens.

For context: When a user logs in, the session token is stored. When the session token expires, future API requests using that session token will obviously fail. The UI was previously handling 401 response codes to invalidate the stored session token and display a login popup or redirect to the OAuth service.

The change introduced in #3948 also prevented the handling of requests that failed to expired session tokens. I’m not convinced that this way of handling expired session tokens is a good solution as it’s pretty opaque.

So with this change, we will keep the newly introduced behavior (which shows an error message and a "Retry" button) in case a request to the metadata API fails, *except* if it failed with a 401 response in which case we still do whatever happened before.

### How to test this

1. Check out the `develop` branch or the `4.1.0-rc1` tag.
2. Follow steps to reproduce the issue from #3999.
3. Now check out this branch again and try to reproduce the issue again.