### PR TITLE
Always use POST from ui, never PUT

### DIFF
--- a/ui/src/actions/entityActions.js
+++ b/ui/src/actions/entityActions.js
@@ -41,7 +41,7 @@ export const createEntity = asyncActionCreator(
       const config = { params: { sync: true } };
       const payload = entity.toJSON();
       payload.collection_id = collection_id;
-      const response = await endpoint.put(
+      const response = await endpoint.post(
         `entities/${entity.id}`,
         payload,
         config
@@ -55,7 +55,7 @@ export const updateEntity = asyncActionCreator(
   (entity) => async () => {
     const config = { params: { sync: true } };
     const payload = entity.toJSON();
-    const response = await endpoint.put(
+    const response = await endpoint.post(
       `entities/${entity.id}`,
       payload,
       config

--- a/ui/src/actions/entityMappingActions.js
+++ b/ui/src/actions/entityMappingActions.js
@@ -20,7 +20,7 @@ export const fetchEntityMapping = asyncActionCreator(
 );
 
 const executeTrigger = async (collectionId, mappingId) =>
-  endpoint.put(`collections/${collectionId}/mappings/${mappingId}/trigger`);
+  endpoint.post(`collections/${collectionId}/mappings/${mappingId}/trigger`);
 
 export const createEntityMapping = asyncActionCreator(
   ({ id, collection }, mapping) =>
@@ -51,7 +51,7 @@ export const deleteEntityMapping = asyncActionCreator(
 export const flushEntityMapping = asyncActionCreator(
   ({ id, collection }, mappingId) =>
     async () => {
-      await endpoint.put(
+      await endpoint.post(
         `collections/${collection.id}/mappings/${mappingId}/flush`
       );
       return { id };
@@ -62,7 +62,7 @@ export const flushEntityMapping = asyncActionCreator(
 export const updateEntityMapping = asyncActionCreator(
   ({ id, collection }, mappingId, mapping) =>
     async () => {
-      const response = await endpoint.put(
+      const response = await endpoint.post(
         `collections/${collection.id}/mappings/${mappingId}`,
         mapping
       );

--- a/ui/src/actions/entitySetActions.js
+++ b/ui/src/actions/entitySetActions.js
@@ -35,7 +35,7 @@ export const createEntitySetNoMutate = asyncActionCreator(createEntitySet, {
 
 export const updateEntitySet = asyncActionCreator(
   (entitySetId, entitySet) => async () => {
-    const response = await endpoint.put(`entitysets/${entitySetId}`, entitySet);
+    const response = await endpoint.post(`entitysets/${entitySetId}`, entitySet);
     return { entitySetId, data: response.data };
   },
   { name: 'UPDATE_ENTITYSET' }
@@ -54,7 +54,7 @@ export const entitySetAddEntity = asyncActionCreator(
     async () => {
       const config = { params: { sync } };
       const payload = entity.toJSON();
-      const response = await endpoint.put(
+      const response = await endpoint.post(
         `entitysets/${entitySetId}/entities`,
         payload,
         config


### PR DESCRIPTION
Aleph supports both POST and PUT for endpoints that modify data, which are always the same.

Just always send POST from the frontend, so we don't need to add every Post handler twice. It already uses POST most of the time.