### PR TITLE
Consider "layout: {}" to be empty

### DIFF
--- a/ui/src/components/Timeline/state.ts
+++ b/ui/src/components/Timeline/state.ts
@@ -168,7 +168,7 @@ export function reducer(state: State, action: Action): State {
 export function useTimelineState(entities: Array<Entity>, layout?: Layout) {
   return useReducer(reducer, {
     entities,
-    layout: layout || { vertices: [] },
+    layout: (layout && layout.vertices) ? layout : {vertices: []},
     selectedId: null,
     renderer: 'list',
     zoomLevel: 'months',

--- a/ui/src/components/Timeline/util.ts
+++ b/ui/src/components/Timeline/util.ts
@@ -118,7 +118,7 @@ export class TimelineItem {
   }
 
   getColor() {
-    if (!this.layout) {
+    if (!this.layout || !this.layout.vertices) {
       return DEFAULT_COLOR;
     }
 


### PR DESCRIPTION
This shouldn't really change anything for Aleph as such, but Alfred sends back "layout: {}". The reason for that is that it's rather a lot of work to not send anything for these type of structs.

Go 1.24 will fix that next year, so I don't want to spend a lot of effort on this. For now, this small change is needed to make it compatible with the Alfred API.