### PR TITLE
More relaxed check when deleting objects

### DIFF
--- a/ui/src/components/common/DeleteDialog.tsx
+++ b/ui/src/components/common/DeleteDialog.tsx
@@ -30,7 +30,7 @@ const DeleteDialog: FC<DeleteDialogProps> = ({
 }) => {
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [confirmationValue, setConfirmationValue] = useState<string>('');
-  const enabled = confirmationValue === expectedConfirmationValue;
+  const enabled = confirmationValue.toLowerCase().trim() === expectedConfirmationValue.toLowerCase().trim();
 
   return (
     <Dialog isOpen={isOpen} title={title} icon="trash" onClose={onClose}>


### PR DESCRIPTION
When deleting a dataset or investigation you have to type in the name of it to confirm. I typically just copy the name, but it's easy to copy an extra space. Don't be too anal about all of this.