### PR TITLE
Send correct sort order when listing entitysets

### DIFF
--- a/ui/src/screens/EntitySetIndexScreen/EntitySetIndexScreen.jsx
+++ b/ui/src/screens/EntitySetIndexScreen/EntitySetIndexScreen.jsx
@@ -117,7 +117,7 @@ const mapStateToProps = (state, ownProps) => {
     location,
     context,
     'entitySets'
-  ).defaultSortBy('created_at', 'asc');
+  ).defaultSortBy('updated_at', 'desc');
   return {
     query,
     result: selectEntitySetsResult(state, query),


### PR DESCRIPTION
It would send a sort order of "created_at ASC", but in the backend it does:

	q.order_by(EntitySet.updated_at.desc())

So that defaultSortBy() doesn't really do anything. Could perhaps remove that backend check; I just left it in for now.

This improves compatibility with Alfred as it doesn't have this hard-coded in the backend and just uses the URL.