### PR TITLE
Fix docker-compose image tax syntax

### DIFF
--- a/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
+++ b/contrib/aleph-traefik-minio-keycloak/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - "traefik.enable=false"
 
   worker:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-4.0.2}
     command: aleph worker
     restart: on-failure
     links:
@@ -79,7 +79,7 @@ services:
       - "traefik.enable=false"
 
   shell:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-4.0.2}
     command: /bin/bash
     depends_on:
       - postgres
@@ -99,7 +99,7 @@ services:
       - "traefik.enable=false"
 
   api:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-4.0.2}
     command: gunicorn -w 6 -b 0.0.0.0:8000 --log-level debug --log-file - aleph.wsgi:app
     expose:
       - 8000
@@ -121,7 +121,7 @@ services:
       - "traefik.enable=false"
 
   ui:
-    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-4.0.2}
     depends_on:
       - api
       - traefik

--- a/contrib/keycloak/docker-compose.dev-keycloak.yml
+++ b/contrib/keycloak/docker-compose.dev-keycloak.yml
@@ -16,7 +16,7 @@ services:
   elasticsearch:
     build:
       context: services/elasticsearch
-    image: ghcr.io/alephdata/aleph-elasticsearch:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: ghcr.io/alephdata/aleph-elasticsearch:${ALEPH_TAG:-4.0.2}
     hostname: elasticsearch
     environment:
       - discovery.type=single-node
@@ -55,7 +55,7 @@ services:
   app:
     build:
       context: .
-    image: alephdata/aleph:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: alephdata/aleph:${ALEPH_TAG:-4.0.2}
     hostname: aleph
     command: /bin/bash
     links:
@@ -83,7 +83,7 @@ services:
   api:
     build:
       context: .
-    image: alephdata/aleph:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: alephdata/aleph:${ALEPH_TAG:-4.0.2}
     command: aleph run -h 0.0.0.0 -p 5000 --with-threads --reload --debugger
     ports:
       - "127.0.0.1:5000:5000"
@@ -117,7 +117,7 @@ services:
   ui:
     build:
       context: ui
-    image: alephdata/aleph-ui:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: alephdata/aleph-ui:${ALEPH_TAG:-4.0.2}
     links:
       - api
     command: npm run start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - aleph.env
 
   worker:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-4.0.2}
     command: aleph worker
     restart: on-failure
     depends_on:
@@ -62,7 +62,7 @@ services:
       - aleph.env
 
   shell:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-4.0.2}
     command: /bin/bash
     depends_on:
       - postgres
@@ -80,7 +80,7 @@ services:
       - aleph.env
 
   api:
-    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: ghcr.io/alephdata/aleph:${ALEPH_TAG:-4.0.2}
     expose:
       - 8000
     depends_on:
@@ -97,7 +97,7 @@ services:
       - aleph.env
 
   ui:
-    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-ALEPH_TAG:-4.0.2}
+    image: ghcr.io/alephdata/aleph-ui-production:${ALEPH_TAG:-4.0.2}
     depends_on:
       - api
     ports:

--- a/helm/charts/aleph/README.md
+++ b/helm/charts/aleph/README.md
@@ -11,7 +11,7 @@ Helm chart for Aleph
 | global.amazon | bool | `true` | Are we using AWS services like s3? |
 | global.google | bool | `false` | Are we using GCE services like storage, vision api? |
 | global.image.repository | string | `"alephdata/aleph"` | Aleph docker image repo |
-| global.image.tag | string | `"global.image.tag | string | `"4.0.2"` | Aleph docker image tag |
+| global.image.tag | string | `"4.0.2"` | Aleph docker image tag |
 | global.image.tag | string | `"Always"` |  |
 | global.namingPrefix | string | `"aleph"` | Prefix for the names of k8s resources |
 


### PR DESCRIPTION
This should fix #4001 , which probably broke during a merge.