### PR TITLE
Use lowercase normalizer in mapping of 'caption'

### DIFF
--- a/aleph/index/indexes.py
+++ b/aleph/index/indexes.py
@@ -85,7 +85,7 @@ def configure_schema(schema, version):
         "dynamic": False,
         "_source": {"excludes": ["text", "fingerprints"]},
         "properties": {
-            "caption": KEYWORD,
+            "caption": {"type": "keyword", "normalizer": "lowercase"},
             "schema": KEYWORD,
             "schemata": KEYWORD,
             registry.entity.group: KEYWORD,


### PR DESCRIPTION
To fix #2022, sorting of documents in an investigation or dataset by name should be case-insensitive
![image](https://github.com/user-attachments/assets/9ce74add-7ba6-4a11-95a8-33de6f3d368d)
