### PR TITLE
Build UI for every commit/PR

### DIFF
--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run tests
         run: make test-ui
 
+      - name: Build
+        run: make build-ui
+
       - name: Build production image
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
         run: docker build -t ghcr.io/alephdata/aleph-ui-production:${GITHUB_SHA} -f ui/Dockerfile.production ui

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "aleph-ui",
       "version": "4.0.2",
       "dependencies": {
-        "@alephdata/followthemoney": "^3.7.9",
+        "@alephdata/followthemoney": "^3.7.12",
         "@blueprintjs/colors": "^4.1.5",
         "@blueprintjs/core": "^4.18.0",
         "@blueprintjs/icons": "^4.16.0",
@@ -89,9 +89,10 @@
       "dev": true
     },
     "node_modules/@alephdata/followthemoney": {
-      "version": "3.7.9",
-      "resolved": "https://registry.npmjs.org/@alephdata/followthemoney/-/followthemoney-3.7.9.tgz",
-      "integrity": "sha512-uaC6JESOyE9fI/fXd9BlsqsQ4tXf+VFmZp6eKe0Ifu4PX3kdbcuVP9iT4zd8tgiX3aD+LV2TQPbOZNolymX/JA==",
+      "version": "3.7.12",
+      "resolved": "https://registry.npmjs.org/@alephdata/followthemoney/-/followthemoney-3.7.12.tgz",
+      "integrity": "sha512-1MytRx0tUoy/7zAS/MuFbW8ogtGWG4Ws3oa8cSWNijCbbtEuPsrsFPkQWW78cn/yYSBANzRZQBQYDgUtNBY0yw==",
+      "license": "MIT",
       "dependencies": {
         "uuid": "~11.0.3"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -3,7 +3,7 @@
   "version": "4.0.2",
   "private": true,
   "dependencies": {
-    "@alephdata/followthemoney": "^3.7.9",
+    "@alephdata/followthemoney": "^3.7.12",
     "@blueprintjs/colors": "^4.1.5",
     "@blueprintjs/core": "^4.18.0",
     "@blueprintjs/icons": "^4.16.0",


### PR DESCRIPTION
We previously skipped this step as it can take quite long (due to the outdated CRA build setup), but some errors will only occur during a final build (e.g. missing type declarations in dependencies).