### PR TITLE
Do not delete API key to enable rollbacks to previous version.

### DIFF
--- a/aleph/logic/api_keys.py
+++ b/aleph/logic/api_keys.py
@@ -129,7 +129,6 @@ def hash_plaintext_api_keys():
     for index, partition in enumerate(results.partitions()):
         for role in partition:
             role.api_key_digest = hash_api_key(role.api_key)
-            role.api_key = None
             db.session.add(role)
             log.info(f"Hashing API key: {role}")
         log.info(f"Comitting partition {index}")

--- a/aleph/tests/test_api_keys.py
+++ b/aleph/tests/test_api_keys.py
@@ -211,7 +211,12 @@ class ApiKeysTestCase(TestCase):
         hash_plaintext_api_keys()
 
         db.session.refresh(user_1)
-        assert user_1.api_key is None
+
+        # Do not delete the plaintext API key to allow for version rollbacks.
+        # `api_key` column will be removed in the next version at which point all
+        # plaintext keys will be deleted.
+        assert user_1.api_key == "1234567890"
+
         assert user_1.api_key_digest == hash_api_key("1234567890")
 
         db.session.refresh(user_2)


### PR DESCRIPTION
The `api_key` column will be removed in the next version at which point all plaintext API keys will be deleted.