### PR TITLE
bugfix: Point out use of Tags db and how it works

### DIFF
--- a/aleph.env.tmpl
+++ b/aleph.env.tmpl
@@ -91,6 +91,10 @@ ALEPH_OAUTH_SECRET=
 # Define a different ftm entity store:
 # FTM_STORE_URI=postgresql://<username>:<password>@<host>/<database>
 
+# ingest-file uses a document cache to speed up operations
+# (it defaults to either one of the two above postgres connection strings)
+# TAGS_DATABASE_URI=postgresql://<username>:<password>@<host>/<database>
+
 # Queue mechanism
 # REDIS_URL=redis://redis:6379/0
 # RABBITMQ_URL=rabbitmq


### PR DESCRIPTION
ingest-file uses the Tags functionality from servicelayer to cache certain document types during ingest to speed up its operation. Normally the settings file defaults to trying the ALEPH_DATABASE_URI followed by the FTM_STORE_URI, which in most cases should be set to non-default values.

But if one were to just follow our prod environment docs blindly and not uncomment these two settings then the TAGS_DATABASE_URI would be unset, causing servicelayer to pick the default (sqlite:///) which breaks now that we have multiple threads writing to the tags database.

This change documents how this setting works and encourages one to set it if the above two settings are left to defaults.

Relates to #4002, #3816