### PR TITLE
fix: incorrect local queue size calculation

### DIFF
--- a/aleph/worker.py
+++ b/aleph/worker.py
@@ -115,7 +115,13 @@ class AlephWorker(Worker):
         version=None,
         prefetch_count_mapping=defaultdict(lambda: 1),
     ):
-        super().__init__(queues, conn=conn, num_threads=num_threads, version=version)
+        super().__init__(
+            queues,
+            conn=conn,
+            num_threads=num_threads,
+            version=version,
+            prefetch_count_mapping=prefetch_count_mapping,
+        )
         self.often = get_rate_limit("often", unit=300, interval=1, limit=1)
         self.daily = get_rate_limit("daily", unit=3600, interval=24, limit=1)
         # special treatment for indexing jobs - indexing jobs need to be batched


### PR DESCRIPTION
The `prefetch_settings` were never passed to the servicelayer worker constructor so the calculation of the `max_size` of the local queue in the worker was always returning 1. Which is generally fine, until it's not. This is only a problem for deployments with a separate index worker.