### PR TITLE
Fix broken URL for installation docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ For further details on the software, how to use it, install it or manage data
 imports, please check the documentation at: 
 
 * https://docs.aleph.occrp.org
-* Installation: https://docs.aleph.occrp.org/developers/installation
+* Installation: https://docs.aleph.occrp.org/developers/how-to/data/install-alephclient
 
 
 Support


### PR DESCRIPTION
Given the extent of the restructuring, it seems the right URL wouldn't simply point to a file identical to what used to be at [developers/installation](/docs/public/assets/pages/developers/installation), so I added my best guess (https://docs.aleph.occrp.org/developers/how-to/data/install-alephclient).