### PR TITLE
fix: remove `copy` event listener on unmount

### DIFF
--- a/ui/src/react-ftm/types/Transliterate.tsx
+++ b/ui/src/react-ftm/types/Transliterate.tsx
@@ -29,14 +29,18 @@ class Transliterate extends React.PureComponent<ITransliterateProps> {
     document.removeEventListener('copy', this.copyText);
   };
 
-  copyText = (e: any) => {
-    e.clipboardData.setData('text/plain', this.getTranslitValue());
+  copyText = (e: ClipboardEvent) => {
+    e.clipboardData?.setData('text/plain', this.getTranslitValue());
     e.preventDefault();
   };
 
   getTranslitValue() {
     const { lookup, value } = this.props;
     return lookup[value];
+  }
+
+  componentWillUnmount(): void {
+    document.removeEventListener('copy', this.copyText);
   }
 
   render() {


### PR DESCRIPTION
This PR removes the `oncopy` event listener when the `Transliterate` component is about to be unmounted.

Fixes: #4213 
