### PR TITLE
Fix rendering of dataset summaries

### DIFF
--- a/ui/src/components/AuthButtons/AuthButtons.scss
+++ b/ui/src/components/AuthButtons/AuthButtons.scss
@@ -31,5 +31,6 @@
     max-width: 120px;
     -webkit-line-clamp: 2;
     -webkit-box-orient: vertical;
+    overflow: hidden;
   }
 }

--- a/ui/src/components/common/Summary.jsx
+++ b/ui/src/components/common/Summary.jsx
@@ -6,20 +6,21 @@ import c from 'classnames';
 import './Summary.scss';
 
 // formats markdown elements to plain text
-const simpleRenderer = ({ children }) => (
-  <>
-    <span>{children}</span>
-    <span> </span>
-  </>
-);
+const simpleRenderer = ({ children }) => children;
+const allowedElements = ['p', 'a', 'ul', 'ol', 'li', 'strong', 'em'];
 
 const Summary = ({ className, text, truncate }) => {
   const content = (
     <ReactMarkdown
       skipHtml
       linkTarget="_blank"
-      renderers={
-        truncate ? { paragraph: simpleRenderer, listItem: simpleRenderer } : {}
+      allowedElements={allowedElements}
+      components={
+        truncate
+          ? Object.fromEntries(
+              allowedElements.map((element) => [element, simpleRenderer])
+            )
+          : {}
       }
     >
       {text}

--- a/ui/src/components/common/Summary.scss
+++ b/ui/src/components/common/Summary.scss
@@ -2,4 +2,5 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+  overflow: hidden;
 }


### PR DESCRIPTION
This fixes two issues with summaries/descriptions of datasets and entity sets:

1. Long summaries weren’t properly truncated, the overflow wasn’t hidden. I introduced this regression in #4057.

3. In listings of datasets and entity sets, Markdown was rendered (including block-level elements such as lists). This is a regression that was introduced a long time ago with a dependency update of `react-markdown`.