### PR TITLE
fix typo in link (readme.rst)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ For further details on the software, how to use it, install it or manage data
 imports, please check the documentation at: 
 
 * https://docs.aleph.occrp.org
-* Installation: https://docs.aleph.occrp.org/developers/installation
+* Installation: https://docs.aleph.occrp.org/developers/getting-started/production-deployment
 
 
 Support


### PR DESCRIPTION
Hi, i noticed a small typo in the link for dev installation (which was not working). 
Kind regards